### PR TITLE
docs: surface 0.5.0 work-on capabilities in user-facing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,12 @@ merges, you run it again for the next issue.
 Or you can hand the whole plan to `/work-on docs/plans/PLAN-plugin-system.md`.
 That mode runs the plan as a batch: shirabe creates one shared branch and
 draft PR, spawns a child workflow per issue with dependency-aware scheduling,
-and when the batch merges it walks the `upstream` chain of artifacts (plan →
-design → PRD → roadmap) and advances each to the right lifecycle state
-automatically. Issues tagged `docs` or `task` skip the code-review panels so
-documentation-only work doesn't pay for gates it doesn't need.
+and once CI passes on the ready PR it walks the `upstream` chain of artifacts
+(plan → design → PRD → roadmap), applies the lifecycle transition at each
+node, and pushes those changes as a final commit on the same PR. The PR then
+merges with the upstream artifacts already transitioned. Issues tagged `docs`
+or `task` skip the code-review panels so documentation-only work doesn't pay
+for gates it doesn't need.
 
 The whole process produces a paper trail -- PRD, design doc, plan, and focused
 PRs -- that you can point to later when someone asks "why did we build it this

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ built-in validation gates so nothing important gets skipped.
 | `/decision` | Structured decision-making for contested choices with adversarial agents, cross-examination, and synthesis |
 | `/plan` | Decompose a design doc or PRD into sequenced GitHub issues with dependency graphs and complexity labels |
 | `/review-plan` | Adversarial review of a plan across scope, design fidelity, acceptance criteria, and sequencing |
-| `/work-on` | Implement a GitHub issue end-to-end: branch, analysis, code, tests, and pull request |
+| `/work-on` | Implement a GitHub issue, milestone, or full plan end-to-end: branch, analysis, code, three-panel review, tests, and pull request |
 
 Skills are designed to chain together. `/explore` helps you figure out what you
 need, then hands off to `/prd`, `/design`, or `/plan`. `/review-plan` catches
@@ -60,8 +60,17 @@ weak acceptance criteria, or sequencing problems.
 
 **Step 5 -- Implement.** You run `/work-on M3` (the milestone). shirabe picks
 the first unblocked issue, creates a branch, analyzes the code, implements
-the change, runs tests, and opens a PR. When that one merges, you run it again
-for the next issue.
+the change, runs it through a three-panel review (completeness/justification/intent,
+then pragmatic/architect/maintainer, then QA), and opens a PR. When that one
+merges, you run it again for the next issue.
+
+Or you can hand the whole plan to `/work-on docs/plans/PLAN-plugin-system.md`.
+That mode runs the plan as a batch: shirabe creates one shared branch and
+draft PR, spawns a child workflow per issue with dependency-aware scheduling,
+and when the batch merges it walks the `upstream` chain of artifacts (plan →
+design → PRD → roadmap) and advances each to the right lifecycle state
+automatically. Issues tagged `docs` or `task` skip the code-review panels so
+documentation-only work doesn't pay for gates it doesn't need.
 
 The whole process produces a paper trail -- PRD, design doc, plan, and focused
 PRs -- that you can point to later when someone asks "why did we build it this

--- a/references/pipeline-model.md
+++ b/references/pipeline-model.md
@@ -119,16 +119,20 @@ Each artifact's `upstream` field points to its parent. The chain enables:
 - Tracing an implementation issue back to its strategic justification
 - Completion cascades (when issues close, propagate status upstream)
 
-When a plan runs through `/work-on PLAN-*.md` and the resulting PR merges with
-passing CI, the completion cascade fires automatically. A single script walks
-the `upstream` chain from the PLAN doc and applies the right transition at
-each node: DESIGN moves to Current (with the Implementation Issues section
-compressed out), PRD moves to Done, the ROADMAP feature entry is updated, and
-the ROADMAP itself moves to Done once all its features complete. Failures at
-any node are best-effort — they don't block the PR — and the cascade emits a
-JSON result recording which steps ran. See `skills/work-on/scripts/run-cascade.sh`
-for the implementation and `docs/designs/current/DESIGN-completion-cascade.md`
-for the design.
+When a plan runs through `/work-on PLAN-*.md` and CI passes on the
+orchestrator's ready PR, `/work-on` runs the completion cascade as its final
+step before `done`. A single script (`run-cascade.sh --push`) walks the
+`upstream` chain from the PLAN doc and applies the right transition at each
+node: DESIGN moves to Current (with the Implementation Issues section
+compressed out), PRD moves to Done, the ROADMAP feature entry is updated,
+and the ROADMAP itself moves to Done once all its features complete. The
+transitions are committed and pushed as `chore(cascade): post-implementation
+artifact transitions` onto the open PR, so the PR merges with the upstream
+artifacts already advanced — there is no post-merge trigger. Cascade
+failures are best-effort: they don't block the PR, and the script emits a
+JSON result recording which steps ran. See
+`skills/work-on/scripts/run-cascade.sh` for the implementation and
+`docs/designs/current/DESIGN-completion-cascade.md` for the design.
 
 For cross-repo traceability, see `references/cross-repo-references.md`.
 For the upstream/downstream field convention, see

