### PR TITLE
feat(skills): hard-stop upstream references to private or wip-staged paths

### DIFF
--- a/references/cross-repo-references.md
+++ b/references/cross-repo-references.md
@@ -72,3 +72,28 @@ The directional rule:
   tooling. Verify manually when the referenced artifact may have moved.
 - **Public referencing private** (`tsukumogami/vision:docs/...` in a
   public repo): violates visibility rules. Omit the field instead.
+- **`wip/...` paths as `upstream:` values**: wip/ artifacts are non-durable.
+  They are deleted before merge per the wip-hygiene rule (see
+  [`wip-hygiene.md`](wip-hygiene.md)). An `upstream: wip/...` value points
+  at a file that disappears on cleanup -- the reference orphans the moment
+  the cleanup commit lands. If the only PRD on disk is a wip/ staging copy,
+  the canonical PRD lives elsewhere. Resolve the canonical location and
+  apply the visibility-direction rules above; if the canonical home is a
+  private repo and your repo is public, OMIT the field entirely.
+
+## Where this rule is enforced
+
+The visibility-direction table above is enforced at these explicit
+validation points (not as a passive reference -- agent phase scripts
+hard-stop on violations):
+
+| Skill | Phase step | What it validates |
+|-------|-----------|-------------------|
+| `skills/design` | [Phase 0 step 0.4a](../skills/design/references/phases/phase-0-setup-prd.md) | The `upstream:` value about to be written into the design doc skeleton |
+| `skills/design` | [Phase 6 step 6.4](../skills/design/references/phases/phase-6-final-review.md) | Final hygiene grep on the design doc body for `wip/...` references and a broken `upstream:` value |
+| `skills/plan`   | [Phase 7 step 7.4b](../skills/plan/references/phases/phase-7-creation.md) | Reference hygiene grep on the about-to-commit PLAN doc body and frontmatter |
+| `skills/prd`    | [Phase 3 step 3.1](../skills/prd/references/phases/phase-3-draft.md) | The `--upstream` value before it is stored for inclusion in PRD frontmatter |
+
+When updating either side, update the other: a new validation point belongs
+in this table; a change to the rule statement belongs in the section above
+that the phase scripts route the agent to.

--- a/references/pipeline-model.md
+++ b/references/pipeline-model.md
@@ -134,7 +134,10 @@ JSON result recording which steps ran. See
 `skills/work-on/scripts/run-cascade.sh` for the implementation and
 `docs/designs/current/DESIGN-completion-cascade.md` for the design.
 
-For cross-repo traceability, see `references/cross-repo-references.md`.
+For cross-repo traceability and the visibility-direction rules, see
+[`cross-repo-references.md`](cross-repo-references.md). For the `wip/`
+hygiene rule that prevents non-durable references in committed artifacts,
+see [`wip-hygiene.md`](wip-hygiene.md).
 For the upstream/downstream field convention, see
 `DESIGN-artifact-traceability.md`.
 

