### PR TITLE
docs: rewrite README to match current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,70 @@
 
 Structured workflow skills for AI coding agents.
 
-shirabe provides five workflow skills for [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
-that guide you from idea to implementation with enforced phase transitions,
-multi-round research, and CI-validated document lifecycle. Powered by
-[koto](https://github.com/tsukumogami/koto) for structural enforcement.
+shirabe is a [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+plugin that adds multi-phase workflows for the thinking that happens *before*
+coding. Instead of jumping straight from idea to implementation, shirabe guides
+you through research, requirements, design, planning, and review -- each with
+built-in validation gates so nothing important gets skipped.
 
 **Pronunciation:** shee-RAH-beh
 
-## What it does
-
-shirabe covers the thinking phase before coding:
+## Skills
 
 | Skill | What it does |
 |-------|-------------|
-| `/explore` | Fan out research agents to investigate options, then decide what artifact to produce |
-| `/design` | Produce a technical architecture document with jury validation |
-| `/prd` | Capture product requirements with numbered criteria |
-| `/plan` | Decompose a design into sequenced GitHub issues with dependency graphs |
-| `/work-on` | Implement a single issue with structured phases |
+| `/explore` | Fan out research agents to investigate options and figure out which artifact to produce next (PRD, design doc, plan, or something else) |
+| `/prd` | Capture product requirements with numbered criteria through conversational scoping and parallel research |
+| `/design` | Produce a technical design document by decomposing the problem into decision questions and evaluating trade-offs |
+| `/decision` | Structured decision-making for contested choices with adversarial agents, cross-examination, and synthesis |
+| `/plan` | Decompose a design doc or PRD into sequenced GitHub issues with dependency graphs and complexity labels |
+| `/review-plan` | Adversarial review of a plan across scope, design fidelity, acceptance criteria, and sequencing |
+| `/work-on` | Implement a GitHub issue end-to-end: branch, analysis, code, tests, and pull request |
 
-Each skill is backed by a koto workflow template -- a state machine with
-evidence-gated transitions. Agents can't skip steps they can't see.
+Skills are designed to chain together. `/explore` helps you figure out what you
+need, then hands off to `/prd`, `/design`, or `/plan`. `/review-plan` catches
+problems in a plan before issues get created. `/work-on` picks up individual
+issues and delivers PRs.
+
+## Example: building a plugin system from scratch
+
+Here's what it looks like to use shirabe for a non-trivial feature -- say you
+need to add a plugin system to your CLI tool, but you're not sure where to start.
+
+**Step 1 -- Explore.** You run `/explore plugin system` and describe what you're
+thinking. shirabe spins up research agents that look at how your codebase is
+structured, what plugin approaches exist, and what constraints matter. After a
+few rounds of convergence, it recommends producing a PRD first (since you
+haven't nailed down requirements yet) and a design doc after.
+
+**Step 2 -- Requirements.** You run `/prd plugin system`. Through a
+conversational scoping phase, shirabe narrows the feature to concrete
+requirements: "plugins must be loadable from a directory", "plugins declare
+capabilities via a manifest file", etc. Parallel research agents check your
+codebase for existing patterns. A 3-agent jury reviews the draft for
+completeness and consistency.
+
+**Step 3 -- Design.** You run `/design docs/PRD-plugin-system.md`. shirabe
+decomposes the PRD into decision questions: "how should plugins be discovered?",
+"what's the manifest format?", "how do we handle version conflicts?" Each
+question gets a structured trade-off analysis with alternatives. The final
+design doc captures the chosen approach with rationale.
+
+**Step 4 -- Plan.** You run `/plan docs/DESIGN-plugin-system.md`. shirabe
+breaks the design into atomic issues, ordered by dependency. A walking skeleton
+issue comes first so you can validate the end-to-end flow early. Each issue gets
+acceptance criteria specific enough to verify mechanically. `/review-plan` then
+challenges the plan before any issues are created -- catching gaps in scope,
+weak acceptance criteria, or sequencing problems.
+
+**Step 5 -- Implement.** You run `/work-on M3` (the milestone). shirabe picks
+the first unblocked issue, creates a branch, analyzes the code, implements
+the change, runs tests, and opens a PR. When that one merges, you run it again
+for the next issue.
+
+The whole process produces a paper trail -- PRD, design doc, plan, and focused
+PRs -- that you can point to later when someone asks "why did we build it this
+way?"
 
 ## Installation
 
@@ -43,29 +86,22 @@ Claude Code session:
 /plugin install shirabe@shirabe
 ```
 
-### For your team (CI validation)
-
-Add a small PR to your repo (~4 files, ~60 lines) that references shirabe's
-reusable validation workflows:
-
-```yaml
-# .github/workflows/validate-docs.yml
-name: Validate Design Docs
-on: [pull_request]
-jobs:
-  validate:
-    uses: tsukumogami/shirabe/.github/workflows/validate.yml@v1
-    with:
-      config-path: tsukumogami.yml
-```
-
-See [Repo Setup Guide](docs/guides/repo-setup.md) for the full setup.
-
 ## Requirements
 
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
-- [koto](https://github.com/tsukumogami/koto) (installed automatically on
-  first skill invocation)
+
+## Roadmap
+
+shirabe currently enforces workflow structure through skill prompts and
+phase-gated instructions. Planned improvements include:
+
+- **[koto](https://github.com/tsukumogami/koto) integration** -- formal state
+  machine enforcement for workflow transitions, so agents physically can't skip
+  steps they haven't earned access to
+- **CI validation workflows** -- reusable GitHub Actions that validate design
+  docs and plans in pull requests
+- **Cross-repo workflow state** -- track multi-repo features through a shared
+  workflow state
 
 ## License
 


### PR DESCRIPTION
Rewrite README.md to reflect the actual state of the project. Replace the
5-skill table with all 7 user-facing skills (adding /decision and
/review-plan). Remove claims about koto integration and CI validation
workflows that don't exist yet, and move those to a new Roadmap section.
Add a walkthrough example showing the full explore-to-implement flow for
a non-trivial feature.

---

## What This Accomplishes

The previous README described aspirational features as current: koto-backed
workflow enforcement, reusable CI validation workflows, and koto as a
runtime dependency. None of these exist yet. The rewrite presents what
shirabe actually does today -- prompt-based workflow skills with phase
gates -- and is honest about what's planned.