### PR TITLE
docs: drop "pre-implementation" from descriptions

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shirabe",
-  "description": "Structured pre-implementation workflow skills for AI coding agents",
+  "description": "Structured workflow skills for AI coding agents",
   "version": "0.1.0",
   "author": {
     "name": "tsukumogami"
@@ -10,7 +10,6 @@
   "license": "Apache-2.0",
   "keywords": [
     "workflow",
-    "pre-implementation",
     "design-docs",
     "planning",
     "ai-agents",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # shirabe
 
-Structured pre-implementation workflow skills for AI coding agents. Powered
+Structured workflow skills for AI coding agents. Powered
 by koto for structural enforcement.
 
 ## Repo Visibility: Public

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # shirabe (調べ)
 
-Structured pre-implementation workflows for AI coding agents.
+Structured workflow skills for AI coding agents.
 
 shirabe provides five workflow skills for [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
 that guide you from idea to implementation with enforced phase transitions,


### PR DESCRIPTION
Replace "pre-implementation" with "structured" in all descriptions:
README.md, CLAUDE.md, and plugin.json. Repo description already updated
via API.

---

3 files changed, consistent wording across all user-facing surfaces.