--- a/references/wip-hygiene.md
+++ b/references/wip-hygiene.md
@@ -1,0 +1,88 @@
+# wip/ Hygiene
+
+Rules for how shirabe-driven workflows treat the `wip/` directory and what
+counts as a durable reference.
+
+## What `wip/` is
+
+`wip/` (Work In Progress) is a per-branch scratch space for intermediate
+artifacts produced during multi-phase workflows. Phase scripts in
+`skills/design`, `skills/plan`, `skills/prd`, and `skills/explore` write
+summaries, research notes, manifests, and coordination state into
+`wip/<skill>_<topic>_*.md` and `wip/research/<skill>_<topic>_*.md`.
+
+`wip/` is committed to feature branches so that workflows survive resume.
+It is NOT included in merged history: workflows clean it up before the PR
+opens, and squash-merge keeps the cleanup out of the main branch trail.
+
+## The rule
+
+`wip/` paths must not appear in any durable reference. The durable surfaces
+are:
+
+- Frontmatter fields on committed docs (`upstream:`, `references:`, `source:`,
+  any path-shaped value)
+- Body prose on committed docs under `docs/` (designs, PRDs, plans,
+  roadmaps, guides)
+- README files, CLAUDE.md files, and other repo-root markdown
+- PR descriptions and issue bodies
+
+Quoted statements of this rule (and of wip/'s purpose) are allowed. A line
+that says "wip/ artifacts are tolerated on the branch but must be cleaned
+before the PR opens" is rule-statement prose. A line that says "see
+`wip/PR-foo.md` for the draft" is a path-shaped reference and a hard fail.
+
+## Why
+
+`wip/` is deleted before merge. A reference to a `wip/...` path resolves
+to nothing the moment the cleanup commit lands. The reader of the merged
+artifact is left with a broken link to a file the workspace's own cleanup
+removed.
+
+When a `wip/...` path also crosses a visibility boundary -- for example, a
+coordinator stages a private-repo PRD into a public repo's `wip/` as a
+handoff, and a design agent then writes `upstream: wip/PRD-<topic>.md` into
+public frontmatter -- the failure compounds. The reference is simultaneously
+non-durable AND a public->private link (forbidden per
+[`cross-repo-references.md`](cross-repo-references.md)).
+
+## Cleanup is two operations
+
+Cleaning up `wip/` before merge means BOTH:
+
+1. **Delete the wip/ files** (mechanical -- usually a single `rm` or
+   `git rm` command per phase script).
+2. **Remove every reference to wip/ paths from committed prose** (semantic
+   -- requires `git grep -nE 'wip/'` from the repo root, with a manual
+   review of each match to distinguish rule-statement prose from
+   path-shaped references).
+
+Doing only (1) leaves the references as orphans. Doing only (2) leaves the
+files committed.
+
+## Where this rule is enforced
+
+Phase scripts hard-stop on violations. Workflows that produce a durable
+artifact include an explicit grep step before the artifact lands:
+
+| Skill | Phase step | Surface checked |
+|-------|-----------|-----------------|
+| `skills/design` | [Phase 0 step 0.4a](../skills/design/references/phases/phase-0-setup-prd.md) | The `upstream:` value before the design doc skeleton is written |
+| `skills/design` | [Phase 6 step 6.4](../skills/design/references/phases/phase-6-final-review.md) | The full design doc body and frontmatter before commit |
+| `skills/plan`   | [Phase 7 step 7.4b](../skills/plan/references/phases/phase-7-creation.md) | The full PLAN doc body and frontmatter before status transition |
+| `skills/prd`    | [Phase 3 step 3.1](../skills/prd/references/phases/phase-3-draft.md) | The `--upstream` value before the PRD draft is written |
+
+## Verification commands
+
+Run from the repo root before opening any PR that touches `docs/`:
+
+```bash
+# Any wip/ path in committed prose under docs/ is a violation.
+git grep -nE 'wip/' -- 'docs/**/*.md'
+
+# Any frontmatter upstream/source pointing at wip/ is a violation.
+git ls-files 'docs/**/*.md' | xargs -I{} head -20 {} | grep -nE '^(upstream|source|references):.*wip/'
+```
+
+Empty output means clean. Any match should be reviewed; rule-statement prose
+is acceptable, path-shaped references are not.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -47,7 +47,10 @@ reading the full document.
 
 **Optional fields:**
 - `upstream: docs/prds/PRD-<name>.md` -- link to source PRD (set by /design Phase 0).
-  For cross-repo upstream references, see `references/cross-repo-references.md`.
+  For cross-repo upstream references and the visibility-direction rules,
+  see `${CLAUDE_PLUGIN_ROOT}/references/cross-repo-references.md`. The
+  Phase 0 setup script validates this value (see step 0.4a in
+  `references/phases/phase-0-setup-prd.md`).
 - `spawned_from` -- for child designs created from needs-design issues:
   ```yaml
   spawned_from:

--- a/skills/design/evals/evals.json
+++ b/skills/design/evals/evals.json
@@ -12,7 +12,14 @@
       "id": 2,
       "name": "prd-based-design",
       "prompt": "/design docs/prds/PRD-plugin-system.md",
-      "expected_output": "Design skill detects path matches docs/prds/PRD-*.md pattern and enters PRD mode. Phase 0 reads phase-0-setup-prd.md, validates PRD status is Accepted, extracts requirements and constraints from the PRD. Sets upstream field in frontmatter to docs/prds/PRD-plugin-system.md. Design doc scoping derives from PRD content rather than asking the user to describe the problem. Decision Drivers section reflects the PRD's requirements. The rest of the 8-phase workflow proceeds normally.",
+      "expected_output": "Design skill detects path matches docs/prds/PRD-*.md pattern and enters PRD mode. Phase 0 reads phase-0-setup-prd.md, validates PRD status is Accepted, extracts requirements and constraints from the PRD. Step 0.4a validates the upstream path: git ls-files shows the PRD is tracked in this repo, so the relative path is used. Sets upstream field in frontmatter to docs/prds/PRD-plugin-system.md. Design doc scoping derives from PRD content rather than asking the user to describe the problem. Decision Drivers section reflects the PRD's requirements. The rest of the 8-phase workflow proceeds normally.",
+      "files": []
+    },
+    {
+      "id": 9,
+      "name": "wip-staging-upstream-rejected",
+      "prompt": "/design wip/PRD-cross-repo-feature.md",
+      "expected_output": "Design skill detects the path. Phase 0 step 0.4a validates the upstream PRD path. Check 1 fires immediately: the candidate path is under wip/. The skill hard-stops with an error explaining wip/ is non-durable and reads ${CLAUDE_PLUGIN_ROOT}/references/cross-repo-references.md to surface recovery options. The skill does NOT write upstream: wip/... into the design doc skeleton. If the repo is public and the canonical PRD lives in a private repo, the skill recommends omitting the upstream field; otherwise it asks the user for the canonical owner/repo:path or same-repo path before proceeding to step 0.5.",
       "files": []
     },
     {

--- a/skills/design/references/phases/phase-0-setup-prd.md
+++ b/skills/design/references/phases/phase-0-setup-prd.md
@@ -51,13 +51,70 @@ the PRD may not cover.
 
 Write the "Decision Drivers" section in the design doc.
 
+### 0.4a Validate Upstream PRD Path
+
+Before writing the `upstream:` value into the design doc, validate that the path
+is durable and visibility-compatible. This is a hard-stop check: do not proceed
+with step 0.5 until the path is resolved or the field is omitted.
+
+**The path the PRD was loaded from (in step 0.2) is the candidate `upstream:`
+value.** Run these checks in order:
+
+1. **Is the candidate path under `wip/`?** If yes, STOP. The PRD on disk is a
+   staging copy, not its canonical home. wip/ paths are non-durable: they are
+   deleted before merge and would leave the design's `upstream:` orphaned.
+   Resolution:
+   - Find the PRD's canonical location (likely in a different repo). If the
+     current repo's visibility allows referencing it, use `owner/repo:path`
+     cross-repo syntax for `upstream:`.
+   - If the canonical PRD lives in a private repo and this repo is public,
+     OMIT the `upstream:` field entirely (see step 0.5 worked example).
+   - Read `${CLAUDE_PLUGIN_ROOT}/references/cross-repo-references.md` for the
+     visibility-direction table and recovery options.
+
+2. **Does the candidate path resolve inside this repo?** Run
+   `git ls-files <path>` from the repo root.
+   - If non-empty: the PRD is tracked in this repo. Use the relative path as
+     `upstream:` and proceed to 0.5.
+   - If empty: the PRD is not in this repo. Detect the current repo's
+     visibility from CLAUDE.md (`## Repo Visibility:`).
+
+3. **Public repo referencing an out-of-repo PRD?** If the repo is public AND
+   the PRD is not tracked here AND the canonical location is private, STOP.
+   This is a visibility violation: external readers can't reach private
+   resources, so the link breaks for them. Resolution: OMIT the `upstream:`
+   field entirely. Add a one-line prose note in the design body's "Context
+   and Problem Statement" section explaining that the source PRD lives in a
+   private tracker (without naming the private path or repo).
+
+4. **Public repo referencing an out-of-repo PUBLIC PRD?** Use the
+   `owner/repo:path` cross-repo syntax. Verify the path exists in the target
+   repo before writing it.
+
+5. **Never write `upstream: wip/...` into committed frontmatter.** wip/
+   paths fail check (1) above. The same rule applies to any other prose or
+   frontmatter field that survives the merge.
+
+**Worked example (the failure mode this step prevents).** During a
+multi-repo coordination run, a coordinator stages a private-repo PRD into the
+current (public) repo's `wip/` directory as a handoff. An agent runs `/design`
+against that staging file. Without this validation, the agent writes
+`upstream: wip/PRD-<topic>.md` into the design frontmatter. Later, a cleanup
+commit deletes the wip/ file (per wip-hygiene), leaving the `upstream:` value
+pointing at nothing. The frontmatter is now a public reference to a private
+resource AND an orphaned path. With this validation, the agent detects the
+`wip/` prefix at check (1), recognises the cross-visibility boundary at check
+(3), and omits the `upstream:` field instead.
+
 ### 0.5 Create Design Doc Skeleton
 
-Write the initial design doc to `docs/designs/DESIGN-<topic>.md`:
+Write the initial design doc to `docs/designs/DESIGN-<topic>.md`. The
+`upstream` line below is conditional on the outcome of step 0.4a -- omit it
+entirely if 0.4a determined the field cannot be set:
 
 ```markdown
 ---
-upstream: docs/prds/PRD-<name>.md
+upstream: docs/prds/PRD-<name>.md   # OMIT this line if step 0.4a resolved to "omit"
 ---
 
 # DESIGN: <Topic>
@@ -76,7 +133,8 @@ Proposed
 ```
 
 The `upstream` field creates a machine-readable link from the design doc back to
-its source PRD.
+its source PRD. When omitted (per 0.4a), a prose note in the Context section
+should describe where the source PRD lives without naming a private path.
 
 ### 0.6 Transition PRD Status
 
@@ -107,6 +165,9 @@ Before proceeding:
 - [ ] On branch `docs/<topic>`
 - [ ] Problem statement is in implementation terms (not a PRD copy)
 - [ ] Decision drivers include both PRD-derived and implementation-specific factors
+- [ ] `upstream:` value is either a same-repo `docs/prds/...` path, a public
+  cross-repo `owner/repo:path`, or omitted (per step 0.4a). It is NEVER a
+  `wip/...` path.
 
 ## Artifact State
 

--- a/skills/design/references/phases/phase-6-final-review.md
+++ b/skills/design/references/phases/phase-6-final-review.md
@@ -93,6 +93,24 @@ Check all required sections are present and well-formed:
 - [ ] Security Considerations (content per Phase 5 outcome)
 - [ ] Consequences (positive, negative, mitigations)
 
+**Reference Hygiene Checks:**
+
+Run this grep from the repo root:
+
+```bash
+git grep -nE 'wip/' -- docs/designs/DESIGN-<topic>.md || true
+```
+
+- [ ] No `wip/...` paths appear in the committed frontmatter or prose. The
+  only acceptable matches are quoted statements OF the wip-hygiene rule
+  itself; any path-shaped reference is a hard fail.
+- [ ] `upstream:` value resolves on disk via `git ls-files <path>`, OR is a
+  valid public `owner/repo:path` cross-repo reference, OR is omitted (per
+  Phase 0 step 0.4a). See
+  `${CLAUDE_PLUGIN_ROOT}/references/cross-repo-references.md`.
+- [ ] No references in the design body to staging artifacts that will be
+  deleted by Phase 6.9 cleanup (search for `wip/design_`, `wip/research/`).
+
 **STOP if any check fails.** Fix before proceeding.
 
 ### 6.5 Write Frontmatter
@@ -103,7 +121,7 @@ YAML literal block scalars (`|`):
 ```markdown
 ---
 status: Proposed
-upstream: docs/prds/PRD-<name>.md   # Only if PRD mode (check wip/ summary)
+upstream: docs/prds/PRD-<name>.md   # Only if PRD mode AND step 0.4a resolved to a usable path. OMIT if 0.4a resolved to "omit" (private cross-repo) or if no upstream PRD exists.
 problem: |
   <1 paragraph: what technical problem this solves>
 decision: |

--- a/skills/plan/evals/evals.json
+++ b/skills/plan/evals/evals.json
@@ -214,6 +214,20 @@
         "Issue 2 waits_on is empty",
         "No additional edges beyond those from explicit **Dependencies**: lines"
       ]
+    },
+    {
+      "id": 16,
+      "name": "phase-7-rejects-wip-paths-in-plan-body",
+      "prompt": "/plan docs/designs/DESIGN-staging-handoff.md",
+      "expected_output": "Phase 7 step 7.4b runs the reference-hygiene grep against the about-to-commit PLAN doc. If the body contains a path-shaped wip/... reference (e.g., an acceptance criterion that says 'committed to wip/PR-foo.md'), the skill hard-stops with an error pointing at the wip-hygiene rule. The skill does NOT proceed to status transition. Rule-statement prose mentioning wip/ as a concept is acceptable; path-shaped references are not. The skill also validates the upstream: frontmatter value resolves via git ls-files or is a valid owner/repo:path cross-repo reference; wip/... is never acceptable as an upstream value.",
+      "files": [],
+      "expectations": [
+        "Transcript describes Phase 7 step 7.4b running git grep for wip/ in the PLAN doc",
+        "Transcript distinguishes rule-statement prose from path-shaped references",
+        "Transcript hard-stops on a path-shaped wip/ match",
+        "Transcript validates the upstream: frontmatter value before status transition",
+        "Transcript cites ${CLAUDE_PLUGIN_ROOT}/references/cross-repo-references.md for the visibility-direction rules"
+      ]
     }
   ]
 }

--- a/skills/plan/references/phases/phase-7-creation.md
+++ b/skills/plan/references/phases/phase-7-creation.md
@@ -313,6 +313,55 @@ Recommend running `/work-on docs/plans/PLAN-<topic>.md` to begin implementation.
 
 These steps run after the mode-specific steps above.
 
+### 7.4b Validate PLAN Doc Reference Hygiene
+
+Before transitioning the source doc's status (which marks the planning step
+as "done" upstream), grep the PLAN artifact for non-durable or
+visibility-violating references. Run from the repo root:
+
+```bash
+# 1. No wip/ paths anywhere in the PLAN body or frontmatter.
+git grep -nE 'wip/' -- 'docs/plans/PLAN-<topic>.md'
+
+# 2. The upstream: frontmatter value resolves to a tracked file in this repo,
+#    OR is a public owner/repo:path cross-repo reference. It must NEVER be a
+#    wip/... path.
+head -20 'docs/plans/PLAN-<topic>.md' | grep -E '^upstream:'
+```
+
+**Match handling:**
+
+- **Any `wip/...` hit in the body or frontmatter is a hard fail.** wip/ paths
+  are non-durable: they are deleted before merge and would leave the PLAN
+  doc's references orphaned the moment cleanup runs. The trigger violation
+  this check exists to catch is acceptance-criteria prose that names a
+  specific `wip/PR-<topic>.md` or `wip/<artifact>.md` path -- replace with
+  a generic phrase that describes the artifact's purpose without naming a
+  non-durable path. Example: instead of `A PR draft is committed to
+  wip/PR-foo.md`, write `A PR draft exists locally (cleaned before merge)`.
+- **Prose mentions of the wip-hygiene rule itself are acceptable.** If a
+  matching line is *describing* the rule (e.g., "wip/ artifacts are tolerated
+  on the branch but must be cleaned before the PR opens"), it is allowed.
+  Path-shaped references (anything that resolves to a file location) are
+  not.
+- **The `upstream:` value must resolve.** If `git ls-files <path>` returns
+  empty for a same-repo value, the upstream is broken -- fix the path. If
+  the upstream is `owner/repo:path`, confirm visibility direction against
+  `${CLAUDE_PLUGIN_ROOT}/references/cross-repo-references.md` (public repos
+  must not reference private repos).
+
+**STOP if any check fails.** Fix the PLAN doc and re-run before proceeding to
+status transition.
+
+**Worked example (the failure mode this step prevents).** A planning agent
+authoring a multi-issue decomposition writes an acceptance criterion that
+says "the PR description is committed to `wip/PR-<topic>.md`." On the same
+branch, another acceptance criterion says "clean up any leftover `wip/`
+artifacts before merge." Both criteria get committed into the PLAN doc body.
+The cleanup commit deletes the wip/ file but leaves the PLAN's prose
+reference pointing at it -- the PLAN is now self-contradictory and contains
+a path that resolves to nothing.
+
 ### 7.5 Source Document Status Transition
 
 **For design docs and PRDs** (input_type: design or prd):
@@ -427,6 +476,9 @@ Before completing:
 - [ ] PLAN artifact created at `docs/plans/PLAN-<topic>.md`
 - [ ] Frontmatter includes all required fields (`schema`, `status`, `execution_mode`, `milestone`, `issue_count`)
 - [ ] multi-pr: all issues created, milestone assigned, status is Active
+- [ ] PLAN doc reference hygiene (step 7.4b) passed: no `wip/...` paths in
+  frontmatter or body prose; `upstream:` resolves on disk or is a valid
+  public cross-repo reference
 
 ## Next Phase
 

--- a/skills/prd/evals/evals.json
+++ b/skills/prd/evals/evals.json
@@ -61,13 +61,27 @@
       "id": 9,
       "name": "upstream-propagation",
       "prompt": "/prd feature-flags --upstream docs/roadmaps/ROADMAP-platform.md",
-      "expected_output": "Detects --upstream flag from arguments. Stores the roadmap path. During Phase 3 (draft), includes upstream: docs/roadmaps/ROADMAP-platform.md in the PRD frontmatter. Does not treat --upstream as part of the topic.",
+      "expected_output": "Detects --upstream flag from arguments. Stores the roadmap path. Phase 3 step 3.1 validates the path: git ls-files confirms the roadmap is tracked in this repo and is not under wip/. The validated path is included as upstream: docs/roadmaps/ROADMAP-platform.md in the PRD frontmatter. Does not treat --upstream as part of the topic.",
       "files": [],
       "expectations": [
         "Transcript detects and parses the --upstream flag from $ARGUMENTS",
         "Transcript stores the upstream path (docs/roadmaps/ROADMAP-platform.md) for use in Phase 3",
+        "Transcript describes Phase 3 step 3.1 validating the path is not under wip/ and resolves in this repo",
         "Transcript describes including upstream: in the PRD frontmatter during Phase 3 drafting",
         "Transcript does NOT treat --upstream as part of the topic name"
+      ]
+    },
+    {
+      "id": 10,
+      "name": "upstream-wip-rejected",
+      "prompt": "/prd integration-spec --upstream wip/ROADMAP-staging.md",
+      "expected_output": "Detects --upstream flag and the wip/-prefixed value. Phase 3 step 3.1 validation check 1 fires: the candidate path is under wip/. The skill hard-stops with an error and routes to ${CLAUDE_PLUGIN_ROOT}/references/cross-repo-references.md. The upstream: field is NOT written into PRD frontmatter; the skill either asks the user for the canonical path or omits the field per the rule.",
+      "files": [],
+      "expectations": [
+        "Transcript detects the wip/ prefix on the --upstream value",
+        "Transcript hard-stops Phase 3 step 3.1 instead of writing upstream: wip/... into frontmatter",
+        "Transcript routes the agent to cross-repo-references.md for the rule and recovery options",
+        "Transcript either omits the upstream field or asks the user for a durable canonical path before proceeding"
       ]
     }
   ]

--- a/skills/prd/references/phases/phase-3-draft.md
+++ b/skills/prd/references/phases/phase-3-draft.md
@@ -34,6 +34,27 @@ path typically points to a Roadmap document when the PRD is part of a
 multi-feature initiative. If `--upstream` is not provided, omit the field
 from frontmatter.
 
+**Validate upstream:** If a path was detected, run these checks in order
+before storing it. These are hard-stops -- do not write a failing value into
+frontmatter:
+
+1. **Is the path under `wip/`?** STOP. wip/ paths are non-durable and would
+   leave the PRD's `upstream:` orphaned after wip-hygiene cleanup. Resolve
+   the canonical location and use that path instead, or OMIT the field.
+2. **Does the path resolve in this repo?** Run `git ls-files <path>`. If
+   non-empty, the upstream is durable -- continue.
+3. **Path is out-of-repo?** Detect this repo's visibility from CLAUDE.md
+   (`## Repo Visibility:`). If public AND the canonical upstream lives in a
+   private repo, STOP and OMIT the `upstream:` field. Public artifacts must
+   not reference private resources. See
+   `${CLAUDE_PLUGIN_ROOT}/references/cross-repo-references.md` for the
+   visibility-direction table and the cross-repo `owner/repo:path` syntax for
+   allowed cases (public->public, private->public, private->private).
+
+When omitting the field, optionally describe the source-context in prose in
+the PRD body's Problem Statement section, without naming a private path or
+repo.
+
 ### 3.2 Draft the PRD
 
 Write a complete PRD draft following the `prd` skill structure. Use the Write tool to
@@ -57,8 +78,9 @@ create `docs/prds/PRD-<topic>.md`.
   existed, and why the chosen option won. Include decisions made during this
   drafting phase as well.
 
-Set frontmatter status to "Draft". If an `--upstream` path was detected in
-step 3.1, include `upstream: <path>` in frontmatter. Otherwise omit the field.
+Set frontmatter status to "Draft". If an `--upstream` path was detected AND
+passed validation in step 3.1, include `upstream: <path>` in frontmatter.
+Otherwise omit the field.
 
 ### 3.3 Present the Draft
 

--- a/skills/prd/references/prd-format.md
+++ b/skills/prd/references/prd-format.md
@@ -31,7 +31,9 @@ source_issue: 123  # optional, GitHub issue number that triggered this PRD
 
 Required fields: `status`, `problem`, `goals`. Optional: `upstream` (path to
 parent artifact when this PRD is part of a larger effort; for cross-repo
-upstream references, see `references/cross-repo-references.md`),
+upstream references and the visibility-direction rules, see
+`${CLAUDE_PLUGIN_ROOT}/references/cross-repo-references.md` -- Phase 3
+step 3.1 validates this value),
 `source_issue` (GitHub issue number that triggered this PRD). Each
 field should be 1 paragraph using YAML literal block scalars (`|`). Frontmatter
 status must match the Status section in the body -- agent workflows parse

