### PR TITLE
fix(release): pass RELEASE_PAT to reusable workflows

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -24,9 +24,13 @@ jobs:
       version: ${{ inputs.version }}
       tag: ${{ inputs.tag }}
       ref: ${{ inputs.ref }}
+    secrets:
+      token: ${{ secrets.RELEASE_PAT }}
 
   finalize:
     needs: release
     uses: tsukumogami/shirabe/.github/workflows/finalize-release.yml@main
     with:
       tag: ${{ inputs.tag }}
+    secrets:
+      token: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
Pass the RELEASE_PAT secret to both reusable workflows in
prepare-release.yml so they can push commits, create tags, and
promote the draft release.

---

The first release attempt failed because the default GITHUB_TOKEN
only had read permission on contents. The reusable workflow's token
validation step caught this correctly before any mutations.

Ref #38