### PR TITLE
feat(cli): add --version flag, tsuku recipe, and CI validation

### DIFF
--- a/.github/workflows/validate-tsuku-recipe.yml
+++ b/.github/workflows/validate-tsuku-recipe.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install tsuku
         run: |
-          curl -fsSL https://raw.githubusercontent.com/tsukumogami/tsuku/main/install.sh | bash
+          curl -fsSL https://get.tsuku.dev/now | bash
           echo "$HOME/.tsuku/bin" >> "$GITHUB_PATH"
 
       - name: Strict-validate recipe TOML
@@ -67,7 +67,7 @@ jobs:
 
       - name: Install tsuku
         run: |
-          curl -fsSL https://raw.githubusercontent.com/tsukumogami/tsuku/main/install.sh | bash
+          curl -fsSL https://get.tsuku.dev/now | bash
           echo "$HOME/.tsuku/bin" >> "$GITHUB_PATH"
 
       - name: Install shirabe via tsuku (latest)

--- a/.github/workflows/validate-tsuku-recipe.yml
+++ b/.github/workflows/validate-tsuku-recipe.yml
@@ -1,0 +1,79 @@
+name: Validate tsuku recipe
+
+# Validates .tsuku-recipes/shirabe.toml against the tsuku CLI on every PR
+# that touches the recipe, the shirabe CLI source, or the release pipeline.
+# Three checks: strict TOML validation, binary --version output sanity,
+# and a best-effort end-to-end install via tsuku against the latest release.
+
+on:
+  pull_request:
+    paths:
+      - '.tsuku-recipes/**'
+      - 'cmd/shirabe/**'
+      - '.goreleaser.yaml'
+      - '.github/workflows/validate-tsuku-recipe.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.tsuku-recipes/**'
+      - 'cmd/shirabe/**'
+      - '.goreleaser.yaml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install tsuku
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/tsukumogami/tsuku/main/install.sh | bash
+          echo "$HOME/.tsuku/bin" >> "$GITHUB_PATH"
+
+      - name: Strict-validate recipe TOML
+        run: tsuku validate --strict .tsuku-recipes/shirabe.toml
+
+      - name: Build shirabe with injected version
+        run: |
+          go build -ldflags "-X main.version=0.0.0-ci-test" -o /tmp/shirabe ./cmd/shirabe
+          /tmp/shirabe --version
+
+      - name: Verify --version output matches recipe pattern
+        # The recipe declares `command = "shirabe --version"` and
+        # `pattern = "{version}"`. tsuku's verifier extracts a version-shaped
+        # token from anywhere in the line, so any output containing the version
+        # is accepted. This step asserts that contract holds for our binary.
+        run: |
+          OUTPUT=$(/tmp/shirabe --version)
+          echo "Binary output: $OUTPUT"
+          echo "$OUTPUT" | grep -qE '0\.0\.0-ci-test' || {
+            echo "::error::shirabe --version did not contain the injected version"
+            exit 1
+          }
+
+  install-latest:
+    # Full end-to-end install check against the latest released version.
+    # Best-effort while the version-flag change is not yet in a release;
+    # tightens to a required check once a release ships with --version
+    # support and the recipe in the released ref matches today's expectations.
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install tsuku
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/tsukumogami/tsuku/main/install.sh | bash
+          echo "$HOME/.tsuku/bin" >> "$GITHUB_PATH"
+
+      - name: Install shirabe via tsuku (latest)
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: tsuku install tsukumogami/shirabe
+
+      - name: Confirm shirabe runs
+        run: shirabe --version

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,6 +18,7 @@ builds:
       - -buildvcs=false
     ldflags:
       - -s -w
+      - -X main.version={{.Version}}
     mod_timestamp: "{{ .CommitTimestamp }}"
     no_unique_dist_dir: true
 

--- a/.tsuku-recipes/shirabe.toml
+++ b/.tsuku-recipes/shirabe.toml
@@ -1,0 +1,26 @@
+[metadata]
+name = "shirabe"
+description = "Doc format validator for AI-assisted workflows"
+homepage = "https://github.com/tsukumogami/shirabe"
+version_format = "semver"
+
+[version]
+github_repo = "tsukumogami/shirabe"
+tag_prefix = "v"
+
+[[steps]]
+action = "download"
+url = "https://github.com/tsukumogami/shirabe/releases/download/v{version}/shirabe-{os}-{arch}"
+checksum_url = "https://github.com/tsukumogami/shirabe/releases/download/v{version}/checksums.txt"
+
+[[steps]]
+action = "chmod"
+files = ["shirabe-{os}-{arch}"]
+
+[[steps]]
+action = "install_binaries"
+outputs = [{src = "shirabe-{os}-{arch}", dest = "bin/shirabe"}]
+
+[verify]
+command = "shirabe --help"
+pattern = ""

