### PR TITLE
fix: use valid source path in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "author": {
         "name": "tsukumogami"
       },
-      "source": "."
+      "source": "./"
     }
   ]
 }


### PR DESCRIPTION
Change marketplace plugin source from `"."` to `"./"` to pass the Claude
Code schema validator. The `"."` format is rejected as invalid input,
while `"./"` matches the pattern used by the official marketplace for
root-level plugins.