--- a/skills/roadmap/references/roadmap-format.md
+++ b/skills/roadmap/references/roadmap-format.md
@@ -38,8 +38,9 @@ be 1 paragraph using YAML literal block scalars (`|`).
 The `upstream` field links the roadmap to the strategic artifact that motivated
 it. When present, it points to a VISION document (the natural parent in the
 traceability chain). Roadmaps that emerge from exploration without a formal
-VISION omit this field. For cross-repo upstream references, see
-`references/cross-repo-references.md`.
+VISION omit this field. For cross-repo upstream references and the
+visibility-direction rules, see
+`${CLAUDE_PLUGIN_ROOT}/references/cross-repo-references.md`.
 
 Frontmatter status must match the Status section in the body -- agent workflows
 parse frontmatter to determine lifecycle state, so divergence causes silent

--- a/skills/vision/references/vision-format.md
+++ b/skills/vision/references/vision-format.md
@@ -37,7 +37,8 @@ Required fields: `status`, `thesis`, `scope`. Optional: `upstream`.
   project exist within the org)
 - **upstream** -- path to parent VISION when a project-level doc derives from
   an org-level one. Project-level only; omit for org-level. For cross-repo
-  upstream references, see `references/cross-repo-references.md`.
+  upstream references and the visibility-direction rules, see
+  `${CLAUDE_PLUGIN_ROOT}/references/cross-repo-references.md`.
 
 Frontmatter status must match the Status section in the body -- agent workflows
 parse frontmatter to determine lifecycle state, so divergence causes silent


