### PR TITLE
feat(explore): recalibrate crystallize framework for documentation bias

### DIFF
--- a/docs/prds/PRD-crystallize-calibration.md
+++ b/docs/prds/PRD-crystallize-calibration.md
@@ -2,19 +2,17 @@
 status: Draft
 problem: |
   The crystallize framework biases toward investigation artifacts over
-  documentation artifacts, and its signal tables are trapped inside
-  /explore while other skills (/plan, /triage) make the same artifact-type
-  decision with ad-hoc heuristics. Two problems, one root cause: the
-  signal definitions need recalibrating and extracting into a shared
-  reference.
+  documentation artifacts. When requirements or thesis are verbally settled
+  but not written down, the framework routes to design docs or spikes
+  instead of PRDs or VISIONs.
 goals: |
-  Create a shared artifact-type signal reference with calibrated signals
-  (including "known but undocumented" scenarios). Update the crystallize
-  framework and /plan to consume it. Merges F7 and F12.
+  Calibrate the signal tables so the framework routes "known but
+  undocumented" work to documentation artifacts. All changes in
+  crystallize-framework.md.
 upstream: docs/roadmaps/ROADMAP-strategic-pipeline.md
 ---
 
-# PRD: Crystallize Calibration and Artifact Type Decision Reference
+# PRD: Crystallize Framework Calibration
 
 ## Status
 
@@ -22,16 +20,16 @@ Draft
 
 ## Problem statement
 
