### PR TITLE
docs(helpers): add re-grounding requirement to decision-presentation

### DIFF
--- a/references/decision-presentation.md
+++ b/references/decision-presentation.md
@@ -54,7 +54,7 @@ Users handle "these are equal but I picked A because X" much better than "here a
 
 Before asking a question, orient the user with a one-line context header:
 
-> **Workflow:** `/explore gstack` · **Phase:** Round 1 convergence · **Decision:** explore further or crystallize
+> **Workflow:** `/explore koto` · **Phase:** Round 1 convergence · **Decision:** explore further or crystallize
 
 Format: `**Workflow:** <command> · **Phase:** <current phase> · **Decision:** <what's being decided>`
 


### PR DESCRIPTION
Adds a **Re-grounding** section to `references/decision-presentation.md`. The section specifies a one-line context header that agents should emit before asking questions mid-workflow, gives the conditional rule (required after async work, optional for rapid back-and-forth), and provides a practical test for deciding when to include it.

---

Fixes #8