### PR TITLE
chore: add *.local* pattern to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ Thumbs.db
 # Eval viewer artifacts
 decision-workspace/
 .local.env
+
+# Local overlay files (e.g. CLAUDE.local.md)
+*.local*


### PR DESCRIPTION
Add a `*.local*` pattern to `.gitignore` to keep local overlay files like `CLAUDE.local.md` out of version control. Without this, niwa workspace tooling emits a warning when setting up new workspaces for this repo.

---

Fixes: N/A (maintenance)