--- a/references/pipeline-model.md
+++ b/references/pipeline-model.md
@@ -119,6 +119,17 @@ Each artifact's `upstream` field points to its parent. The chain enables:
 - Tracing an implementation issue back to its strategic justification
 - Completion cascades (when issues close, propagate status upstream)
 
+When a plan runs through `/work-on PLAN-*.md` and the resulting PR merges with
+passing CI, the completion cascade fires automatically. A single script walks
+the `upstream` chain from the PLAN doc and applies the right transition at
+each node: DESIGN moves to Current (with the Implementation Issues section
+compressed out), PRD moves to Done, the ROADMAP feature entry is updated, and
+the ROADMAP itself moves to Done once all its features complete. Failures at
+any node are best-effort — they don't block the PR — and the cascade emits a
+JSON result recording which steps ran. See `skills/work-on/scripts/run-cascade.sh`
+for the implementation and `docs/designs/current/DESIGN-completion-cascade.md`
+for the design.
+
 For cross-repo traceability, see `references/cross-repo-references.md`.
 For the upstream/downstream field convention, see
 `DESIGN-artifact-traceability.md`.
@@ -132,6 +143,7 @@ skills apply and in what order.
 |-----------|---------------|
 | Trivial fix (typo, config) | /work-on directly |
 | Simple task with issue | /work-on -> /release |
+| Full plan ready to ship | /work-on PLAN-*.md (plan orchestrator) -> /release |
 | Known approach, design decisions exist | /design -> /plan -> /work-on |
 | Shape unclear, multiple unknowns | /explore -> (crystallize) -> /prd or /design -> /plan -> /work-on |
 | New project, thesis needed | /explore --strategic -> /vision -> /roadmap -> per-feature pipeline |

--- a/skills/work-on/SKILL.md
+++ b/skills/work-on/SKILL.md
@@ -217,25 +217,6 @@ Repeat:
 **Errors:** exit 1 = gate failed (fix and retry), exit 2 = bad evidence (check `expects`).
 Use `koto rewind <WF>` to step back.
 
-### Terminal States
-
-The workflow can terminate at several states. Only `done_blocked` is a
-failure; the others are successful exits:
-
-- `done` — PR created and CI passing. The normal happy path.
-- `done_already_complete` — analysis found every acceptance criterion already
-  satisfied in current code, so no commits were needed. Submit
-  `plan_outcome: already_complete` at `analysis` to reach this state. Common
-  in plan-backed mode when a sibling issue's commit already covers this
-  issue's scope. Treat this as a success, not a skip.
-- `validation_exit` — free-form task validation rejected the task as not
-  ready for direct implementation (needs a design, needs an issue, or scope
-  too large).
-- `skipped_due_to_dep_failure` — plan-backed children bypass implementation
-  when an upstream dependency failed. Marked as skipped, not failed.
-- `done_blocked` — only failure terminal. Requires human intervention; use
-  `koto rewind <WF>` to back up once the blocker is resolved.
-
 ### Review Panel
 
 Read `references/review-panel-orchestration.md` for details (panel states: `scrutiny`, `review`, `qa_validation` — require parallel spawns, not standard directive execution).

--- a/skills/work-on/SKILL.md
+++ b/skills/work-on/SKILL.md
@@ -217,6 +217,25 @@ Repeat:
 **Errors:** exit 1 = gate failed (fix and retry), exit 2 = bad evidence (check `expects`).
 Use `koto rewind <WF>` to step back.
 