-Two related problems share a root cause.
+The crystallize framework in /explore Phase 4 scores artifact types using
+signal/anti-signal tables. The tables bias toward investigation: signals
+reward open questions ("how should we build this?", "can we do this?")
+while anti-signals penalize settled answers ("requirements were provided
+as input", "approach is known").
 
-**Documentation bias (F7).** The crystallize framework in /explore Phase 4
-scores artifact types using signal/anti-signal tables. The tables bias
-toward investigation: signals reward open questions ("how should we build
-this?", "can we do this?") while anti-signals penalize settled answers
-("requirements were provided as input", "approach is known"). When a team
-has verbally agreed on requirements or thesis but hasn't written it down,
-the framework routes to an investigation artifact instead of a
-documentation artifact.
+When a team has verbally agreed on requirements, thesis, or technical
+approach but hasn't written it down, the framework routes to an
+investigation artifact (design doc, spike) instead of a documentation
+artifact (PRD, VISION).
 
 Three mechanisms cause this:
 
@@ -50,28 +48,15 @@ Three mechanisms cause this:
    Documentation artifacts trigger anti-signals in settled scenarios,
    dropping below investigation artifacts with zero anti-signals.
 
-**Inconsistent classification (F12).** Multiple skills decide what
-artifact type work needs: /explore scores types in the crystallize
-framework, /plan assigns needs-* labels in Phase 1, /triage assesses
-untriaged issues. Each uses different heuristics for the same question.
-The crystallize framework has the most thorough logic but it's embedded
-in /explore and not reusable.
-
-**Shared root cause.** The signal definitions need to live in one place,
-be calibrated for both investigation and documentation scenarios, and be
-consumable by any skill that classifies work.
-
 ## Goals
 
-- Shared reference document with artifact-type signals consumable by
-  multiple skills
-- "Known but undocumented" signals so the framework routes correctly when
-  the answer is settled but not captured
-- Anti-signals that don't penalize documenting settled decisions
-- /explore crystallize framework consumes the shared reference
-- /plan Phase 1 consumes the shared reference for needs-* labels
-- Investigation artifacts still score correctly for genuinely open
-  questions
+- Framework correctly routes "known but undocumented" work to documentation
+  artifacts (PRD, VISION, Design Doc)
+- Anti-signals don't penalize the act of documenting settled decisions
+- The demotion rule still protects against genuine misclassification but
+  doesn't amplify the documentation bias
+- Investigation artifacts (spike, design doc with open questions) still
+  score correctly when questions are genuinely open
 
 ## User stories
 
@@ -79,107 +64,92 @@ consumable by any skill that classifies work.
    knows what to build, I want the framework to recommend PRD so I
    capture requirements instead of re-investigating them.
 
-2. As an agent in /plan assigning a needs-* label, I want to use the same
-   signal definitions as /explore so classification is consistent.
+2. As an agent crystallizing a strategic exploration where the thesis is
+   clear, I want the framework to recommend VISION so I document the
+   justification instead of exploring whether the project should exist.
 
-3. As a skill author adding a new classification point, I want a shared
-   reference to import rather than inventing my own heuristics.
+3. As an agent crystallizing work where the technical approach was decided
+   in discussion, I want the framework to recommend Design Doc as a record
+   of the decision, not a Spike to re-investigate feasibility.
 
 ## Requirements
 
 ### Functional
 
-**R1. Create shared artifact-type signal reference.** Create
-`references/artifact-type-signals.md` defining observable signals and
-anti-signals for each artifact type. This is the single source of truth
-for "what does this work need?"
-
-**R2. Add "known but undocumented" signals.** For PRD, VISION, and Design
+**R1. Add "known but undocumented" signals.** For PRD, VISION, and Design
 Doc, add signals that detect when the answer is settled but not captured.
-These should be observable from user input or exploration findings.
+These should be observable from exploration findings (e.g., "requirements
+emerged as statements, not questions" or "thesis is asserted, not
+debated").
 
-**R3. Soften punitive anti-signals.** Review anti-signals that penalize
-documentation of agreements. Either remove them, add qualifying conditions,
-or reclassify them.
+**R2. Soften punitive anti-signals.** Review anti-signals that penalize
+documentation of agreements. Either remove them, reclassify them as
+neutral, or add qualifying conditions (e.g., "requirements provided as
+input" is only an anti-signal when the PRD already exists, not when
+requirements are verbal).
 
-**R4. Refine the demotion rule.** Review the current rule (any anti-signal
-demotes below all zero-anti-signal types). If adding signals is sufficient
-to fix the bias, the rule can stay. If not, soften it to distinguish
-genuine misclassification from partial fit.
+**R3. Refine the demotion rule.** The current rule demotes any type with
+one or more anti-signals below all types with zero. If adding signals
+(R1) and softening anti-signals (R2) are sufficient to fix the bias, the
+rule can stay. If not, soften it to distinguish genuine misclassification
+from partial fit.
 
-**R5. Update crystallize framework.** The crystallize framework in
-`skills/explore/references/quality/crystallize-framework.md` references
-or imports the shared signal tables instead of maintaining its own copy.
-The scoring mechanics (count signals, subtract anti-signals, apply
-demotion) stay in the crystallize framework -- only the signal definitions
-move to the shared reference.
-
-**R6. Update /plan Phase 1.** /plan's needs-* label assignment in Phase 1
-references the shared signal document instead of its current ad-hoc
-heuristics ("requirements unclear -> needs-prd, approach unclear ->
-needs-design").
-
-**R7. Preserve investigation routing.** Spikes, design docs with open
-questions, and other investigation artifacts still score correctly when
-questions are genuinely open.
+**R4. Preserve investigation routing.** Spikes, design docs with open
+questions, and other investigation artifacts must still score correctly
+when questions are genuinely open.
 
 ### Non-functional
 
-**R8. No changes to /explore phases or detection algorithm.** The
-crystallize framework's scoring mechanics are unchanged. Only the signal
-table content and its location change.
-
-**R9. Backward compatible.** Existing signals keep their meaning. New
-signals are additive. Anti-signal changes are documented as intentional
-recalibration.
+**R5. All changes in one file.** Modifications only to
+`skills/explore/references/quality/crystallize-framework.md`. No changes
+to /explore phases, other skills, or the detection algorithm.
 
 ## Acceptance criteria
 
-- [ ] `references/artifact-type-signals.md` exists with signal tables for
-      all artifact types
-- [ ] PRD, VISION, and Design Doc tables include "known but undocumented"
-      signals
-- [ ] Anti-signals that penalize documentation of agreements are addressed
-- [ ] Demotion rule reviewed and adjusted if needed
-- [ ] Crystallize framework references the shared signal document
-- [ ] /plan Phase 1 references the shared signal document for needs-*
-      labels
-- [ ] Investigation artifacts still score correctly
-- [ ] Evals updated for "known but undocumented" classification
+- [ ] PRD signal table includes "known but undocumented" signals
+- [ ] VISION signal table includes "known but undocumented" signals
+- [ ] Design Doc signal table includes "known but undocumented" signals
+- [ ] Anti-signals that penalize documentation of agreements are softened
+      or removed
+- [ ] Demotion rule is reviewed and adjusted if needed
+- [ ] Investigation artifacts still score correctly for genuinely open
+      questions
+- [ ] All changes are in crystallize-framework.md
+- [ ] Evals updated to test "known but undocumented" classification
 
 ## Out of scope
 
-- Changes to /explore phases or detection algorithm
-- Changes to /prd, /design, /vision skill internals
+- Extracting signals into a shared reference document (revisit when a
+  second consumer beyond /explore exists)
+- Changes to /plan Phase 1 needs-* label heuristics
+- Changes to /explore phases or the detection algorithm
+- Changes to other skills
 - New artifact types or lifecycle states
-- Enforcement of classification (signals are guidance, not hard gates)
+- Deferred Types and Disambiguation Rules sections (no signal tables)
 
 ## Decisions and trade-offs
 
-**Merge F7 and F12.** Originally scoped as separate features: F7
-calibrates the crystallize framework, F12 creates a shared reference. But
-F7's calibration work (adding signals, softening anti-signals) is the
-same work F12 needs for a good shared reference. Doing them separately
-means touching the same tables twice. Merging delivers consistent signals
-in one pass.
-
-**Shared reference with framework-specific scoring.** The signal
-definitions move to the shared reference. The scoring mechanics (signal
-counting, demotion rule, tiebreakers) stay in the crystallize framework.
-This lets /plan use the signals with a simpler decision process while
-/explore keeps its full scoring engine.
+**Calibrate in place, don't extract.** The original plan merged this with
+F12 (shared reference extraction). Review found the extraction is
+premature: /triage doesn't exist yet, and /plan's needs-* logic is a
+four-line lookup that doesn't need a shared reference. Fix the signal
+tables directly in crystallize-framework.md. F12 stays on the roadmap for
+when a real second consumer materializes.
 
 **Additive signals over anti-signal removal.** Adding "known but
 undocumented" signals is safer than removing existing anti-signals.
 Removal risks making the framework too permissive. Addition gives a new
 dimension without breaking existing classification.
 
+**Demotion rule refinement is conditional.** The rule is aggressive but
+prevents a common error. If R1 and R2 are sufficient to fix the bias, the
+rule stays. Changing it is a fallback, not a default.
+
 ## Related
 
-- **ROADMAP-strategic-pipeline.md** -- Features 7 and 12 (merged)
+- **ROADMAP-strategic-pipeline.md** -- Feature 7 describes this work
 - **skills/explore/references/quality/crystallize-framework.md** -- the
-  file containing current signal tables and scoring rules
-- **skills/plan/references/phases/phase-1-analysis.md** -- current ad-hoc
-  needs-* label heuristics
-- **references/pipeline-model.md** -- pipeline reference that describes
-  the role of crystallize in the workflow
+  file being modified
+- **DESIGN-complexity-routing-expansion.md** (Current) -- F4 added the
+  five-level routing model; the crystallize framework is the scoring
+  engine inside the Complex and Strategic levels

--- a/docs/prds/PRD-crystallize-calibration.md
+++ b/docs/prds/PRD-crystallize-calibration.md
@@ -1,18 +1,20 @@
 ---
 status: Draft
 problem: |
-  The crystallize framework biases toward artifact types that investigate
-  unknowns (design docs, spikes) over types that document agreements (PRDs,
-  VISIONs). When requirements or thesis are verbally settled but not written
-  down, the framework still routes to investigation artifacts.
+  The crystallize framework biases toward investigation artifacts over
+  documentation artifacts, and its signal tables are trapped inside
+  /explore while other skills (/plan, /triage) make the same artifact-type
+  decision with ad-hoc heuristics. Two problems, one root cause: the
+  signal definitions need recalibrating and extracting into a shared
+  reference.
 goals: |
-  Add "known but undocumented" signals so the framework routes to the right
-  artifact type when the answer is settled but not captured. Soften
-  anti-signals that penalize documentation of existing agreements.
+  Create a shared artifact-type signal reference with calibrated signals
+  (including "known but undocumented" scenarios). Update the crystallize
+  framework and /plan to consume it. Merges F7 and F12.
 upstream: docs/roadmaps/ROADMAP-strategic-pipeline.md
 ---
 
-# PRD: Crystallize Framework Calibration
+# PRD: Crystallize Calibration and Artifact Type Decision Reference
 
 ## Status
 
@@ -20,18 +22,16 @@ Draft
 
 ## Problem statement
 
-The crystallize framework in /explore Phase 4 scores artifact types using
-signal/anti-signal tables. The current tables bias toward investigation:
-signals reward open questions ("how should we build this?", "can we do
-this?") while anti-signals penalize settled answers ("requirements were
-provided as input", "approach is known").
+Two related problems share a root cause.
 
-This creates a specific failure mode: when a team has verbally agreed on
-requirements, thesis, or technical approach but hasn't written it down,
-the framework routes to an investigation artifact (design doc, spike)
-instead of a documentation artifact (PRD, VISION). The user then runs a
-design exploration for something already decided, wasting time on a
-question that's already answered.
+**Documentation bias (F7).** The crystallize framework in /explore Phase 4
+scores artifact types using signal/anti-signal tables. The tables bias
+toward investigation: signals reward open questions ("how should we build
+this?", "can we do this?") while anti-signals penalize settled answers
+("requirements were provided as input", "approach is known"). When a team
+has verbally agreed on requirements or thesis but hasn't written it down,
+the framework routes to an investigation artifact instead of a
+documentation artifact.
 
 Three mechanisms cause this:
 
@@ -41,26 +41,37 @@ Three mechanisms cause this:
    validation, not thesis documentation.
 
 2. **Punitive anti-signals.** PRD has "requirements were provided as
-   input" as an anti-signal -- the framework penalizes exactly the
-   scenario where a PRD is most useful. VISION has "specific users and
-   needs already identified" as an anti-signal, penalizing documented
-   strategic clarity.
+   input" as an anti-signal. VISION has "specific users and needs already
+   identified" as an anti-signal. Both penalize exactly the scenario where
+   these artifact types are most useful.
 
 3. **Demotion rule amplification.** Any type with one or more anti-signals
    drops below all types with zero anti-signals, regardless of raw score.
-   In "known but undocumented" scenarios, documentation artifacts often
-   trigger anti-signals (because the answers exist), causing them to rank
-   below investigation artifacts that happen to have zero anti-signals.
+   Documentation artifacts trigger anti-signals in settled scenarios,
+   dropping below investigation artifacts with zero anti-signals.
+
+**Inconsistent classification (F12).** Multiple skills decide what
+artifact type work needs: /explore scores types in the crystallize
+framework, /plan assigns needs-* labels in Phase 1, /triage assesses
+untriaged issues. Each uses different heuristics for the same question.
+The crystallize framework has the most thorough logic but it's embedded
+in /explore and not reusable.
+
+**Shared root cause.** The signal definitions need to live in one place,
+be calibrated for both investigation and documentation scenarios, and be
+consumable by any skill that classifies work.
 
 ## Goals
 
-- Framework correctly routes "known but undocumented" work to documentation
-  artifacts (PRD, VISION, Design Doc)
-- Anti-signals don't penalize the act of documenting settled decisions
-- The demotion rule still protects against genuine misclassification but
-  doesn't amplify the documentation bias
-- Investigation artifacts (spike, design doc with open questions) still
-  score correctly when questions are genuinely open
+- Shared reference document with artifact-type signals consumable by
+  multiple skills
+- "Known but undocumented" signals so the framework routes correctly when
+  the answer is settled but not captured
+- Anti-signals that don't penalize documenting settled decisions
+- /explore crystallize framework consumes the shared reference
+- /plan Phase 1 consumes the shared reference for needs-* labels
+- Investigation artifacts still score correctly for genuinely open
+  questions
 
 ## User stories
 
@@ -68,97 +79,107 @@ Three mechanisms cause this:
    knows what to build, I want the framework to recommend PRD so I
    capture requirements instead of re-investigating them.
 
-2. As an agent crystallizing a strategic exploration where the thesis is
-   clear, I want the framework to recommend VISION so I document the
-   justification instead of exploring whether the project should exist.
+2. As an agent in /plan assigning a needs-* label, I want to use the same
+   signal definitions as /explore so classification is consistent.
 
-3. As an agent crystallizing work where the technical approach was decided
-   in discussion, I want the framework to recommend Design Doc as a record
-   of the decision, not a Spike to re-investigate feasibility.
+3. As a skill author adding a new classification point, I want a shared
+   reference to import rather than inventing my own heuristics.
 
 ## Requirements
 
 ### Functional
 
-**R1. Add "known but undocumented" signals.** For PRD, VISION, and Design
+**R1. Create shared artifact-type signal reference.** Create
+`references/artifact-type-signals.md` defining observable signals and
+anti-signals for each artifact type. This is the single source of truth
+for "what does this work need?"
+
+**R2. Add "known but undocumented" signals.** For PRD, VISION, and Design
 Doc, add signals that detect when the answer is settled but not captured.
-These should be observable from exploration findings (e.g., "requirements
-emerged as statements, not questions" or "thesis is asserted, not
-debated").
+These should be observable from user input or exploration findings.
 
-**R2. Soften punitive anti-signals.** Review anti-signals that penalize
-documentation of agreements. Either remove them, reclassify them as
-neutral, or add qualifying conditions (e.g., "requirements provided as
-input" is only an anti-signal when the PRD already exists, not when
-requirements are verbal).
+**R3. Soften punitive anti-signals.** Review anti-signals that penalize
+documentation of agreements. Either remove them, add qualifying conditions,
+or reclassify them.
 
-**R3. Refine the demotion rule.** The current rule demotes any type with
-one or more anti-signals below all types with zero. Consider softening
-this: distinguish between anti-signals that indicate genuine
-misclassification ("this is the wrong artifact type") vs anti-signals
-that indicate partial fit ("this type applies but with caveats").
+**R4. Refine the demotion rule.** Review the current rule (any anti-signal
+demotes below all zero-anti-signal types). If adding signals is sufficient
+to fix the bias, the rule can stay. If not, soften it to distinguish
+genuine misclassification from partial fit.
 
-**R4. Preserve investigation routing.** Spikes, design docs with open
-questions, and other investigation artifacts must still score correctly
-when questions are genuinely open. The calibration adds documentation
-paths without removing investigation paths.
+**R5. Update crystallize framework.** The crystallize framework in
+`skills/explore/references/quality/crystallize-framework.md` references
+or imports the shared signal tables instead of maintaining its own copy.
+The scoring mechanics (count signals, subtract anti-signals, apply
+demotion) stay in the crystallize framework -- only the signal definitions
+move to the shared reference.
+
+**R6. Update /plan Phase 1.** /plan's needs-* label assignment in Phase 1
+references the shared signal document instead of its current ad-hoc
+heuristics ("requirements unclear -> needs-prd, approach unclear ->
+needs-design").
+
+**R7. Preserve investigation routing.** Spikes, design docs with open
+questions, and other investigation artifacts still score correctly when
+questions are genuinely open.
 
 ### Non-functional
 
-**R5. Changes scoped to crystallize framework.** Modifications only to
-the signal/anti-signal tables and scoring rules in the crystallize
-framework reference file. No changes to /explore phases, other skills,
-or the detection algorithm.
+**R8. No changes to /explore phases or detection algorithm.** The
+crystallize framework's scoring mechanics are unchanged. Only the signal
+table content and its location change.
 
-**R6. Backward compatible signal semantics.** Existing signals keep their
-meaning. New signals are additive. Anti-signal changes are clearly
-documented as intentional recalibration.
+**R9. Backward compatible.** Existing signals keep their meaning. New
+signals are additive. Anti-signal changes are documented as intentional
+recalibration.
 
 ## Acceptance criteria
 
-- [ ] PRD signal table includes "known but undocumented" signals
-- [ ] VISION signal table includes "known but undocumented" signals
-- [ ] Design Doc signal table includes "known but undocumented" signals
-- [ ] Anti-signals that penalize documentation of agreements are softened
-      or removed
-- [ ] Demotion rule is reviewed and adjusted if needed
-- [ ] Investigation artifacts still score correctly for genuinely open
-      questions
-- [ ] All changes are in the crystallize framework reference file
-- [ ] Evals updated to test "known but undocumented" classification
+- [ ] `references/artifact-type-signals.md` exists with signal tables for
+      all artifact types
+- [ ] PRD, VISION, and Design Doc tables include "known but undocumented"
+      signals
+- [ ] Anti-signals that penalize documentation of agreements are addressed
+- [ ] Demotion rule reviewed and adjusted if needed
+- [ ] Crystallize framework references the shared signal document
+- [ ] /plan Phase 1 references the shared signal document for needs-*
+      labels
+- [ ] Investigation artifacts still score correctly
+- [ ] Evals updated for "known but undocumented" classification
 
 ## Out of scope
 
-- Changes to /explore phases or the detection algorithm
-- Changes to other skills (/prd, /design, /vision, /plan)
-- The artifact type decision reference (F12 -- separate feature)
+- Changes to /explore phases or detection algorithm
+- Changes to /prd, /design, /vision skill internals
 - New artifact types or lifecycle states
-- Scoring for Roadmap, Rejection Record, or No Artifact types (unless
-  the recalibration surfaces issues there too)
+- Enforcement of classification (signals are guidance, not hard gates)
 
 ## Decisions and trade-offs
 
+**Merge F7 and F12.** Originally scoped as separate features: F7
+calibrates the crystallize framework, F12 creates a shared reference. But
+F7's calibration work (adding signals, softening anti-signals) is the
+same work F12 needs for a good shared reference. Doing them separately
+means touching the same tables twice. Merging delivers consistent signals
+in one pass.
+
+**Shared reference with framework-specific scoring.** The signal
+definitions move to the shared reference. The scoring mechanics (signal
+counting, demotion rule, tiebreakers) stay in the crystallize framework.
+This lets /plan use the signals with a simpler decision process while
+/explore keeps its full scoring engine.
+
 **Additive signals over anti-signal removal.** Adding "known but
 undocumented" signals is safer than removing existing anti-signals.
-Removal risks making the framework too permissive (recommending PRD when
-a design doc is genuinely needed). Addition gives the framework a new
-dimension to score on without breaking existing classification.
-
-**Demotion rule refinement is optional.** The demotion rule is aggressive
-but it prevents a common error (high-scoring wrong type beats low-scoring
-right type). Softening it might fix the documentation bias but could
-introduce new misclassification. The PRD requires reviewing it but
-doesn't mandate changing it -- if adding signals is sufficient, the rule
-can stay as-is.
+Removal risks making the framework too permissive. Addition gives a new
+dimension without breaking existing classification.
 
 ## Related
 
-- **ROADMAP-strategic-pipeline.md** -- Feature 7 describes this work
+- **ROADMAP-strategic-pipeline.md** -- Features 7 and 12 (merged)
 - **skills/explore/references/quality/crystallize-framework.md** -- the
-  file containing the signal/anti-signal tables and scoring rules
-- **DESIGN-complexity-routing-expansion.md** (Current) -- F4 added the
-  five-level routing model; the crystallize framework is the scoring
-  engine inside the Complex and Strategic levels
-- **F12 (Artifact Type Decision Reference)** -- a separate shared
-  reference for needs-* label classification; complementary but
-  independent
+  file containing current signal tables and scoring rules
+- **skills/plan/references/phases/phase-1-analysis.md** -- current ad-hoc
+  needs-* label heuristics
+- **references/pipeline-model.md** -- pipeline reference that describes
+  the role of crystallize in the workflow

--- a/docs/prds/PRD-crystallize-calibration.md
+++ b/docs/prds/PRD-crystallize-calibration.md
@@ -1,0 +1,164 @@
+---
+status: Draft
+problem: |
+  The crystallize framework biases toward artifact types that investigate
+  unknowns (design docs, spikes) over types that document agreements (PRDs,
+  VISIONs). When requirements or thesis are verbally settled but not written
+  down, the framework still routes to investigation artifacts.
+goals: |
+  Add "known but undocumented" signals so the framework routes to the right
+  artifact type when the answer is settled but not captured. Soften
+  anti-signals that penalize documentation of existing agreements.
+upstream: docs/roadmaps/ROADMAP-strategic-pipeline.md
+---
+
+# PRD: Crystallize Framework Calibration
+
+## Status
+
+Draft
+
+## Problem statement
+
+The crystallize framework in /explore Phase 4 scores artifact types using
+signal/anti-signal tables. The current tables bias toward investigation:
+signals reward open questions ("how should we build this?", "can we do
+this?") while anti-signals penalize settled answers ("requirements were
+provided as input", "approach is known").
+
+This creates a specific failure mode: when a team has verbally agreed on
+requirements, thesis, or technical approach but hasn't written it down,
+the framework routes to an investigation artifact (design doc, spike)
+instead of a documentation artifact (PRD, VISION). The user then runs a
+design exploration for something already decided, wasting time on a
+question that's already answered.
+
+Three mechanisms cause this:
+
+1. **Missing signals.** No artifact type has signals for "known but
+   undocumented." PRD signals are about unclear/contested requirements,
+   not about capturing agreed ones. VISION signals are about thesis
+   validation, not thesis documentation.
+
+2. **Punitive anti-signals.** PRD has "requirements were provided as
+   input" as an anti-signal -- the framework penalizes exactly the
+   scenario where a PRD is most useful. VISION has "specific users and
+   needs already identified" as an anti-signal, penalizing documented
+   strategic clarity.
+
+3. **Demotion rule amplification.** Any type with one or more anti-signals
+   drops below all types with zero anti-signals, regardless of raw score.
+   In "known but undocumented" scenarios, documentation artifacts often
+   trigger anti-signals (because the answers exist), causing them to rank
+   below investigation artifacts that happen to have zero anti-signals.
+
+## Goals
+
+- Framework correctly routes "known but undocumented" work to documentation
+  artifacts (PRD, VISION, Design Doc)
+- Anti-signals don't penalize the act of documenting settled decisions
+- The demotion rule still protects against genuine misclassification but
+  doesn't amplify the documentation bias
+- Investigation artifacts (spike, design doc with open questions) still
+  score correctly when questions are genuinely open
+
+## User stories
+
+1. As an agent crystallizing exploration findings where the user already
+   knows what to build, I want the framework to recommend PRD so I
+   capture requirements instead of re-investigating them.
+
+2. As an agent crystallizing a strategic exploration where the thesis is
+   clear, I want the framework to recommend VISION so I document the
+   justification instead of exploring whether the project should exist.
+
+3. As an agent crystallizing work where the technical approach was decided
+   in discussion, I want the framework to recommend Design Doc as a record
+   of the decision, not a Spike to re-investigate feasibility.
+
+## Requirements
+
+### Functional
+
+**R1. Add "known but undocumented" signals.** For PRD, VISION, and Design
+Doc, add signals that detect when the answer is settled but not captured.
+These should be observable from exploration findings (e.g., "requirements
+emerged as statements, not questions" or "thesis is asserted, not
+debated").
+
+**R2. Soften punitive anti-signals.** Review anti-signals that penalize
+documentation of agreements. Either remove them, reclassify them as
+neutral, or add qualifying conditions (e.g., "requirements provided as
+input" is only an anti-signal when the PRD already exists, not when
+requirements are verbal).
+
+**R3. Refine the demotion rule.** The current rule demotes any type with
+one or more anti-signals below all types with zero. Consider softening
+this: distinguish between anti-signals that indicate genuine
+misclassification ("this is the wrong artifact type") vs anti-signals
+that indicate partial fit ("this type applies but with caveats").
+
+**R4. Preserve investigation routing.** Spikes, design docs with open
+questions, and other investigation artifacts must still score correctly
+when questions are genuinely open. The calibration adds documentation
+paths without removing investigation paths.
+
+### Non-functional
+
+**R5. Changes scoped to crystallize framework.** Modifications only to
+the signal/anti-signal tables and scoring rules in the crystallize
+framework reference file. No changes to /explore phases, other skills,
+or the detection algorithm.
+
+**R6. Backward compatible signal semantics.** Existing signals keep their
+meaning. New signals are additive. Anti-signal changes are clearly
+documented as intentional recalibration.
+
+## Acceptance criteria
+
+- [ ] PRD signal table includes "known but undocumented" signals
+- [ ] VISION signal table includes "known but undocumented" signals
+- [ ] Design Doc signal table includes "known but undocumented" signals
+- [ ] Anti-signals that penalize documentation of agreements are softened
+      or removed
+- [ ] Demotion rule is reviewed and adjusted if needed
+- [ ] Investigation artifacts still score correctly for genuinely open
+      questions
+- [ ] All changes are in the crystallize framework reference file
+- [ ] Evals updated to test "known but undocumented" classification
+
+## Out of scope
+
+- Changes to /explore phases or the detection algorithm
+- Changes to other skills (/prd, /design, /vision, /plan)
+- The artifact type decision reference (F12 -- separate feature)
+- New artifact types or lifecycle states
+- Scoring for Roadmap, Rejection Record, or No Artifact types (unless
+  the recalibration surfaces issues there too)
+
+## Decisions and trade-offs
+
+**Additive signals over anti-signal removal.** Adding "known but
+undocumented" signals is safer than removing existing anti-signals.
+Removal risks making the framework too permissive (recommending PRD when
+a design doc is genuinely needed). Addition gives the framework a new
+dimension to score on without breaking existing classification.
+
+**Demotion rule refinement is optional.** The demotion rule is aggressive
+but it prevents a common error (high-scoring wrong type beats low-scoring
+right type). Softening it might fix the documentation bias but could
+introduce new misclassification. The PRD requires reviewing it but
+doesn't mandate changing it -- if adding signals is sufficient, the rule
+can stay as-is.
+
+## Related
+
+- **ROADMAP-strategic-pipeline.md** -- Feature 7 describes this work
+- **skills/explore/references/quality/crystallize-framework.md** -- the
+  file containing the signal/anti-signal tables and scoring rules
+- **DESIGN-complexity-routing-expansion.md** (Current) -- F4 added the
+  five-level routing model; the crystallize framework is the scoring
+  engine inside the Complex and Strategic levels
+- **F12 (Artifact Type Decision Reference)** -- a separate shared
+  reference for needs-* label classification; complementary but
+  independent

--- a/docs/roadmaps/ROADMAP-strategic-pipeline.md
+++ b/docs/roadmaps/ROADMAP-strategic-pipeline.md
@@ -200,19 +200,13 @@ Delivered as `references/pipeline-model.md` -- a single reference document
 covering the three-diamond model, five complexity levels, named transitions,
 artifact lifecycle states, traceability chain, and skill routing table.
 
-### Feature 7: Crystallize Calibration and Artifact Type Decision Reference
+### Feature 7: Crystallize Framework Calibration
 
-Recalibrate the crystallize framework's scoring and extract signal
-definitions into a shared reference. Two problems share a root cause: the
-framework biases toward investigation artifacts ("what's unknown") over
-documentation artifacts ("what's known but not written down"), and its
-signal tables are trapped inside /explore while other skills (/plan,
-/triage) make the same decision with ad-hoc heuristics.
-
-Merges the original F7 (calibration) with F12 (shared reference). The
-signal definitions move to `references/artifact-type-signals.md`,
-calibrated with "known but undocumented" scenarios. The crystallize
-framework and /plan Phase 1 both consume the shared reference.
+Recalibrate the crystallize framework's scoring to handle work where the
+answer is known but undocumented. The framework biases toward investigation
+artifacts ("what's unknown") over documentation artifacts ("what's known
+but not written down"). Fix the signal tables directly in
+crystallize-framework.md.
 
 **Dependencies:** None (can be done independently, but benefits from F4
 routing improvements being in place)
@@ -220,13 +214,22 @@ routing improvements being in place)
 **Downstream:** PRD-crystallize-calibration.md (Draft)
 
 Changes:
-- Create `references/artifact-type-signals.md` with calibrated signal
-  tables for all artifact types
 - Add "known but undocumented" signals for PRD, VISION, and Design Doc
 - Soften anti-signals that penalize documentation of agreements
 - Review and adjust the demotion rule if needed
-- Update crystallize framework to reference the shared signal document
-- Update /plan Phase 1 to reference the shared signal document
+- Preserve investigation routing for genuinely open questions
+
+### Feature 12: Artifact Type Decision Reference
+
+Extract the crystallize framework's signal definitions into a shared
+reference document consumable by multiple skills. Deferred until a second
+consumer beyond /explore exists (e.g., a /triage skill). /plan's needs-*
+label logic is a four-line lookup that doesn't warrant the indirection.
+
+**Dependencies:** Feature 7 (calibrated signals should exist before
+extracting them)
+**Status:** Not Started
+**Downstream:** Needs PRD
 
 ### Feature 8: Completion Cascade Automation
 
@@ -335,9 +338,12 @@ progress consistency, and lifecycle hardening became separate features.
 Feature 6 (Docs) depends on Features 1-4 because it documents the
 completed pipeline.
 
-Feature 7 (Crystallize Calibration + Artifact Type Decision Reference)
-is independent but benefits from F4's routing improvements. Merges the
-original F7 and F12 -- calibration and shared reference are the same work.
+Feature 7 (Crystallize Calibration) is independent but benefits from F4's
+routing improvements being in place.
+
+Feature 12 (Artifact Type Decision Reference) depends on F7 (calibrated
+signals should exist before extracting). Deferred until a second consumer
+beyond /explore exists.
 
 Feature 8 (Completion Cascade) depends on F5 (roadmap enrichment must be
 in place) and F3 (cascade reads upstream chain from frontmatter). Has
@@ -366,8 +372,9 @@ Feature 2 (Roadmap) ---+---> Feature 4 (Routing)
                        |
                        +---> Feature 6 (Docs)
 
-Feature 7 (Crystallize Calibration + Decision Reference) --- independent
+Feature 7 (Crystallize Calibration) --- independent
 Feature 11 (Lifecycle Hardening) --- independent
+Feature 12 (Artifact Type Decision Reference) --- depends on F7, deferred
 ```
 
 ## Progress
@@ -380,8 +387,9 @@ Feature 11 (Lifecycle Hardening) --- independent
 | Feature 4: Complexity Routing Expansion | Done | PRD-complexity-routing-expansion.md (Done), DESIGN-complexity-routing-expansion.md (Current) |
 | Feature 5: Plan Skill Rework | Done | PRD-plan-skill-rework.md (Done), DESIGN-plan-skill-rework.md (Current) |
 | Feature 6: Pipeline Documentation | Done | PRD-pipeline-documentation.md (Done) |
-| Feature 7: Crystallize Calibration + Decision Reference | In Progress | PRD-crystallize-calibration.md (Draft) |
+| Feature 7: Crystallize Framework Calibration | In Progress | PRD-crystallize-calibration.md (Draft) |
 | Feature 8: Completion Cascade Automation | Not Started | -- |
 | Feature 9: Upstream Context Propagation | Not Started | -- |
 | Feature 10: Progress Consistency | Not Started | -- |
 | Feature 11: Lifecycle Script Hardening | Not Started | -- |
+| Feature 12: Artifact Type Decision Reference | Not Started | -- |

--- a/docs/roadmaps/ROADMAP-strategic-pipeline.md
+++ b/docs/roadmaps/ROADMAP-strategic-pipeline.md
@@ -404,7 +404,7 @@ Feature 12 (Artifact Type Decision Reference) --- independent
 | Feature 4: Complexity Routing Expansion | Done | PRD-complexity-routing-expansion.md (Done), DESIGN-complexity-routing-expansion.md (Current) |
 | Feature 5: Plan Skill Rework | Done | PRD-plan-skill-rework.md (Done), DESIGN-plan-skill-rework.md (Current) |
 | Feature 6: Pipeline Documentation | Done | PRD-pipeline-documentation.md (Done) |
-| Feature 7: Crystallize Framework Calibration | Not Started | -- |
+| Feature 7: Crystallize Framework Calibration | In Progress | PRD-crystallize-calibration.md (Draft) |
 | Feature 8: Completion Cascade Automation | Not Started | -- |
 | Feature 9: Upstream Context Propagation | Not Started | -- |
 | Feature 10: Progress Consistency | Not Started | -- |

--- a/docs/roadmaps/ROADMAP-strategic-pipeline.md
+++ b/docs/roadmaps/ROADMAP-strategic-pipeline.md
@@ -200,26 +200,33 @@ Delivered as `references/pipeline-model.md` -- a single reference document
 covering the three-diamond model, five complexity levels, named transitions,
 artifact lifecycle states, traceability chain, and skill routing table.
 
-### Feature 7: Crystallize Framework Calibration
+### Feature 7: Crystallize Calibration and Artifact Type Decision Reference
 
-Recalibrate the crystallize framework's scoring to better handle work
-where the answer is known but undocumented. Currently the framework biases
-toward "what's unknown" (design docs, spikes) over "what's known but not
-written down" (PRDs, VISIONs). It pushes users toward answering open
-questions before capturing agreed-upon decisions, when the right order is
-often the reverse: document what's settled, then investigate what's open.
+Recalibrate the crystallize framework's scoring and extract signal
+definitions into a shared reference. Two problems share a root cause: the
+framework biases toward investigation artifacts ("what's unknown") over
+documentation artifacts ("what's known but not written down"), and its
+signal tables are trapped inside /explore while other skills (/plan,
+/triage) make the same decision with ad-hoc heuristics.
+
+Merges the original F7 (calibration) with F12 (shared reference). The
+signal definitions move to `references/artifact-type-signals.md`,
+calibrated with "known but undocumented" scenarios. The crystallize
+framework and /plan Phase 1 both consume the shared reference.
 
 **Dependencies:** None (can be done independently, but benefits from F4
 routing improvements being in place)
-**Status:** Not Started
-**Downstream:** Needs PRD
+**Status:** In Progress
+**Downstream:** PRD-crystallize-calibration.md (Draft)
 
 Changes:
-- Review crystallize signal/anti-signal tables for documentation-bias
-- Add signals that detect "known but undocumented" scenarios
-- Adjust scoring so PRD and VISION score higher when requirements or
-  thesis are verbally agreed but not written down
-- Consider adding a "document first" principle to the framework
+- Create `references/artifact-type-signals.md` with calibrated signal
+  tables for all artifact types
+- Add "known but undocumented" signals for PRD, VISION, and Design Doc
+- Soften anti-signals that penalize documentation of agreements
+- Review and adjust the demotion rule if needed
+- Update crystallize framework to reference the shared signal document
+- Update /plan Phase 1 to reference the shared signal document
 
 ### Feature 8: Completion Cascade Automation
 
@@ -305,33 +312,6 @@ Changes:
 - Consider extracting shared transition-script functions into a common
   library (three scripts share ~70% identical code)
 
-### Feature 12: Artifact Type Decision Reference
-
-Create a shared reference document (`references/artifact-type-signals.md`)
-that defines observable signals for deciding what artifact type a piece of
-work needs next. Multiple skills currently make this decision with ad-hoc
-logic: /plan assigns needs-* labels in Phase 1, /explore scores artifact
-types in its crystallize framework, /triage decides what an untriaged
-issue needs. Each uses different heuristics for the same underlying
-question.
-
-A shared reference gives all skills a consistent decision pattern with
-clear discriminators between "requirements need capturing" (PRD),
-"approach needs deciding" (design doc), "feasibility needs testing"
-(spike), and "single choice needs making" (decision record).
-
-**Dependencies:** None (independent, but benefits from F4's signal-based
-routing pattern)
-**Status:** Not Started
-**Downstream:** Needs PRD
-
-Changes:
-- Create `references/artifact-type-signals.md` with observable signals
-  and discriminators for each artifact type
-- Update /plan Phase 1 to reference the shared document for needs-* labels
-- Update /explore crystallize framework to reference or delegate to it
-- Update /triage to use the same decision pattern
-
 ## Sequencing Rationale
 
 Features 1 and 2 are independent and can proceed in parallel. Both fill
@@ -355,8 +335,9 @@ progress consistency, and lifecycle hardening became separate features.
 Feature 6 (Docs) depends on Features 1-4 because it documents the
 completed pipeline.
 
-Feature 7 (Crystallize Calibration) is independent but benefits from F4's
-routing improvements being in place.
+Feature 7 (Crystallize Calibration + Artifact Type Decision Reference)
+is independent but benefits from F4's routing improvements. Merges the
+original F7 and F12 -- calibration and shared reference are the same work.
 
 Feature 8 (Completion Cascade) depends on F5 (roadmap enrichment must be
 in place) and F3 (cascade reads upstream chain from frontmatter). Has
@@ -372,10 +353,6 @@ milestone-detection problem).
 Feature 11 (Lifecycle Script Hardening) is independent. Can ship any
 time.
 
-Feature 12 (Artifact Type Decision Reference) is independent. Benefits
-from F4's signal-based routing pattern. Once shipped, F5's /plan Phase 1,
-F7's crystallize calibration, and /triage can all consume it.
-
 ```
 Feature 1 (VISION) ----+---> Feature 3 (Traceability)
                        |
@@ -389,9 +366,8 @@ Feature 2 (Roadmap) ---+---> Feature 4 (Routing)
                        |
                        +---> Feature 6 (Docs)
 
-Feature 7 (Crystallize Calibration) --- independent
+Feature 7 (Crystallize Calibration + Decision Reference) --- independent
 Feature 11 (Lifecycle Hardening) --- independent
-Feature 12 (Artifact Type Decision Reference) --- independent
 ```
 
 ## Progress
@@ -404,9 +380,8 @@ Feature 12 (Artifact Type Decision Reference) --- independent
 | Feature 4: Complexity Routing Expansion | Done | PRD-complexity-routing-expansion.md (Done), DESIGN-complexity-routing-expansion.md (Current) |
 | Feature 5: Plan Skill Rework | Done | PRD-plan-skill-rework.md (Done), DESIGN-plan-skill-rework.md (Current) |
 | Feature 6: Pipeline Documentation | Done | PRD-pipeline-documentation.md (Done) |
-| Feature 7: Crystallize Framework Calibration | In Progress | PRD-crystallize-calibration.md (Draft) |
+| Feature 7: Crystallize Calibration + Decision Reference | In Progress | PRD-crystallize-calibration.md (Draft) |
 | Feature 8: Completion Cascade Automation | Not Started | -- |
 | Feature 9: Upstream Context Propagation | Not Started | -- |
 | Feature 10: Progress Consistency | Not Started | -- |
 | Feature 11: Lifecycle Script Hardening | Not Started | -- |
-| Feature 12: Artifact Type Decision Reference | Not Started | -- |


### PR DESCRIPTION
Recalibrate the crystallize framework's scoring to handle "known but
undocumented" work correctly. Currently the framework biases toward
investigation artifacts (design docs, spikes) when the answer is
settled but not captured, routing users to re-investigate decisions
they've already made.

Feature 7 of ROADMAP-strategic-pipeline.md.

---

## Summary

- Draft PRD identifying three bias mechanisms (missing signals, punitive
  anti-signals, demotion rule amplification)
- Implementation to follow in subsequent commits