### PR TITLE
fix: correct plugin configuration in settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,7 @@
 {
   "enabledPlugins": {
     "skill-creator@claude-plugins-official": true,
-    "shirabe": true,
-    "tsukumogami@tsukumogami": true
+    "shirabe@shirabe": true
   },
   "extraKnownMarketplaces": {
     "shirabe": {


### PR DESCRIPTION
`.claude/settings.json` had two errors preventing the shirabe plugin from loading automatically when opening the repo. Corrects the marketplace file path (was pointing at the repo root directory, causing EISDIR), fixes the enabled-plugin key format to use the `name@marketplace` convention, and removes a personal plugin entry that belongs in `settings.local.json`.

---

## What This Fixes

- `extraKnownMarketplaces.shirabe.source.path` was `"."` — Claude Code reads that as a file and gets `EISDIR: illegal operation on a directory, read`. Changed to `".claude-plugin/marketplace.json"`.
- `enabledPlugins` had `"shirabe"` — the correct key format is `name@marketplace`, so `"shirabe@shirabe"`.
- `tsukumogami@tsukumogami` was in committed settings — it's a personal plugin that belongs in `settings.local.json`, not the shared file.

No linked issue — trivial config fix.