+### Terminal States
+
+The workflow can terminate at several states. Only `done_blocked` is a
+failure; the others are successful exits:
+
+- `done` — PR created and CI passing. The normal happy path.
+- `done_already_complete` — analysis found every acceptance criterion already
+  satisfied in current code, so no commits were needed. Submit
+  `plan_outcome: already_complete` at `analysis` to reach this state. Common
+  in plan-backed mode when a sibling issue's commit already covers this
+  issue's scope. Treat this as a success, not a skip.
+- `validation_exit` — free-form task validation rejected the task as not
+  ready for direct implementation (needs a design, needs an issue, or scope
+  too large).
+- `skipped_due_to_dep_failure` — plan-backed children bypass implementation
+  when an upstream dependency failed. Marked as skipped, not failed.
+- `done_blocked` — only failure terminal. Requires human intervention; use
+  `koto rewind <WF>` to back up once the blocker is resolved.
+
 ### Review Panel
 
 Read `references/review-panel-orchestration.md` for details (panel states: `scrutiny`, `review`, `qa_validation` — require parallel spawns, not standard directive execution).


### PR DESCRIPTION
Update README.md and references/pipeline-model.md to describe /work-on
capabilities added in 0.5.0: plan orchestrator mode, the three-panel
review (scrutiny, review, QA), the completion cascade, and the
docs/task fast path that skips review panels. No behavior change.

---

## What was missing

| Capability | Before | After |
|---|---|---|
| Plan orchestrator mode (/work-on PLAN-*.md) | Absent from README and pipeline-model | Covered in both |
| Three-panel review | Absent from README | Named in the /work-on row and walkthrough |
| Completion cascade | Absent from README and pipeline-model | Added to traceability-chain section |
| Docs / task fast path | Absent from README | Covered in the walkthrough |

SKILL.md already covered plan-backed child mode, shared branch/PR, cross-issue context, escalation, PR finalization, and the two new terminal states (`done_already_complete`, `skipped_due_to_dep_failure`). No SKILL.md edits were needed.

---

## Friction log

Per the original task instruction to keep a log for future skill improvement. Kept in the PR body rather than the tree so it persists without adding a doc artifact.

**Blocking bug.** `skills/work-on/koto-templates/work-on.md` fails to compile under koto 0.8.2 (`{"error":"invalid YAML: failed to parse front-matter"}`). Sibling templates compile (koto-author.md works; work-on-plan.md compiles with a W4 warning). SKILL.md claims `koto >= 0.3.3`; README claims `>= 0.2.1`. The state machine is unreachable on any workspace with a recent koto, and the skill has no documented escape hatch. I did this task manually as a result.

**Documentation error I introduced and then corrected.** My first draft said the completion cascade "fires automatically when the PR merges." That is wrong — there is no post-merge trigger. The cascade is the final step of the orchestrator workflow itself: after CI passes on the ready PR, the agent runs `run-cascade.sh --push`, which applies lifecycle transitions along the upstream chain and pushes a `chore(cascade):` commit onto the open PR. The PR merges with those transitions already included. I caught this after the user challenged the wording, not during my own review. Implication: I should verify trigger/timing claims by tracing the code, not by paraphrasing SKILL.md prose.

**Subsection I added and then reverted.** First revision added a "Terminal States" subsection to SKILL.md enumerating all five terminals from the koto template. Agents running the execution loop already get terminal status from `koto next` and the template's `failure: true` flag, so the section filled no real gap. Of the five, only `done_already_complete` and `skipped_due_to_dep_failure` are new in 0.5.0, and both are already documented elsewhere (phase-3-analysis.md and SKILL.md's Plan-Backed Child Mode subsection respectively). I included the other three to make the list look "complete," which was scope creep on a "what's undocumented in 0.5.0" task.

Prioritized follow-ups:

1. Pin a working koto version range in README and SKILL.md, and gate the skill on `koto version` before `koto init`.
2. Compile templates in CI on every PR — would have caught the 0.8.x regression at adoption time.
3. Doc-sync check at release — README.md and pipeline-model.md drifted substantially from SKILL.md across 0.5.0 with no signal.
4. Shorten the SKILL.md entry prompt. Plan Mode occupies ~40% of the prompt; it should live in `references/plan-mode.md` and load only when the input is a PLAN path.
5. Surface a free-form docs fast path at entry. A free-form task that is obviously docs-only today still routes through analysis then scrutiny, review, and QA. Let entry evidence accept `issue_type: docs|task` the way plan-backed mode does.
6. Friction-log convention. The skill asks for a log but does not say where to put it; make `--friction-log` a first-class flag or name a canonical path.

Smaller observations:

- Input Resolution leads with issue/milestone and mentions free-form mode only further down in Mode Detection. Put the four modes in a single table at the top.
- Free-form mode has no slug convention, which fragments resume.
- "Branch Context Evaluation" sits under Plan Mode, but the same logic applies to free-form and issue-backed resumes.
- The "maintain a friction log" instruction was useful; it changed how I treated the koto blocker (product observation, not just a route-around). Worth making this a first-class mode.