### PR TITLE
fix: use correct marketplace.json schema

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,10 +1,19 @@
 {
-  "plugins": {
-    "shirabe": {
-      "source": {
-        "source": "directory",
-        "path": "."
-      }
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "shirabe",
+  "description": "Structured workflow skills for AI coding agents",
+  "owner": {
+    "name": "tsukumogami"
+  },
+  "plugins": [
+    {
+      "name": "shirabe",
+      "description": "Structured workflow skills for AI coding agents",
+      "version": "0.1.0",
+      "author": {
+        "name": "tsukumogami"
+      },
+      "source": "."
     }
-  }
+  ]
 }


### PR DESCRIPTION
Update marketplace.json to use the schema expected by
`claude plugin marketplace add`. The previous format used `plugins` as
an object and was missing required `name` and `owner` fields, causing
registration to fail.