### PR DESCRIPTION
Add Phase-0 validation in the design, plan, and prd skills that hard-stops when an `upstream:` value would reference a wip/-staged path or a private artifact from a public repo. The validation routes the agent to `references/cross-repo-references.md` (which already documented the rule) with a worked example reproducing the failure mode the trigger violation exhibited: an `upstream: wip/PRD-<name>.md` written into the frontmatter of a public-repo design doc because a coordinator-handoff had staged the source artifact under `wip/`.

Add `references/wip-hygiene.md` documenting the workspace-wide rule, the "cleanup is two operations" guidance (delete files AND grep for references), and an enforcement-point table linking each validation point back to the rule.

Switch existing skill citations of `references/cross-repo-references.md` from broken relative paths to the working `${CLAUDE_PLUGIN_ROOT}/...` form (the relative path did not resolve from inside skill subdirectories).

Extend eval scenarios in `skills/design/evals/evals.json`, `skills/plan/evals/evals.json`, and `skills/prd/evals/evals.json` to cover the wip-staging rejection paths.

---

## What This Accomplishes

The rule was already documented in `references/cross-repo-references.md`. It said plainly: "Public referencing private (...): violates visibility rules. Omit the field instead." A forensic audit of a recent public-repo PR found a design doc that shipped with `upstream: wip/PRD-<name>.md` — three problems compounded: public-to-private reference, wip-artifact reference, and orphaned path after the cleanup commit. The root cause was that the rule lived in a passive reference doc the agent had to choose to read; the design skill's Phase 0 procedure agents actually execute never loaded it. This PR closes that loop.