--- a/.tsuku-recipes/shirabe.toml
+++ b/.tsuku-recipes/shirabe.toml
@@ -22,5 +22,5 @@ action = "install_binaries"
 outputs = [{src = "shirabe-{os}-{arch}", dest = "bin/shirabe"}]
 
 [verify]
-command = "shirabe --help"
-pattern = ""
+command = "shirabe --version"
+pattern = "{version}"

--- a/cmd/shirabe/main.go
+++ b/cmd/shirabe/main.go
@@ -11,6 +11,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// version is set at build time via -ldflags "-X main.version=<value>".
+// Defaults to "dev" for unversioned local builds.
+var version = "dev"
+
 func main() {
 	if err := rootCmd().Execute(); err != nil {
 		os.Exit(1)
@@ -19,9 +23,11 @@ func main() {
 
 func rootCmd() *cobra.Command {
 	root := &cobra.Command{
-		Use:   "shirabe",
-		Short: "Workflow skills for AI coding agents",
+		Use:     "shirabe",
+		Short:   "Workflow skills for AI coding agents",
+		Version: version,
 	}
+	root.SetVersionTemplate("shirabe {{.Version}}\n")
 	root.AddCommand(validateCmd())
 	return root
 }


### PR DESCRIPTION
Add a `--version` flag to the shirabe CLI via cobra's `Version` field, with the version variable injected at release time by GoReleaser's `ldflags`. Add `.tsuku-recipes/shirabe.toml`, a tsuku distributed recipe modeled on the niwa pattern that pins binary downloads at the release ref and verifies via `shirabe --version` with a `{version}` pattern. Add `.github/workflows/validate-tsuku-recipe.yml` that strict-validates the recipe TOML, builds the binary with an injected version, and asserts the verify contract holds on every PR touching the recipe, the CLI source, or the GoReleaser config; a best-effort follow-on job exercises a full install via `tsuku install tsukumogami/shirabe` against the live latest release.

---

## What this enables

`tsuku install tsukumogami/shirabe` becomes a working install path once the recipe lands on main and a release with the `--version` flag ships. The existing `install.sh` curl-based installer is unaffected — the tsuku recipe is a parallel path. The CI workflow catches recipe drift on every PR that could break the install: TOML changes, CLI changes, or GoReleaser config changes.

## Implementation notes

- `cmd/shirabe/main.go`: `var version = "dev"` default. Cobra root sets `Version: version` and `SetVersionTemplate("shirabe {{.Version}}\n")` so output is `shirabe <version>` — the line the recipe's `pattern = "{version}"` matches against.
- `.goreleaser.yaml`: adds `-X main.version={{.Version}}` to ldflags so released binaries report their tag.
- `.tsuku-recipes/shirabe.toml`: mirrors `public/niwa/.tsuku-recipes/niwa.toml` — explicit `download` → `chmod` → `install_binaries` chain with `checksum_url` verification. Version-mode verify is the canonical pattern from the tsuku recipe-author skill; replaces the earlier non-idiomatic empty pattern.
- `.github/workflows/validate-tsuku-recipe.yml`: two jobs.
  - `validate` (required) — strict-validates the recipe and asserts `shirabe --version` output contains the injected version. Builds the binary with `-X main.version=0.0.0-ci-test` and greps for that token, so the verify contract holds for our binary irrespective of which version ships.
  - `install-latest` (best-effort, `continue-on-error: true`) — runs `tsuku install tsukumogami/shirabe` against the live latest release. Returns exit 3 (recipe not found on main) until this PR merges, then exit 7 (verify fails on v0.6.0's no-version-flag binary) until a release with `--version` support ships, then succeeds.

## Tightening the install-latest check

Once a release with `--version` is live, flip `continue-on-error: false` so the job becomes a hard gate against future recipe drift.

## Test plan

- `tsuku validate --strict .tsuku-recipes/shirabe.toml` passes locally.
- `go build -ldflags "-X main.version=0.6.0" ./cmd/shirabe && ./shirabe --version` → `shirabe 0.6.0`.
- `go build ./cmd/shirabe && ./shirabe --version` → `shirabe dev` (default fallback for local builds).
- `go test ./...` passes.
- CI on this PR: `validate-tsuku-recipe / validate` green; `validate-tsuku-recipe / install-latest` red (expected, see above); `validate-shirabe-docs` green.