## What This Enables

After merge, any agent running `/shirabe:design` or `/shirabe:plan` or `/shirabe:prd` encounters the validation step before the `upstream:` value reaches the doc frontmatter. The validation rejects wip-paths outright and hard-stops on public-to-private resolution, routing the agent to the rule doc with the worked example. The same loophole cannot recur in future PRs authored under these skills.

## How It Works

Each skill's Phase-0 procedure gains an explicit validation step:

- `skills/design/references/phases/phase-0-setup-prd.md` — new step **0.4a Validate Upstream PRD Path**: rejects `wip/...` prefix; runs `git ls-files <path>` to resolve same-repo; detects current-repo visibility for public-to-private rejection; allows public-to-public cross-repo via `owner/repo:path`.
- `skills/design/references/phases/phase-6-final-review.md` — pre-commit reference-hygiene grep on the design doc body.
- `skills/plan/references/phases/phase-7-creation.md` — new step **7.4b Validate PLAN Doc Reference Hygiene**: scans for `wip/` references in the PLAN doc body, distinguishing rule-statement prose (allowed) from path-shaped references (hard fail).
- `skills/prd/references/phases/phase-3-draft.md` — validates the `--upstream` argument before storing it for PRD frontmatter inclusion.

`references/cross-repo-references.md` gains a back-reference table linking each validation point to the rule, closing the bidirectional loop.

## Test Plan

- [x] Phase-0 / 3 / 7 validation steps appear in the relevant phase docs with clear procedures (verified by `grep -rn 'upstream' skills/design/references/phases/ skills/plan/references/phases/ skills/prd/references/phases/`).
- [x] All citations of `cross-repo-references.md` resolve via `${CLAUDE_PLUGIN_ROOT}/...` (verified by `grep -rn 'cross-repo-references' skills/ references/`).
- [ ] Run the updated evals via `scripts/run-evals.sh design`, `scripts/run-evals.sh plan`, `scripts/run-evals.sh prd` once eval-runner access is available. The eval changes are additive guidance text (no schema or surface change), so existing scenarios continue to describe the skill accurately.

## Notes

The evals were updated but not executed in this PR. Happy to run them as a follow-up if validation is desired before merge.
