### PR TITLE
docs: add roadmap-plan-standardization planning chain (brief, PRD, design, plan)

### DIFF
--- a/docs/briefs/BRIEF-roadmap-plan-standardization.md
+++ b/docs/briefs/BRIEF-roadmap-plan-standardization.md
@@ -1,6 +1,6 @@
 ---
 schema: brief/v1
-status: Draft
+status: Accepted
 problem: |
   The roadmap and plan workflows are procedure-rich but principle-poor.
   The issues table has four drifting schemas, the dependency diagram has
@@ -23,7 +23,7 @@ outcome: |
 
 ## Status
 
-Draft
+Accepted
 
 This brief stops before requirements articulation. The follow-on PRD
 (`PRD-roadmap-plan-standardization.md`) owns the requirements, and the

--- a/docs/briefs/BRIEF-roadmap-plan-standardization.md
+++ b/docs/briefs/BRIEF-roadmap-plan-standardization.md
@@ -79,8 +79,8 @@ Six gaps make the drift concrete.
   When the input is a roadmap the plan workflow goes multi-pr, which is the
   right outcome — every roadmap feature should be an increment of
   observable value — but it reaches that outcome by mechanism (the input
-  is a roadmap) rather than by the walking-skeleton value principle, and
-  nothing confirms the breakdown actually delivers incremental value. The
+  is a roadmap) rather than by the value principle, and nothing confirms
+  that each feature actually delivers observable incremental value. The
   same blind spot lets a roadmap sequence features by technical building
   block instead of by the value each delivers. The tangle and the missing
   value-orientation are the likely causes of authors landing the wrong
@@ -129,12 +129,11 @@ when the work is a walking skeleton whose PRs are each independently
 useful. The rule is stated as that default with its named escape
 conditions, separated from the unrelated slicing decision it used to be
 tangled with. A roadmap is always multi-pr — every roadmap feature is an
-increment of observable value, so a roadmap is a walking skeleton by
-construction — and that outcome is now grounded in the value principle
-rather than reached by mechanism. Where the breakdown is a walking
-skeleton (always for a roadmap, and for a plan whenever its multi-pr
-rationale is incremental value rather than a hard landing constraint), a
-step confirms the breakdown actually delivers incremental value. The
+increment of observable value, a cohesive deliverable in its own right —
+and that outcome is now grounded in the value principle rather than
+reached by mechanism. A step confirms each unit delivers observable
+incremental value: every feature for a roadmap, and each PR for a plan
+split for incremental value rather than a hard landing constraint. The
 author lands the right call because the reasoning is visible at the point
 of decision, not buried in a reference they would have to know to load.
 
@@ -276,11 +275,12 @@ The scope holds the following inside:
   into both the plan and roadmap workflows: lifting the single-pr/multi-pr
   decision to the skill surface, anchoring it on usable value, and
   decoupling it from the work-slicing decision. A roadmap stays
-  multi-pr — every roadmap is a walking skeleton — but that outcome is
-  re-grounded in the value principle rather than reached by mechanism, and
-  a step (always for a roadmap, and for a plan when its multi-pr rationale
-  is incremental value rather than a hard landing constraint) confirms the
-  breakdown delivers incremental value. Plus giving the roadmap a
+  multi-pr — every roadmap feature delivers observable incremental value
+  as a cohesive deliverable — but that outcome is re-grounded in the value
+  principle rather than reached by mechanism, and a step (always for a
+  roadmap, and for a plan when its multi-pr rationale is incremental value
+  rather than a hard landing constraint) confirms each feature or PR
+  delivers observable incremental value. Plus giving the roadmap a
   first-class path to its issues table in place of the brittle string
   surgery in the plan re-entry.
 - **An enforced document lifecycle.** A shared lifecycle for plan and

--- a/docs/briefs/BRIEF-roadmap-plan-standardization.md
+++ b/docs/briefs/BRIEF-roadmap-plan-standardization.md
@@ -1,0 +1,298 @@
+---
+schema: brief/v1
+status: Draft
+problem: |
+  The roadmap and plan workflows are procedure-rich but principle-poor.
+  The issues table has four drifting schemas, the dependency diagram has
+  a canonical spec docs apply inconsistently, the roadmap has no native
+  path to its own issues table, the single-pr/multi-pr decision is buried
+  and not anchored on usable value (the plan workflow even forces multiple
+  PRs on roadmap input), and validation checks section presence but never
+  table or diagram contents.
+outcome: |
+  Skill authors get standardized, principle-driven roadmap and plan
+  workflows: the issues table and dependency diagram are defined once and
+  reused, the single-pr/multi-pr decision is surfaced and anchored on
+  usable value, the roadmap has a first-class path to its issues table, and
+  validation checks structure and content. An author reaches for one
+  canonical format instead of reinventing one.
+---
+
+# BRIEF: roadmap-plan-standardization
+
+## Status
+
+Draft
+
+This brief stops before requirements articulation. The follow-on PRD
+(`PRD-roadmap-plan-standardization.md`) owns the requirements, and the
+design after it owns the implementation specifics — the exact shared
+reference layout, the validation check codes, the script interfaces, and
+the principle wording.
+
+The framing emerged from exploration rather than an upstream roadmap, so
+this brief has no `upstream:` field. The exploration findings the brief
+draws on are the grounding, not a parent artifact.
+
+## Problem Statement
+
+shirabe's tactical chain runs `/roadmap` to `/brief` to `/prd` to
+`/design` to `/plan`. The roadmap and plan workflows sit at opposite ends
+of that chain and already share more than they look like they do: the
+same lifecycle vocabulary, a reserved-section handoff where the roadmap
+stubs an issues table and a dependency graph that the plan fills, and the
+same spec-driven validator. The trouble isn't that the two workflows are
+unrelated. It's that the shared parts were never named as shared, and the
+conventions that should hold them together have drifted.
+
+Five gaps make the drift concrete.
+
+- **The issues table has four schemas in active use.** The plan workflow
+  keys its table on issues; the roadmap keys its reserved table on
+  features; a later phase introduced a third column set; a committed doc
+  uses a fourth. One section name hides at least two altitudes. An author
+  writing either doc has no single format to copy, so each new table
+  perpetuates whichever variant the author happened to see first.
+
+- **The dependency diagram has a canonical spec docs ignore.** A solid
+  diagram spec already exists in one reference, but committed docs use
+  partial style sets, ad-hoc colors, inline-break labels, and three
+  differently worded legends. The spec is correct and unenforced, so it
+  documents an ideal nobody is held to.
+
+- **The roadmap has no native path to its issues table.** The roadmap
+  writes empty placeholders for its issues table and expects them filled
+  later. The only way to fill them is to re-enter the plan workflow in a
+  special mode that rewrites the placeholders through brittle in-prose
+  string surgery — not a script, the way the plan workflow populates its
+  own table. A roadmap author who wants a populated table has to drive a
+  second workflow against their own document and hope the string match
+  holds.
+
+- **The single-pr/multi-pr decision is buried, conflated, and not
+  anchored on usable value.** A rule is stated — default to a single PR,
+  escape to multiple only on a hard constraint — but it lives in a lazily
+  loaded reference, never appears on the skill surface, and sits tangled
+  with a separate decision about how to slice the work. It also misses the
+  thing that should drive the call: whether each PR lands usable value.
+  The plan workflow forces multiple PRs whenever its input is a roadmap,
+  splitting by mechanism rather than by value. And the same blind spot
+  reaches the roadmap, which can sequence features by technical building
+  block and ignore the value each feature delivers. The tangle and the
+  missing value-orientation are the likely causes of authors landing the
+  wrong call.
+
+- **Validation checks presence, never contents.** The validator confirms
+  that required sections exist, that frontmatter fields are present, and
+  that status agrees between frontmatter and body. It never looks inside
+  the issues table or the dependency graph it requires. A doc with a
+  malformed table, a table and diagram that disagree, or a dangling
+  cross-reference passes validation as long as the headings are there.
+
+Underneath all five is the same root: the workflows are specified as
+procedures with local rationale or none, and the few real principles that
+do exist are each trapped in one skill and never generalized. An author
+follows the steps without the reasons, so when a step doesn't fit their
+case they have nothing to reason from. The gap isn't missing
+machinery — most of the structure already exists. The gap is that the
+shared parts aren't named as shared, the formats aren't defined once, and
+the principles that would let an author make the right call aren't
+surfaced where the call gets made.
+
+## User Outcome
+
+A skill author writing a roadmap or a plan works from one set of shared
+conventions instead of reconstructing them per document. There is one
+canonical issues-table format and one canonical dependency-diagram
+format, each defined in a single place and consumed by both workflows, so
+the author copies a known-good shape rather than picking among four. The
+altitude distinction that matters — a roadmap keys its table on features,
+a plan keys its table on issues — survives, because the shared format
+carries two profiles rather than collapsing into one.
+
+When the author reaches the single-pr/multi-pr decision, the principle is
+in front of them on the skill surface: every PR should land usable value,
+so default to one PR and split only when a hard constraint forces it or
+when each PR is independently useful. The rule is stated as that default
+with its named escape conditions, separated from the unrelated slicing
+decision it used to be tangled with, and the plan workflow no longer
+forces multiple PRs just because the input is a roadmap. The same
+value-orientation reaches the roadmap author, who sequences features by
+the value each delivers rather than by technical building block. The
+author lands the right call because the reasoning is visible at the point
+of decision, not buried in a reference they would have to know to load.
+
+A roadmap author who wants their issues table populated gets there
+through a first-class path built for the roadmap, not by re-driving the
+plan workflow against their own document and hoping a string match holds.
+And when any doc's table or diagram drifts from the canonical
+format — a malformed row, a table and diagram that disagree, a
+cross-reference to an issue that isn't in the table — validation catches
+it, in local checks and in the same review surface where the rest of the
+format spec is already enforced.
+
+Behind each of these is the same shift: the workflows derive from a small
+set of stated principles instead of restating procedure. An author who
+hits a case the steps don't cover has the reasons to fall back on, so the
+workflows stay usable at their edges instead of only down their happy
+path.
+
+## User Journeys
+
+Four journeys exercise the standardization from different entry points.
+Each names the user, the trigger, and the outcome shape.
+
+### Journey 1: Roadmap author populating the issues table
+
+A roadmap author has sequenced their features and wants the roadmap's
+issues table filled in. Today the only path is to re-enter the plan
+workflow in a special mode that rewrites the roadmap's placeholders
+through in-prose string surgery. With the standardization, the author
+reaches a first-class path built for the roadmap: the table populates
+through the roadmap's own scripted path, keyed on features at the
+roadmap's altitude, without driving a second workflow against the
+document or depending on a fragile string match. The outcome is a
+populated, correctly-keyed issues table the author got to directly.
+
+This journey validates that the roadmap-to-issues path is native to the
+roadmap, not borrowed from the plan workflow.
+
+### Journey 2: Plan author landing the single-pr/multi-pr call
+
+A plan author is decomposing a design and has to decide whether the work
+ships as one PR or several. The principle — every PR lands usable value,
+so default to one and split only when a hard constraint forces it (a
+cross-repo landing order, a workflow that must reach main before it can be
+invoked) or when each PR is independently useful — is on the skill surface
+in front of them, separated from the unrelated decision about how to slice
+the work. The author's input is a design rather than a roadmap, so nothing
+forces a multi-PR split by mechanism; they check their case against the
+value test and the escape conditions and land the right call. The outcome
+is a decomposition with the correct PR shape, chosen because each PR's
+value was the thing weighed, not the input's type.
+
+This journey validates that anchoring the decision on usable value,
+surfacing it, and de-conflating it from work-slicing fixes the misfires
+the buried, mechanism-driven version produced.
+
+### Journey 3: Author hitting a validation failure on table drift
+
+An author commits a roadmap or plan whose issues table has drifted from
+the canonical format — a column out of the schema, a row the dependency
+diagram doesn't account for, a cross-reference to an issue that isn't in
+the table. Instead of passing because the section headings are present,
+validation fails with a message naming the specific table or diagram
+defect, both in the author's local check and in CI on the pull request.
+The outcome is a caught drift the author fixes before merge, on the same
+review surface where the rest of the format spec is already enforced.
+
+This journey validates that validation moved from section-presence to
+table and diagram content, and that the new checks run where existing
+ones do.
+
+### Journey 4: Author reaching for the one canonical format
+
+An author starting a new roadmap or plan needs an issues table and a
+dependency diagram. Rather than searching prior docs and copying whichever
+variant they find — and propagating one of four schemas or one of three
+legends — they reach for the single shared reference that defines the
+table format and the diagram convention once. They consume the canonical
+shape, parameterized to their document's altitude, and produce a table and
+diagram that match every other doc built from the same reference. The
+outcome is a new document that conforms by construction, not by the
+author's luck in which example they copied.
+
+This journey validates that defining the formats once, in a shared place
+both workflows consume, ends the per-document reinvention.
+
+## Scope Boundary
+
+This brief, and the downstream PRD it points at, cover standardizing the
+roadmap and plan workflows around shared, principle-driven conventions.
+The scope holds the following inside:
+
+- **A reusable principle set** the roadmap and plan workflows (and their
+  siblings) derive from rather than restate — a small, named set covering
+  the lowest-ceremony default, decisions needing a durable home, one
+  canonical format per concern, strictness tracking blast radius, formats
+  defined once, and usable value as the unit of work (every PR and every
+  roadmap feature delivers usable value; split only for a hard constraint
+  or genuine incremental value, never by mechanism).
+- **A shared issues-table framework with two altitude profiles.** One
+  canonical table framework — shared columns, shared validation, shared
+  rendering — parameterized into a roadmap profile (feature-keyed) and a
+  plan profile (issue-keyed), replacing the four drifting schemas while
+  preserving the altitude distinction.
+- **A shared dependency-diagram convention with enforcement.** The
+  existing canonical diagram spec promoted into a shared reference both
+  workflows consume, with its style palette and legend enforced in CI so
+  the spec stops being an unheld ideal.
+- **Validation content checks.** Extending validation from
+  section-presence to table and diagram contents: schema conformance for
+  the issues table, reconciliation between the table and the dependency
+  diagram, and cross-reference existence.
+- **The decision-surfacing fixes.** Encoding the usable-value principle
+  into both the plan and roadmap workflows: lifting the single-pr/multi-pr
+  decision to the skill surface, anchoring it on usable value, decoupling
+  it from the work-slicing decision, and removing the plan workflow's
+  forced-multi-pr behavior on roadmap input so the split follows value
+  rather than mechanism. Plus giving the roadmap a first-class path to its
+  issues table in place of the brittle string surgery in the plan re-entry.
+
+The scope explicitly excludes:
+
+- **The implementation specifics.** This brief frames the standardization
+  and its boundary. How the shared references are laid out, what the
+  validation check codes are, how the roadmap-to-issues path is scripted,
+  and the exact wording of the principles are the downstream design's job,
+  not this brief's.
+- **The issue-tracker mechanics.** Validation here checks a document's
+  own table and diagram contents. Network-dependent checks against live
+  issue-tracker state are a separate, optional concern the standardization
+  does not require — they can follow as a second workflow if they're
+  warranted at all.
+- **Changing other artifact types beyond aligning them.** The roadmap and
+  plan workflows are the drivers. Other doc types may consume the shared
+  table and diagram conventions, but reshaping their own formats, naming,
+  or lifecycles is out — the only change to a sibling type is adopting the
+  shared conventions where it already has a table or a diagram.
+
+## Open Questions
+
+These surface for the downstream PRD to resolve. None block this brief.
+
+1. **Which principles make the named set.** The brief names six candidate
+   principles. Whether all six earn a place in the surfaced set, or whether
+   some collapse together or stay implicit, is a framing call the PRD
+   settles against the goal of a set small enough to be load-bearing rather
+   than decorative.
+
+2. **How strict the first validation pass is.** Content validation can
+   land strict (schema conformance, full table-diagram reconciliation,
+   cross-reference existence all at once) or adopt incrementally the way
+   the existing schema-gate did. The PRD picks the initial strictness
+   against the cost of retrofitting already-committed docs.
+
+3. **How much altitude the two table profiles share.** The framework
+   reuses columns, validation, and rendering across the roadmap and plan
+   profiles, but the exact split between shared and profile-specific
+   structure is undecided. The PRD names the shared core and the
+   per-profile additions.
+
+## Downstream Artifacts
+
+- **`PRD-roadmap-plan-standardization.md`** — requirements articulation
+  for the standardization: the principle set, the shared issues-table
+  framework and its two profiles, the diagram convention and its
+  enforcement, the validation content checks, and the decision-surfacing
+  fixes. Lives in `docs/prds/`. (planned)
+- **`DESIGN-roadmap-plan-standardization.md`** — implementation shape,
+  picked up after the PRD lands: the shared-reference layout, the
+  validation check codes, the roadmap-to-issues script interface, and the
+  principle wording. Lives in `docs/designs/current/`. (planned)
+
+## References
+
+- Brief structural precedents: `docs/briefs/BRIEF-shirabe-strategy-skill.md`,
+  `docs/briefs/BRIEF-shirabe-brief-skill.md`.
+- Brief format reference: `skills/brief/references/brief-format.md`.

--- a/docs/briefs/BRIEF-roadmap-plan-standardization.md
+++ b/docs/briefs/BRIEF-roadmap-plan-standardization.md
@@ -6,9 +6,10 @@ problem: |
   The issues table has four drifting schemas, the dependency diagram has
   a canonical spec docs apply inconsistently, the roadmap has no native
   path to its own issues table, the single-pr/multi-pr decision is buried
-  and not anchored on usable value (the plan workflow even forces multiple
-  PRs on roadmap input), and validation checks section presence but never
-  table or diagram contents.
+  and not anchored on usable value, the document lifecycle is inconsistent
+  and unenforced (no review gate before issues are created, no clean
+  terminal), and validation checks section presence but never table or
+  diagram contents.
 outcome: |
   Skill authors get standardized, principle-driven roadmap and plan
   workflows: the issues table and dependency diagram are defined once and
@@ -45,7 +46,7 @@ same spec-driven validator. The trouble isn't that the two workflows are
 unrelated. It's that the shared parts were never named as shared, and the
 conventions that should hold them together have drifted.
 
-Five gaps make the drift concrete.
+Six gaps make the drift concrete.
 
 - **The issues table has four schemas in active use.** The plan workflow
   keys its table on issues; the roadmap keys its reserved table on
@@ -75,12 +76,15 @@ Five gaps make the drift concrete.
   loaded reference, never appears on the skill surface, and sits tangled
   with a separate decision about how to slice the work. It also misses the
   thing that should drive the call: whether each PR lands usable value.
-  The plan workflow forces multiple PRs whenever its input is a roadmap,
-  splitting by mechanism rather than by value. And the same blind spot
-  reaches the roadmap, which can sequence features by technical building
-  block and ignore the value each feature delivers. The tangle and the
-  missing value-orientation are the likely causes of authors landing the
-  wrong call.
+  When the input is a roadmap the plan workflow goes multi-pr, which is the
+  right outcome — every roadmap feature should be an increment of
+  observable value — but it reaches that outcome by mechanism (the input
+  is a roadmap) rather than by the walking-skeleton value principle, and
+  nothing confirms the breakdown actually delivers incremental value. The
+  same blind spot lets a roadmap sequence features by technical building
+  block instead of by the value each delivers. The tangle and the missing
+  value-orientation are the likely causes of authors landing the wrong
+  call.
 
 - **Validation checks presence, never contents.** The validator confirms
   that required sections exist, that frontmatter fields are present, and
@@ -89,7 +93,15 @@ Five gaps make the drift concrete.
   malformed table, a table and diagram that disagree, or a dangling
   cross-reference passes validation as long as the headings are there.
 
-Underneath all five is the same root: the workflows are specified as
+- **The lifecycle is inconsistent and unenforced.** The states exist
+  (Draft, Active, Done) but the transitions carry no discipline: a multi-pr
+  plan or roadmap can create GitHub issues with no review gate, there is no
+  clean signal that a completed doc has been verified and can be retired,
+  and nothing in CI holds a doc to the state its mode requires. A plan that
+  should have been ephemeral lingers; a roadmap merges before it is ready;
+  issues get created before anyone approved them.
+
+Underneath all six is the same root: the workflows are specified as
 procedures with local rationale or none, and the few real principles that
 do exist are each trapped in one skill and never generalized. An author
 follows the steps without the reasons, so when a step doesn't fit their
@@ -113,12 +125,16 @@ carries two profiles rather than collapsing into one.
 When the author reaches the single-pr/multi-pr decision, the principle is
 in front of them on the skill surface: every PR should land usable value,
 so default to one PR and split only when a hard constraint forces it or
-when each PR is independently useful. The rule is stated as that default
-with its named escape conditions, separated from the unrelated slicing
-decision it used to be tangled with, and the plan workflow no longer
-forces multiple PRs just because the input is a roadmap. The same
-value-orientation reaches the roadmap author, who sequences features by
-the value each delivers rather than by technical building block. The
+when the work is a walking skeleton whose PRs are each independently
+useful. The rule is stated as that default with its named escape
+conditions, separated from the unrelated slicing decision it used to be
+tangled with. A roadmap is always multi-pr — every roadmap feature is an
+increment of observable value, so a roadmap is a walking skeleton by
+construction — and that outcome is now grounded in the value principle
+rather than reached by mechanism. Where the breakdown is a walking
+skeleton (always for a roadmap, and for a plan whenever its multi-pr
+rationale is incremental value rather than a hard landing constraint), a
+step confirms the breakdown actually delivers incremental value. The
 author lands the right call because the reasoning is visible at the point
 of decision, not buried in a reference they would have to know to load.
 
@@ -131,6 +147,15 @@ cross-reference to an issue that isn't in the table — validation catches
 it, in local checks and in the same review surface where the rest of the
 format spec is already enforced.
 
+The document lifecycle carries discipline too. A multi-pr plan or roadmap
+finishes its draft and stops for the author's approval before any GitHub
+issue is created — creating the issues is the act of approving, the move
+to Active, not a silent side effect. A completed doc rests at Done until
+the author has reviewed the delivered work; verifying it retires the doc
+rather than leaving it to linger. CI holds each doc to the state its mode
+requires, so a doc can't merge in the wrong state and a finished one
+doesn't outlive its purpose.
+
 Behind each of these is the same shift: the workflows derive from a small
 set of stated principles instead of restating procedure. An author who
 hits a case the steps don't cover has the reasons to fall back on, so the
@@ -139,7 +164,7 @@ path.
 
 ## User Journeys
 
-Four journeys exercise the standardization from different entry points.
+Five journeys exercise the standardization from different entry points.
 Each names the user, the trigger, and the outcome shape.
 
 ### Journey 1: Roadmap author populating the issues table
@@ -205,6 +230,22 @@ author's luck in which example they copied.
 This journey validates that defining the formats once, in a shared place
 both workflows consume, ends the per-document reinvention.
 
+### Journey 5: Author moving a doc through its lifecycle
+
+A plan author finishes decomposing a multi-pr plan. Instead of the
+workflow filing GitHub issues immediately, the draft stops for the
+author's review; the author approves, and that approval — the move to
+Active — is what creates the issues. The author would not have wanted
+issues filed before they signed off, and now they aren't. Later, when the
+work the plan tracked is complete, the doc rests at Done until the author
+reviews the delivered result; the author verifies it, and the doc is
+retired rather than left behind. A single-pr plan never reaches that point
+on the main branch at all — it lives only on its own PR and is gone before
+that PR merges.
+
+This journey validates that the lifecycle gates issue creation on approval
+and gives a completed doc a clean, enforced end.
+
 ## Scope Boundary
 
 This brief, and the downstream PRD it points at, cover standardizing the
@@ -233,11 +274,24 @@ The scope holds the following inside:
   diagram, and cross-reference existence.
 - **The decision-surfacing fixes.** Encoding the usable-value principle
   into both the plan and roadmap workflows: lifting the single-pr/multi-pr
-  decision to the skill surface, anchoring it on usable value, decoupling
-  it from the work-slicing decision, and removing the plan workflow's
-  forced-multi-pr behavior on roadmap input so the split follows value
-  rather than mechanism. Plus giving the roadmap a first-class path to its
-  issues table in place of the brittle string surgery in the plan re-entry.
+  decision to the skill surface, anchoring it on usable value, and
+  decoupling it from the work-slicing decision. A roadmap stays
+  multi-pr — every roadmap is a walking skeleton — but that outcome is
+  re-grounded in the value principle rather than reached by mechanism, and
+  a step (always for a roadmap, and for a plan when its multi-pr rationale
+  is incremental value rather than a hard landing constraint) confirms the
+  breakdown delivers incremental value. Plus giving the roadmap a
+  first-class path to its issues table in place of the brittle string
+  surgery in the plan re-entry.
+- **An enforced document lifecycle.** A shared lifecycle for plan and
+  roadmap docs: a multi-pr doc finishes its draft and stops for approval
+  before issues are created, with approval being the move to Active; a
+  completed doc rests at Done until the author verifies the delivered work,
+  and verification retires the doc; and CI enforces the states — a multi-pr
+  doc may only merge in Active, a completed one is expected to be deleted,
+  and a single-pr plan is ephemeral, living only on its PR branch and
+  removed before that PR merges. The exact transitions, the virtual
+  VERIFIED state, and the CI checks are the downstream design's.
 
 The scope explicitly excludes:
 
@@ -278,6 +332,13 @@ These surface for the downstream PRD to resolve. None block this brief.
    profiles, but the exact split between shared and profile-specific
    structure is undecided. The PRD names the shared core and the
    per-profile additions.
+
+4. **How the lifecycle is enforced without overreach.** The lifecycle
+   adds a review gate before issue creation, a verified-then-deleted
+   terminal, and CI checks on document state. How strict the CI
+   enforcement is at first, and how the virtual VERIFIED transition is
+   realized (a transition that deletes versus a separate cleanup step),
+   are calls the PRD and design settle.
 
 ## Downstream Artifacts
 

--- a/docs/briefs/BRIEF-roadmap-plan-standardization.md
+++ b/docs/briefs/BRIEF-roadmap-plan-standardization.md
@@ -48,17 +48,19 @@ conventions that should hold them together have drifted.
 
 Six gaps make the drift concrete.
 
-- **The issues table has four schemas in active use.** The plan workflow
-  keys its table on issues; the roadmap keys its reserved table on
-  features; a later phase introduced a third column set; a committed doc
-  uses a fourth. One section name hides at least two altitudes. An author
-  writing either doc has no single format to copy, so each new table
-  perpetuates whichever variant the author happened to see first.
+- **The issues table has several incompatible schemas in active use.** The
+  plan workflow keys its table on issues (and still accepts a legacy column
+  set); the roadmap keys its reserved table on features; and a committed
+  roadmap diverges from even that. One section name spans two altitudes —
+  feature-level and issue-level — and an author writing either doc has no
+  single format to copy, so each new table perpetuates whichever variant the
+  author happened to see first. (Progress-tracking tables some docs also
+  carry are a separate concern, not part of this issues-table work.)
 
 - **The dependency diagram has a canonical spec docs ignore.** A solid
   diagram spec already exists in one reference, but committed docs use
-  partial style sets, ad-hoc colors, inline-break labels, and three
-  differently worded legends. The spec is correct and unenforced, so it
+  partial style sets, ad-hoc colors, inline-break labels, and differently
+  worded legends. The spec is correct and unenforced, so it
   documents an ideal nobody is held to.
 
 - **The roadmap has no native path to its issues table.** The roadmap
@@ -93,13 +95,19 @@ Six gaps make the drift concrete.
   malformed table, a table and diagram that disagree, or a dangling
   cross-reference passes validation as long as the headings are there.
 
-- **The lifecycle is inconsistent and unenforced.** The states exist
-  (Draft, Active, Done) but the transitions carry no discipline: a multi-pr
-  plan or roadmap can create GitHub issues with no review gate, there is no
-  clean signal that a completed doc has been verified and can be retired,
-  and nothing in CI holds a doc to the state its mode requires. A plan that
-  should have been ephemeral lingers; a roadmap merges before it is ready;
-  issues get created before anyone approved them.
+- **The lifecycle is inconsistent, contradictory, and unenforced.** The
+  states exist (Draft, Active, Done), but the terminal is three-way
+  contradictory today: the live `/work-on` cascade deletes a completed plan
+  (`git rm`), the plan reference doc still says move it to a `done/` archive,
+  and a completed roadmap is kept forever as a permanent record. Plans and
+  roadmaps terminate in opposite ways, and the plan's own terminal disagrees
+  with itself. The transitions carry little discipline beyond a client-side
+  transition script: a multi-pr plan or roadmap creates GitHub issues with no
+  review gate (the cascade can even auto-complete a roadmap with no human
+  sign-off), and nothing in CI holds a doc to the state its mode requires — a
+  single-pr plan that should be ephemeral can reach main, a multi-pr doc can
+  merge before it is ready, and issues get created before anyone approved
+  them.
 
 Underneath all six is the same root: the workflows are specified as
 procedures with local rationale or none, and the few real principles that
@@ -117,7 +125,7 @@ A skill author writing a roadmap or a plan works from one set of shared
 conventions instead of reconstructing them per document. There is one
 canonical issues-table format and one canonical dependency-diagram
 format, each defined in a single place and consumed by both workflows, so
-the author copies a known-good shape rather than picking among four. The
+the author copies a known-good shape rather than picking among several. The
 altitude distinction that matters — a roadmap keys its table on features,
 a plan keys its table on issues — survives, because the shared format
 carries two profiles rather than collapsing into one.
@@ -125,17 +133,21 @@ carries two profiles rather than collapsing into one.
 When the author reaches the single-pr/multi-pr decision, the principle is
 in front of them on the skill surface: every PR should land usable value,
 so default to one PR and split only when a hard constraint forces it or
-when the work is a walking skeleton whose PRs are each independently
-useful. The rule is stated as that default with its named escape
-conditions, separated from the unrelated slicing decision it used to be
-tangled with. A roadmap is always multi-pr — every roadmap feature is an
-increment of observable value, a cohesive deliverable in its own right —
-and that outcome is now grounded in the value principle rather than
-reached by mechanism. A step confirms each unit delivers observable
-incremental value: every feature for a roadmap, and each PR for a plan
-split for incremental value rather than a hard landing constraint. The
-author lands the right call because the reasoning is visible at the point
-of decision, not buried in a reference they would have to know to load.
+when the work delivers value incrementally, each PR independently useful (a
+walking skeleton is one such split). The rule is stated as that default
+with its named escape conditions, separated from the unrelated slicing
+decision it used to be tangled with. A roadmap is multi-pr because each of
+its features should be an increment of observable value — a cohesive
+deliverable in its own right — so the outcome is grounded in the value
+principle, not reached by mechanism. A confirmation step tests that: it
+checks each unit delivers observable incremental value — every feature for
+a roadmap, and each PR for a plan whose split delivers incremental value
+(whether or not a hard constraint also forces the split). It is a guard
+that can fail: a roadmap feature that isn't a standalone increment signals
+the roadmap is mis-decomposed and should be re-scoped or merged with a
+neighbor, not waved through. The author lands the right call because the
+reasoning is visible at the point of decision, not buried in a reference
+they would have to know to load.
 
 A roadmap author who wants their issues table populated gets there
 through a first-class path built for the roadmap, not by re-driving the
@@ -146,14 +158,23 @@ cross-reference to an issue that isn't in the table — validation catches
 it, in local checks and in the same review surface where the rest of the
 format spec is already enforced.
 
-The document lifecycle carries discipline too. A multi-pr plan or roadmap
-finishes its draft and stops for the author's approval before any GitHub
-issue is created — creating the issues is the act of approving, the move
-to Active, not a silent side effect. A completed doc rests at Done until
-the author has reviewed the delivered work; verifying it retires the doc
-rather than leaving it to linger. CI holds each doc to the state its mode
-requires, so a doc can't merge in the wrong state and a finished one
-doesn't outlive its purpose.
+The document lifecycle carries discipline and one consistent terminal. A
+multi-pr plan or roadmap finishes its draft and stops for the author's
+approval before any GitHub issue is created — creating the issues is the
+act of approving, the move to Active, not a silent side effect. The doc
+rests at Active while the work lands, reaches Done when the work is
+complete, and is retired by deletion once the author verifies the delivered
+work — the same verify-then-delete end for both plans and roadmaps. That
+replaces today's split, where a completed plan is already deleted by the
+cascade but a completed roadmap is kept forever; unifying on deletion is a
+deliberate change for roadmaps. A single-pr plan is different: it is
+ephemeral, lives only on its own PR branch, and is verified and deleted
+before that PR merges, so it never reaches main. CI holds docs to the
+states it can see: a multi-pr doc may only merge in Active, and a single-pr
+plan must be absent at merge — CI fails while one is present and passes once
+it is deleted, which makes "gone before merge" enforceable without CI having
+to know which commit is the merge. The verified-deletion of a multi-pr doc
+stays a human act CI permits rather than performs.
 
 Behind each of these is the same shift: the workflows derive from a small
 set of stated principles instead of restating procedure. An author who
@@ -218,8 +239,8 @@ ones do.
 
 An author starting a new roadmap or plan needs an issues table and a
 dependency diagram. Rather than searching prior docs and copying whichever
-variant they find — and propagating one of four schemas or one of three
-legends — they reach for the single shared reference that defines the
+variant they find — and propagating one of several schemas or a divergent
+legend — they reach for the single shared reference that defines the
 table format and the diagram convention once. They consume the canonical
 shape, parameterized to their document's altitude, and produce a table and
 diagram that match every other doc built from the same reference. The
@@ -251,8 +272,10 @@ This brief, and the downstream PRD it points at, cover standardizing the
 roadmap and plan workflows around shared, principle-driven conventions.
 The scope holds the following inside:
 
-- **A reusable principle set** the roadmap and plan workflows (and their
-  siblings) derive from rather than restate — a small, named set covering
+- **A reusable principle set** the roadmap and plan workflows derive from
+  rather than restate — authored to be reusable by sibling doc types later,
+  though this work wires only the roadmap and plan workflows to it — a small,
+  named set covering
   the lowest-ceremony default, decisions needing a durable home, one
   canonical format per concern, strictness tracking blast radius, formats
   defined once, and usable value as the unit of work (every PR and every
@@ -274,24 +297,33 @@ The scope holds the following inside:
 - **The decision-surfacing fixes.** Encoding the usable-value principle
   into both the plan and roadmap workflows: lifting the single-pr/multi-pr
   decision to the skill surface, anchoring it on usable value, and
-  decoupling it from the work-slicing decision. A roadmap stays
-  multi-pr — every roadmap feature delivers observable incremental value
-  as a cohesive deliverable — but that outcome is re-grounded in the value
-  principle rather than reached by mechanism, and a step (always for a
-  roadmap, and for a plan when its multi-pr rationale is incremental value
-  rather than a hard landing constraint) confirms each feature or PR
-  delivers observable incremental value. Plus giving the roadmap a
-  first-class path to its issues table in place of the brittle string
-  surgery in the plan re-entry.
-- **An enforced document lifecycle.** A shared lifecycle for plan and
-  roadmap docs: a multi-pr doc finishes its draft and stops for approval
-  before issues are created, with approval being the move to Active; a
-  completed doc rests at Done until the author verifies the delivered work,
-  and verification retires the doc; and CI enforces the states — a multi-pr
-  doc may only merge in Active, a completed one is expected to be deleted,
-  and a single-pr plan is ephemeral, living only on its PR branch and
-  removed before that PR merges. The exact transitions, the virtual
-  VERIFIED state, and the CI checks are the downstream design's.
+  decoupling it from the work-slicing decision. A roadmap stays multi-pr
+  because each feature should deliver observable incremental value as a
+  cohesive deliverable — re-grounded in the value principle rather than
+  reached by mechanism — and a confirmation step (always for a roadmap, and
+  for a plan whose split delivers incremental value, whether or not a hard
+  constraint also forces it) checks that each feature or PR actually does. It
+  can fail: a feature that isn't a standalone increment flags a mis-decomposed
+  roadmap to re-scope rather than waving it through. Plus giving the roadmap a
+  first-class path to its issues table in place of the brittle string surgery
+  in the plan re-entry.
+- **An enforced document lifecycle with one terminal.** A shared lifecycle
+  for plan and roadmap docs: a multi-pr doc finishes its draft and stops for
+  approval before issues are created (approval is the move to Active); it
+  reaches Done when the work is complete; and the author's verification
+  retires it by deletion. This unifies today's split terminal — a completed
+  plan is already deleted by the work-on cascade, a completed roadmap is kept
+  forever, and the plan reference doc still says move-to-`done/`; the
+  standardization makes verify-then-delete the single terminal for both (a
+  deliberate change for roadmaps) and retires the stale move-to-archive
+  wording. A single-pr plan is ephemeral — it lives only on its PR branch and
+  is deleted before that PR merges. CI enforces the states it can observe: a
+  multi-pr doc may only merge in Active, and a single-pr plan must be absent
+  at merge (CI fails while it is present, passes once it is deleted). The
+  verified-deletion of a multi-pr doc is a human act CI permits, not one it
+  performs. The precise transitions, how the virtual VERIFIED step is
+  realized, and the enforcement surface for the CI checks are the downstream
+  design's.
 
 The scope explicitly excludes:
 
@@ -333,12 +365,13 @@ These surface for the downstream PRD to resolve. None block this brief.
    structure is undecided. The PRD names the shared core and the
    per-profile additions.
 
-4. **How the lifecycle is enforced without overreach.** The lifecycle
-   adds a review gate before issue creation, a verified-then-deleted
-   terminal, and CI checks on document state. How strict the CI
-   enforcement is at first, and how the virtual VERIFIED transition is
-   realized (a transition that deletes versus a separate cleanup step),
-   are calls the PRD and design settle.
+4. **The enforcement surface for the lifecycle checks.** Scope commits the
+   two CI checks observable on a stateless per-PR pass: a multi-pr doc may
+   only merge in Active, and a single-pr plan must be absent at merge. What
+   stays open is the surface that carries them — the existing PR
+   doc-validator, a whole-tree scan, or a push-to-main / branch-protection
+   gate — and how the virtual VERIFIED step (the human verify-then-delete) is
+   realized. The PRD and design settle these.
 
 ## Downstream Artifacts
 

--- a/docs/designs/DESIGN-roadmap-plan-standardization.md
+++ b/docs/designs/DESIGN-roadmap-plan-standardization.md
@@ -1,6 +1,6 @@
 ---
 schema: design/v1
-status: Accepted
+status: Planned
 upstream: docs/prds/PRD-roadmap-plan-standardization.md
 problem: |
   The roadmap and plan workflows share an issues table, a dependency
@@ -41,7 +41,7 @@ rationale: |
 
 ## Status
 
-Accepted
+Planned
 
 ## Context and Problem Statement
 

--- a/docs/designs/DESIGN-roadmap-plan-standardization.md
+++ b/docs/designs/DESIGN-roadmap-plan-standardization.md
@@ -1,0 +1,785 @@
+---
+schema: design/v1
+status: Proposed
+upstream: docs/prds/PRD-roadmap-plan-standardization.md
+problem: |
+  The roadmap and plan workflows share an issues table, a dependency
+  diagram, a lifecycle vocabulary, and one validator, but none of that is
+  defined once: the table has several drifting schemas across the skill
+  references and committed corpus, the diagram spec lives inside one plan
+  reference and is unenforced, the validator checks only section presence
+  (no Markdown-table or mermaid tokenizer exists in internal/validate), the
+  single-pr/multi-pr rule is buried in a lazily loaded plan phase file, the
+  roadmap fills its table by re-driving the plan workflow through in-prose
+  string surgery, and the lifecycle terminal is three-way contradictory with
+  no CI enforcement. This design fixes the implementation shape of all six.
+decision: |
+  Introduce a shared references directory both skills consume (a principles
+  reference, one issues-table framework with a plan and a roadmap profile,
+  and the promoted diagram convention), extend internal/validate with one
+  new Markdown-table parser feeding two error-level content checks (schema
+  conformance, cross-reference existence) plus a deferred mermaid-reconcile
+  check staged behind a spike and shipped notice-then-error, surface and
+  re-anchor the single-pr/multi-pr decision with a value-confirmation guard,
+  add a scripted roadmap-to-issues path mirroring the plan's, and enforce a
+  single verify-then-delete lifecycle via a new whole-tree-scan CI surface
+  running alongside the existing changed-files validator.
+rationale: |
+  Most machinery already exists; the work is naming shared parts as shared
+  and defining each once. The validator's pure-function check architecture,
+  the SCHEMA notice-then-error precedent, and the existing git-shelling
+  presence check (checkPlanUpstream) all extend cleanly, so the first
+  content pass adds exactly one parser and reuses the existing CLI and
+  reusable workflow. Staging reconciliation behind a mermaid-parser spike
+  honors strictness-tracks-blast-radius: the two cheap checks land strict
+  while the corpus-wide one lands as a notice first. A separate whole-tree
+  scan is required because presence-without-touch is invisible to the
+  existing changed-files diff.
+---
+
+# DESIGN: roadmap-plan-standardization
+
+## Status
+
+Proposed
+
+## Context and Problem Statement
+
+shirabe's `/roadmap` and `/plan` skills sit at opposite ends of the tactical
+chain yet share four things at the implementation level: an issues table, a
+mermaid dependency diagram, a lifecycle vocabulary (`Draft`/`Active`/`Done`),
+and one Go validator (`internal/validate/`). None of these shared concerns is
+defined in a single place, and the drift that follows is the technical problem
+this design solves. The work is meta: the artifacts being modified are
+shirabe's own skill references, its Go validator package, the skill scripts,
+and the reusable CI workflows in this repo.
+
+Six concrete gaps, each grounded in current code:
+
+- **The issues table has no single definition.** The plan profile is specified
+  in `skills/plan/references/quality/plan-doc-structure.md` as `Issue |
+  Dependencies | Complexity` with a still-accepted legacy `Issue | Title |
+  Dependencies | Complexity` variant; the roadmap reserves `Feature | Issues |
+  Status` in `skills/roadmap/references/roadmap-format.md`; and committed docs
+  carry further divergences. There is no shared reference and no parser that
+  can read a table to check it.
+
+- **The diagram spec is buried and unenforced.** A complete mermaid spec
+  (syntax rules, a fixed status-class palette, a legend) lives only inside the
+  plan's `plan-doc-structure.md`. The roadmap reserves an empty `mermaid`
+  block with no spec reference. Nothing checks a committed diagram against the
+  palette or legend.
+
+- **Validation stops at section presence.** `internal/validate/` parses a doc
+  into a `Doc` IR (`Fields`, `Sections`, `Body`) and runs pure-function checks
+  (FC01-FC04, the format-specific R6/R7/R8 checks) dispatched by `spec.Name` in
+  `ValidateFile`. No function tokenizes a Markdown table or a fenced `mermaid`
+  block. A malformed table, a dangling dependency link, or a table-diagram
+  disagreement all pass as long as the headings exist.
+
+- **The single-pr/multi-pr decision is buried and mechanism-driven.** The rule
+  lives in `skills/plan/references/phases/phase-3-decomposition.md` (step 3.6),
+  loaded lazily, never on the skill surface. Its "Roadmap input forces
+  multi-pr" row reaches the right outcome by mechanism, not by the usable-value
+  principle, and nothing confirms each unit delivers standalone value.
+
+- **The roadmap fills its table by string surgery.** The roadmap writes empty
+  reserved placeholders; the only fill path is the plan workflow's roadmap mode
+  (`input_type: roadmap`), which rewrites placeholders in prose. The plan
+  populates its own table with scripts (`plan-to-tasks.sh`,
+  `create-issues-batch.sh`); the roadmap has no equivalent native path.
+
+- **The lifecycle terminal is contradictory and unenforced.** `plan-doc-
+  structure.md` says move a Done plan to `docs/plans/done/`; the live work-on
+  cascade deletes it; a completed roadmap is kept forever (roadmap-format.md:
+  "Done -> any: Forbidden... a historical record"). No CI check holds a doc to
+  the state its mode requires, and the existing `validate-docs.yml` runs only
+  on the changed-files diff (`git diff --name-only base...head`), which cannot
+  observe a doc the PR does not touch.
+
+The PRD settles five decisions (the five-principle set, the staged validation
+split, the smallest table split, the whole-tree-scan/ephemeral-Done lifecycle,
+and record-and-proceed for both `--auto` gates). This design operationalizes
+them: it does not relitigate them. The downstream questions it must answer are
+the implementation shapes the PRD explicitly deferred -- the shared-reference
+file layout, the validation check codes and parser design, the
+roadmap-to-issues script interface, the mermaid-parser spike framing, the CI
+whole-tree-scan surface, and the final principle wording.
+
+## Decision Drivers
+
+- **Reuse over rebuild (R19).** The first content pass must extend the existing
+  `internal/validate/` package, run through the existing `shirabe validate`
+  CLI and the existing reusable workflow, and add exactly one new parser (the
+  shared Markdown table parser). No second binary, no parallel pipeline.
+
+- **Strictness tracks blast radius (R1.5, R8, R20).** Schema conformance and
+  cross-reference (small, localized retrofit cost, no new parser beyond the
+  shared table parser) land at error-level on day one. Table-diagram
+  reconciliation (needs a mermaid parser, corpus-wide retrofit) is staged into
+  a later increment behind a spike and ships as a notice before promotion to
+  error -- mirroring the existing SCHEMA notice gate.
+
+- **Define each shared concern once (R1.4, R2-R5).** The issues table, the
+  dependency diagram, and the principle set each get one source of truth both
+  skills consume, replacing per-skill restatement.
+
+- **Presence-without-touch must be observable (R17, R18).** The two lifecycle
+  checks need whole-tree visibility the changed-files diff cannot provide, so
+  they require a distinct CI surface that scans the checked-out tree.
+
+- **`--auto` must never deadlock (R12, R14).** Both human-judgment gates
+  (value confirmation, issue-creation approval) record a decision block and
+  proceed under `--auto`, surfacing high-priority assumed blocks rather than
+  blocking on a human who is not present.
+
+- **Public-repo cleanliness (R22).** Every shared reference, surfaced rule, and
+  validation message must be free of private repo names, paths, filenames,
+  issue numbers, and pre-announcement features.
+
+- **Altitude distinction must survive (R2-R4).** The shared table framework
+  carries two profiles (feature-keyed roadmap, issue-keyed plan) rather than
+  collapsing the altitude difference.
+
+- **Migration is in scope, not a permanent dual format (R3, R4).** The legacy
+  separate-`Title` plan table and the divergent committed roadmap shapes are
+  migrated into the canonical profiles, not accepted forever.
+
+## Considered Options
+
+The PRD settled five decisions (the principle-set membership, the validation
+staging seam, the table split, the lifecycle shape, and the `--auto` gate
+behavior). This design decomposed the deferred implementation shape into six
+independent questions, each evaluated against the current code. The PRD's
+settled positions are inputs here, not options to relitigate.
+
+### Decision 1: Where shared references live and how the skills consume them
+
+Today the issues-table spec and the dependency-diagram spec are trapped inside
+`skills/plan/references/quality/plan-doc-structure.md`, and the roadmap's table
+stub lives in `skills/roadmap/references/roadmap-format.md`. Nothing is shared.
+The PRD's principle "one canonical format per concern, defined once" (R1.4)
+requires a single home both skills consume. The plugin already hosts cross-skill
+references at its root (`references/decision-protocol.md`,
+`references/cross-repo-references.md`), loaded via `${CLAUDE_PLUGIN_ROOT}`. The
+Go validator does not read these references at runtime -- it hardcodes the
+format contract in `internal/validate/formats.go` -- so the references are
+authoring guidance and the validator is their enforcement twin.
+
+Key assumptions: the references and `formats.go` are kept in sync by the author
+(edited together), mirroring the existing split where `formats.go` encodes what
+the prose describes.
+
+#### Chosen: Plugin-root shared references, consumed via `${CLAUDE_PLUGIN_ROOT}`
+
+Add three shared references at the plugin root: `workflow-principles.md` (the
+five named principles, R1), `issues-table.md` (the one table framework -- shared
+core, shared rendering, the plan and roadmap profiles, plus the migration rules),
+and `dependency-diagram.md` (the diagram convention promoted verbatim out of
+`plan-doc-structure.md`). Both skills point at them with `${CLAUDE_PLUGIN_ROOT}`,
+the mechanism already used for the decision protocol. `plan-doc-structure.md` and
+`roadmap-format.md` shrink to their profile-specific deltas and lifecycle
+content. This reuses a proven loader with no new machinery and gives a future
+sibling doc type one place to consume the same conventions.
+
+#### Alternatives Considered
+
+**One skill owns, the other cross-references**: keep the spec in the plan
+references and have the roadmap link into it. Rejected because it re-encodes the
+"trapped in one skill" anti-pattern the PRD names as the root cause, and makes
+the roadmap depend on a plan-internal path.
+
+**Duplicate the content into each skill**: Rejected outright -- duplication is
+the exact drift source being removed, violating define-once (R1.4).
+
+### Decision 2: The Markdown-table parser and the two content checks
+
+`internal/validate/` parses a doc into a `Doc` IR (`Fields`, `Sections`,
+`Body []string`) and runs pure-function checks dispatched by `spec.Name` in
+`ValidateFile`. No function tokenizes a table. R6 (schema conformance) and R7
+(cross-reference existence) both need to read the issues table, and R19 caps the
+first pass at exactly one new parser. The corpus shows the shapes the parser
+must read and reject: plan `Issue | Dependencies | Complexity` (and a legacy
+`Issue | Title | ...`), roadmap `Feature | Issues | Status`, and divergences
+`Feature | Status | Downstream Artifact` and `Issue | Phase | Dependencies |
+Label`. Cells carry markdown links, `None`, comma-separated links, and
+`~~strikethrough~~`.
+
+Key assumptions: tables use GFM pipe syntax with a `---` separator (true across
+the corpus); profile is selected by doc schema, not by inspecting the header, so
+a roadmap carrying a plan-shaped table fails the schema check (the intended
+migration signal).
+
+#### Chosen: One tokenizer in `table.go` feeding `checkFC05` (schema) and `checkFC06` (cross-reference)
+
+A new `parseIssuesTable(doc Doc)` locates the table under the Implementation
+Issues section using `Doc.Sections` line bounds and `Doc.Body`, parses the
+header into columns, and classifies each body row as entity, description
+(`| _..._ | | |`), or child (`| ^_..._ | ... |`), stripping `~~..~~` before
+classification so a done row parses like an open one. `checkFC05` selects the
+profile from the doc's format, compares the header against the profile's
+required columns and order, and checks row well-formedness; `checkFC06` builds
+the set of entity-row keys and verifies every Dependencies value resolves to a
+row in the same table. Both are error-level, dispatch in the `Plan` and a new
+`Roadmap` arm of the `ValidateFile` switch, and name the specific defect in
+their messages. The legacy `Title`-column plan table is recognized as a
+migration input the message points the author to migrate, not a permanent
+accepted form. This adds one file, two checks, two dispatch arms -- no IR or CLI
+change -- and the `Table` it produces is the foundation the later
+reconciliation check reuses.
+
+#### Alternatives Considered
+
+**Two independent parsers, one per check**: Rejected -- R6 and R7 read the same
+table; two parsers duplicate tokenization and cut against R19's one-parser
+constraint.
+
+**Regex-only checks with no table model**: Rejected -- R7 needs the set of row
+keys, a structured property; per-line regex cannot build that set cleanly and is
+brittle against link syntax.
+
+### Decision 3: The mermaid-parser spike and the staged reconciliation check
+
+Table-diagram reconciliation (R8) is the one content check needing a mermaid
+node/edge parser, and its retrofit blast radius is the whole committed-diagram
+corpus (which carries ad-hoc classDefs and reworded legends). The PRD stages it
+behind a feasibility spike (R9) and requires notice-then-error rollout. shirabe
+has a spike artifact type, and `checkSchema`/`IsNotice` is a working
+notice-then-error precedent. The corpus uses a narrow mermaid subset:
+`graph LR`/`TD`, quoted node labels, `-->` edges, `subgraph`, `classDef`, and
+`class` directives -- far smaller than full mermaid.
+
+Key assumptions: a line-oriented extractor over the corpus subset suffices (the
+spike confirms before R8 is detailed); notice-level R8 is wired by adding its
+code to the notice set in `IsNotice` initially.
+
+#### Chosen: A named spike precedes R8; R8 is a later increment, notice-then-error, reusing the table parser
+
+A spike artifact (under `docs/spikes/`) investigates the three things R9 names:
+the exact `graph` subset the docs use, how to extract nodes and edges without a
+full grammar (a line-oriented extractor, no external dependency), and the
+reconciliation strictness (exact node-set equality versus subset, to allow
+external cross-repo nodes). R8 then lands as `checkFC07` in a later increment,
+adding `mermaid.go` and consuming both the existing parsed `Table` and the
+extracted diagram. It ships as a notice (via `IsNotice`, like `SCHEMA`) so an
+unreconciled committed diagram does not redden CI, then is promoted to
+error-level once the corpus is reconciled -- a one-line change to the notice
+membership. This keeps R8 off the first pass's critical path and honors
+strictness-tracks-blast-radius (R1.5) and no-day-one-breakage (R20).
+
+#### Alternatives Considered
+
+**Skip the spike, write R8 against a guessed subset**: Rejected -- the PRD makes
+the spike an explicit upstream and an acceptance criterion, and skipping it risks
+a grammar mismatch.
+
+**Pull in a full mermaid grammar or external parser**: Rejected -- over-built for
+the narrow subset, and it adds a Go dependency to a package that has none beyond
+stdlib and yaml. The spike exists precisely to avoid a full grammar.
+
+### Decision 4: The roadmap-to-issues scripted path interface
+
+The plan populates its own table with scripts (a manifest plus
+`create-issues-batch.sh`, which is manifest-driven and skill-agnostic). The
+roadmap has no script -- its only fill path is the plan workflow's
+`input_type: roadmap` mode, which rewrites reserved placeholders in prose. R13
+wants a path native to the roadmap, not a re-drive of the plan workflow. The
+roadmap already ships `transition-status.sh`, so it has a scripts directory and
+a JSON-output convention.
+
+Key assumptions: the roadmap's Features section is machine-readable enough (the
+per-feature format with `Needs`/`Dependencies`) to build a manifest;
+`create-issues-batch.sh` stays generic.
+
+#### Chosen: A roadmap-owned populate script reusing the generic create-issues primitive, writing reserved sections by section replacement
+
+Add `skills/roadmap/scripts/populate-issues-table.sh`. It reads the Features
+section, builds a per-feature planning-issue manifest in the shape
+`create-issues-batch.sh` already consumes, calls that shared primitive to create
+the issues and obtain an id-to-url mapping, then renders the feature-keyed table
+(with the Issues fan-out column populated) and the dependency diagram and writes
+them into the reserved sections by replacing each section's body between its
+headings -- a structural replacement, not the fragile placeholder string match
+the plan re-entry used. Issue creation is the gated step (R14): in interactive
+mode the skill stops for approval before invoking it; under `--auto` it records
+an assumed approval block at high review priority, then proceeds. The gate lives
+in the skill phase that invokes the script, so the scripted path does not bypass
+it. `create-issues-batch.sh` may optionally be relocated to a shared scripts
+location so both skills cite one copy.
+
+#### Alternatives Considered
+
+**Keep the plan re-entry but make it script-driven instead of prose**: Rejected
+-- R13 explicitly wants the path native to the roadmap; even a script-driven
+re-entry still drives the plan workflow against the roadmap document.
+
+### Decision 5: The CI surface for the lifecycle checks and the verify-then-delete wiring
+
+The existing `validate-docs.yml` runs `shirabe validate` on the changed-files
+diff (`git diff --name-only base...head`), which cannot see a doc the PR does not
+touch -- so it provably cannot enforce presence-without-touch, the core of both
+lifecycle checks (the PRD's Decision 4 settles this). The validator already
+shells out to git (`checkPlanUpstream` runs `git ls-files`) and already parses
+frontmatter `status` and `execution_mode`, so a whole-tree status read fits the
+existing CLI.
+
+Key assumptions: roadmaps and plans live under a known doc tree the scan walks,
+selected by filename prefix via `DetectFormat`; `execution_mode` is present in
+plan frontmatter (a required field), so the multi-pr/single-pr split is reliable;
+`L01`/`L02` are new error-level codes.
+
+#### Chosen: A new whole-tree `--lifecycle` validator mode, run by a separate CI job alongside the unchanged changed-files validator
+
+The validator gains a `--lifecycle <root>` mode that walks the doc tree, selects
+roadmap and plan docs, and runs two stateless checks on the parsed `Doc` IR:
+Check A (`L01`) fails any roadmap or `multi-pr` plan present with a status other
+than `Active` (a present Draft fails; a present Done fails, the forcing function
+for deletion), and Check B (`L02`) fails while any `single-pr` plan exists in the
+tree and passes once it is gone. A new reusable workflow plus a self-caller runs
+this mode on every PR with no `paths:` filter, as a separate job from the
+content validator (which keeps running diff-scoped and unchanged). The
+verify-then-delete terminal (R15) lands atomically in the work-completing PR: the
+skill transitions Active to Done via `transition-status.sh`, the author verifies,
+and the same PR deletes the doc. CI never deletes -- Check A failing on a present
+Done is what makes the deletion non-optional (R18). The stale
+move-to-`docs/plans/done/` wording is removed.
+
+#### Alternatives Considered
+
+**Extend `validate-docs.yml` to also scan the whole tree**: Rejected -- it
+conflates two concerns with different trigger semantics. The content validator is
+correctly diff-scoped and `paths:`-filtered; the lifecycle gate must run on every
+PR regardless of what changed. Bundling forces one to inherit the other's wrong
+trigger.
+
+**A bash/grep-only CI step with no Go**: Rejected -- frontmatter status and
+`execution_mode` parsing already live in `ParseDoc`; re-implementing YAML
+frontmatter parsing in shell duplicates logic and drifts from the validator.
+
+### Decision 6: Surfacing the single-pr/multi-pr decision and the value guard
+
+The single-pr/multi-pr rule lives in
+`skills/plan/references/phases/phase-3-decomposition.md` (step 3.6), loaded
+lazily, never on the SKILL surface, tangled with the separate
+decomposition-strategy decision, and its multi-pr trigger table includes
+"Roadmap input" as a mechanism row. R10 wants it surfaced, anchored on usable
+value, and de-conflated; R11 wants a guard that can fail; R12 wants `--auto`
+record-and-proceed. The decision protocol already defines confirmed / assumed /
+escalated record-and-proceed.
+
+Key assumptions: the plan `SKILL.md` is the right always-loaded surface; "high
+review priority" is expressed via the assumed block and its appearance in the
+terminal summary and PR body, with no new priority field.
+
+#### Chosen: Lift the rule onto the SKILL surface anchored on usable value; add a separate value-confirmation step that records-and-proceeds under `--auto`
+
+The plan `SKILL.md` gains a short always-loaded statement of the default (one PR)
+and its named escape conditions (a hard constraint, or each PR independently
+useful), citing the usable-value principle in `workflow-principles.md`. The
+decomposition-strategy decision is named as separate and stays in the phase file.
+The roadmap's always-multi-pr outcome is re-anchored on value (each feature is a
+cohesive deliverable), not on the mechanism "the input is a roadmap." A
+value-confirmation step checks each unit -- every feature for a roadmap, each
+value-driven PR for a plan -- and can fail, naming the mis-decomposed unit and
+why. Under `--auto` it writes a decision block: `confirmed` for a clear
+standalone-value unit, `assumed` at high review priority for a failing or
+ambiguous unit (both route to the same recorded outcome on purpose), surfaced in
+the terminal summary and PR body. This is the same record-and-proceed shape the
+issue-creation approval gate uses, so the two `--auto` gates stay symmetric.
+
+#### Alternatives Considered
+
+**Keep the rule in the phase file but add a pointer from the surface**: Rejected
+-- a pointer is not surfacing; a "see phase 3" link reproduces the
+buried-reference problem R10 fixes.
+
+**Make the guard hard-fail even under `--auto`**: Rejected by the PRD's
+Decision 5 -- a hard stop breaks `--auto`'s non-interactive contract.
+
+## Decision Outcome
+
+**Chosen: 1A + 2A + 3A + 4A + 5A + 6A** (the chosen option of each decision
+above), forming one coherent standardization.
+
+### Summary
+
+The work splits cleanly into three tracks that share one foundation. The
+foundation is a set of three plugin-root shared references --
+`workflow-principles.md`, `issues-table.md`, `dependency-diagram.md` -- that both
+the plan and roadmap skills consume via `${CLAUDE_PLUGIN_ROOT}`, with
+`plan-doc-structure.md` and `roadmap-format.md` trimmed to point at them and keep
+only their profile deltas and lifecycle content. The five named principles get
+their wording finalized here; each surfaced rule in the two skills cites the
+principle it derives from.
+
+The validation track extends `internal/validate/` with one new file,
+`table.go`, exposing `parseIssuesTable` over the existing `Doc.Body`/`Doc.Sections`
+IR. Two new error-level checks consume it: `checkFC05` (schema conformance --
+header matches the doc's profile, rows well-formed) and `checkFC06`
+(cross-reference -- every Dependencies value names a row that exists). Both
+dispatch in the `Plan` and a new `Roadmap` arm of `ValidateFile` and run through
+the existing CLI and the existing changed-files reusable workflow, so the first
+pass adds no second binary and exactly one parser (R19). Table-diagram
+reconciliation is deliberately not in this pass: it is staged behind a named
+mermaid-parser spike, then lands later as `checkFC07` in a new `mermaid.go`,
+reusing the parsed `Table` and shipping as a notice (via `IsNotice`, the SCHEMA
+precedent) before promotion to error -- so the committed-diagram corpus can be
+reconciled before reconciliation becomes blocking (R20).
+
+The workflow track surfaces and re-anchors the single-pr/multi-pr decision on the
+plan `SKILL.md`, de-conflated from the decomposition-strategy decision, with a
+value-confirmation step that can fail and names the mis-decomposed unit. The
+roadmap gains a native scripted path, `populate-issues-table.sh`, that builds a
+per-feature manifest, reuses the generic `create-issues-batch.sh`, and writes the
+reserved table and diagram sections by structural section replacement rather than
+prose string surgery. The lifecycle track adds a whole-tree `--lifecycle`
+validator mode -- Check A (`L01`, a present roadmap or multi-pr plan must be
+Active; a present Done or Draft fails) and Check B (`L02`, a single-pr plan must
+be absent) -- run by a new CI job on every PR with no `paths:` filter, alongside
+the unchanged diff-scoped content validator. The verify-then-delete terminal
+lands atomically in the work-completing PR (transition to Done, verify, delete in
+one PR); CI demands the deletion by failing a present Done but never performs it.
+
+Both `--auto` human-judgment gates -- the value-confirmation guard and the
+issue-creation approval gate -- record a decision block (`confirmed` or `assumed`
+at high review priority) and proceed, never deadlocking, surfacing the assumed
+block in the terminal summary and PR body.
+
+### Rationale
+
+The decisions reinforce each other through two shared mechanisms. First, the
+`Doc` IR and the pure-function check pattern carry the entire validation track:
+`table.go` reads the same IR the lifecycle mode reads, and the reconciliation
+increment reuses the `Table` the first pass already produces -- so the three
+validation pieces compose rather than duplicate. Second, one record-and-proceed
+gate pattern serves both `--auto` judgment points across the plan script, the
+roadmap script, and the surfaced decision, so authors and the harness track one
+behavior, not three.
+
+The build order falls out of two couplings the cross-validation surfaced (and
+the Implementation Approach phases): the reconciliation check depends on the
+table parser existing, and on the spike; everything else in the first pass is
+independent. Staging reconciliation last is the seam the PRD chose on
+blast-radius grounds, and nothing in the first pass needs it. The main trade-off
+accepted is the one the PRD already named: the whole-tree lifecycle scan reads
+unchanged docs on every PR, so an unrelated PR can fail on a left-behind doc --
+which is exactly how presence-without-touch becomes observable and how the
+Done-must-delete forcing function works.
+
+## Solution Architecture
+
+### Overview
+
+The standardization touches four surfaces in this repo: shared skill references
+(authoring guidance), the Go validator (`internal/validate/`, enforcement), the
+skill scripts (`skills/plan/scripts/`, `skills/roadmap/scripts/`), and the
+reusable CI workflows (`.github/workflows/`). References describe the
+conventions; the validator enforces the subset that is machine-checkable; the
+scripts populate tables and create issues; CI runs the validator on PRs. The
+references and the validator are kept in agreement by the author -- they are two
+expressions of the same contract, not a runtime coupling.
+
+### Components
+
+- **Shared references (plugin root).**
+  - `references/workflow-principles.md` -- the five named principles (R1), each a
+    one-line statement plus the rule(s) it governs.
+  - `references/issues-table.md` -- the one table framework: shared core (key
+    column parameterized by profile, Dependencies, Status), shared rendering
+    (italic description row, strikethrough-on-done across entity/description/child
+    rows), the plan profile (`Issue` key, `[#N: <title>](url)` link form, the
+    `Complexity` column, the `^_Child: ..._` row), the roadmap profile (`Feature`
+    key, the `Issues` fan-out column), and the migration rules for the legacy
+    `Title` plan form and the divergent committed roadmap shapes.
+  - `references/dependency-diagram.md` -- the diagram convention moved out of
+    `plan-doc-structure.md`: `graph` syntax rules, the fixed status-class
+    palette, node format, and the legend.
+  - The two skill references (`skills/plan/references/quality/plan-doc-structure.md`,
+    `skills/roadmap/references/roadmap-format.md`) are trimmed to cite these and
+    keep only profile deltas and lifecycle content.
+
+- **Validator (`internal/validate/`).**
+  - `table.go` (new): `parseIssuesTable(doc Doc) (Table, bool)` and the `Table`
+    type (header columns, typed rows: entity / description / child). Reads
+    `Doc.Body` within the Implementation Issues section bounds from
+    `Doc.Sections`. Strips `~~..~~` before classifying.
+  - `checks.go` (extended): `checkFC05` (R6 schema conformance) and `checkFC06`
+    (R7 cross-reference existence), both pure functions returning
+    `[]ValidationError`, both error-level.
+  - `validate.go` (extended): a new `Roadmap` arm in the `ValidateFile` switch
+    that runs FC05/FC06; the existing `Plan` arm gains FC05/FC06 alongside
+    `checkPlanUpstream`.
+  - `mermaid.go` (new, later increment): the line-oriented node/edge extractor
+    and `checkFC07` (R8 reconciliation), shaped by the spike.
+  - A whole-tree `--lifecycle` mode (CLI flag in `cmd/shirabe/main.go` plus a
+    tree walk) running Check A (`L01`) and Check B (`L02`) against the parsed IR.
+
+- **Scripts.**
+  - `skills/roadmap/scripts/populate-issues-table.sh` (new): Features -> manifest
+    -> `create-issues-batch.sh` -> rendered table + diagram written by section
+    replacement.
+  - `create-issues-batch.sh` (existing, treated as shared; optional relocation).
+  - `transition-status.sh` (existing for roadmap; drives the roadmap's
+    Active->Done step). The plan's Active->Done step is wired through the
+    work-completion cascade rather than a standalone plan script -- the precise
+    per-doc transition mechanics are the plan's to settle, but both modes land
+    the transition, verification, and deletion atomically in the
+    work-completing PR.
+
+- **CI (`.github/workflows/`).**
+  - `validate-docs.yml` (unchanged): diff-scoped content/frontmatter validation.
+  - A new reusable lifecycle workflow plus a self-caller: runs `shirabe validate
+    --lifecycle` on the checked-out tree on every PR, no `paths:` filter.
+
+### Key Interfaces
+
+- **`parseIssuesTable(doc Doc) (Table, bool)`** -- returns the parsed table and
+  whether one was found under the Implementation Issues section. `Table` carries
+  `Columns []string` and `Rows []Row`, where `Row` has a kind
+  (entity/description/child), the key token (the `#N` for plan, the feature label
+  for roadmap), and the dependency targets parsed from the Dependencies cell.
+
+- **`checkFC05(doc, spec, cfg) []ValidationError`** -- profile selected by
+  `spec.SchemaVersion` (plan/v1 vs roadmap/v1); compares header to the profile's
+  column contract and checks row pairing. Message form:
+  `[FC05] <specific defect naming the column or row>`.
+
+- **`checkFC06(doc, spec, cfg) []ValidationError`** -- builds the entity-row key
+  set, validates each Dependencies target against it. Message form:
+  `[FC06] dependency "<key>" in row "<key>" names no row in this table`.
+
+- **`--lifecycle` mode** -- input: a root path. Walks the doc tree, selects docs
+  by `DetectFormat` prefix, reads frontmatter `status` and `execution_mode` from
+  the parsed `Doc`. Output: `L01`/`L02` errors (error-level, non-notice). Exit
+  non-zero if any fire.
+
+- **`populate-issues-table.sh <roadmap-path>`** -- reads the Features section,
+  emits a per-feature manifest (`title`, `needs_label`, `dependencies`,
+  `complexity: simple`), calls `create-issues-batch.sh --manifest`, renders and
+  writes the reserved sections by replacing the body between each section's
+  heading and the next. Output: updated doc + a JSON summary on stdout.
+
+### Data Flow
+
+Authoring a plan or roadmap: the skill reads the shared references for the table
+and diagram shape, drafts the doc, and (multi-pr) stops at the approval gate. On
+approval -- or under `--auto`, after recording an assumed approval block -- the
+populate/create scripts run, issues are created, the table and diagram are
+written, and the doc transitions to Active. Validation runs two ways: per-PR on
+the changed files (content checks FC01-FC06) and per-PR whole-tree (lifecycle
+checks L01/L02). The work-completing PR transitions Active->Done, the author
+verifies, and the same PR deletes the doc; L01 failing on a present Done is what
+forces the deletion into that PR.
+
+## Implementation Approach
+
+The phases match the PRD's staging: the shared references, the table parser, the
+two error-level checks, the decision-surfacing, the roadmap script, and the
+lifecycle/CI gate all land before the reconciliation increment, which sits behind
+the spike.
+
+### Phase 1: Shared references and principle wording
+
+Create `workflow-principles.md`, `issues-table.md`, and `dependency-diagram.md`
+at the plugin root. Move the diagram spec out of `plan-doc-structure.md`
+verbatim. Trim `plan-doc-structure.md` and `roadmap-format.md` to cite the shared
+references and keep only profile deltas and lifecycle content. Finalize the
+five-principle wording. No code yet.
+Deliverables: three new references; two trimmed skill references.
+
+### Phase 2: Table parser and the two content checks
+
+Add `internal/validate/table.go` with `parseIssuesTable` and the `Table` type.
+Add `checkFC05` and `checkFC06` to `checks.go`, wire them into the `Plan` and a
+new `Roadmap` arm of `ValidateFile`, with unit tests covering the canonical
+profiles, the legacy `Title` plan form (migration message), the divergent
+roadmap shapes, and a dangling cross-reference. The existing changed-files CI
+workflow picks these up with no change.
+Deliverables: `table.go`; FC05/FC06 in `checks.go`; switch arms in `validate.go`;
+tests in `checks_test.go`.
+
+### Phase 3: Migrate the committed corpus to the canonical profiles
+
+Migrate the committed roadmap tables (`Feature | Status | Downstream Artifact`,
+`Issue | Phase | Dependencies | Label`) into the roadmap profile and the legacy
+plan table into the canonical plan shape, so FC05/FC06 pass on the corpus. This
+phase exists because FC05 is error-level on day one (R6) and the divergent shapes
+would otherwise redden CI.
+Deliverables: migrated `docs/roadmaps/*` and `docs/plans/*` tables.
+
+### Phase 4: Surface the decision and add the value guard
+
+Lift the single-pr/multi-pr rule onto the plan `SKILL.md`, anchored on the
+usable-value principle and de-conflated from the decomposition-strategy decision
+(which stays in the phase file, explicitly named separate). Re-anchor the roadmap
+multi-pr case on value. Add the value-confirmation step (can fail; names the
+unit) with `--auto` record-and-proceed via decision blocks.
+Deliverables: edits to plan `SKILL.md` and phase-3-decomposition.md; roadmap
+SKILL value framing; value-guard step.
+
+### Phase 5: Roadmap-to-issues scripted path
+
+Add `skills/roadmap/scripts/populate-issues-table.sh` reusing
+`create-issues-batch.sh`, writing the reserved sections by section replacement.
+Route its issue-creation step through the R14 approval gate (interactive stop;
+`--auto` assumed block). Retire the plan re-entry's prose string surgery for the
+roadmap case. Add a script test mirroring the existing plan-script tests.
+Deliverables: `populate-issues-table.sh`; its test; skill-phase gate wiring.
+
+### Phase 6: Enforced lifecycle and the whole-tree CI gate
+
+Add the `--lifecycle` mode (CLI flag + tree walk + `L01`/`L02` checks) and the
+new reusable lifecycle workflow plus self-caller (no `paths:` filter). Wire the
+verify-then-delete terminal into the skills/cascade: Active->Done +
+verify + delete atomically in the work-completing PR. Remove the stale
+move-to-`docs/plans/done/` wording. Update both skills' lifecycle references.
+Deliverables: `--lifecycle` mode + tests; new CI workflow + self-caller; lifecycle
+wiring; reference edits.
+
+### Phase 7 (later increment): Mermaid-parser spike, then reconciliation
+
+Write the spike artifact (grammar subset, extraction approach, strictness
+recommendation). Then add `mermaid.go` and `checkFC07` reusing the parsed
+`Table`, shipping as a notice first (via `IsNotice`) and promoted to error after
+the committed-diagram corpus is reconciled.
+Deliverables: spike artifact; later: `mermaid.go`, `checkFC07`, corpus diagram
+reconciliation, notice-to-error promotion.
+
+### Implicit decisions recorded
+
+In `--auto` the implicit-decision review records rather than prompts. Two
+implicit choices in the architecture above:
+
+<!-- decision:start id="check-code-family" status="assumed" -->
+### Decision: New checks reuse the FCnn code family; lifecycle checks use a new Lnn family
+
+**Question:** What code namespace do the new content and lifecycle checks use?
+
+**Choice:** Content checks continue the `FCnn` family (`FC05`, `FC06`, later
+`FC07`); the whole-tree lifecycle checks use a new `L01`/`L02` family.
+
+**Assumptions:** `FCnn` is the established family for per-doc content/structure
+checks, so schema/cross-reference/reconciliation fit it; the lifecycle checks are
+a distinct concern (whole-tree, presence-based) that reads more clearly under its
+own prefix. A reviewer may prefer a single family -- low-cost to rename before
+implementation.
+
+**Consequences:** Check codes group by concern. Recorded as assumed so the
+naming can be confirmed at plan time.
+<!-- decision:end -->
+
+<!-- decision:start id="corpus-migration-phase" status="assumed" -->
+### Decision: Migrate the committed corpus in its own phase, before the checks go error-level in CI
+
+**Question:** When does the committed-corpus migration happen relative to FC05/FC06 landing?
+
+**Choice:** A dedicated migration phase (Phase 3) lands the corpus on the
+canonical profiles right after the checks exist, so error-level FC05/FC06 do not
+redden CI on the next PR.
+
+**Assumptions:** The corpus is small (a handful of roadmaps/plans), so a single
+migration phase is enough; FC05 is error-level on day one per R6 (only
+reconciliation R8 is staged as a notice).
+
+**Consequences:** The schema/cross-reference checks are strict immediately with
+no retroactive breakage, satisfying R20 for the first pass. Recorded as assumed
+because the exact per-document migration mechanics are the plan's.
+<!-- decision:end -->
+
+## Security Considerations
+
+A dedicated security review covered four dimensions. The feature parses
+repo-local Markdown and creates GitHub issues from committed content; it
+downloads and executes nothing external and exposes no new data. The review's
+verdict was that the architecture's existing controls address the risks, with
+one implementation must-fix to capture.
+
+**External artifact handling (applies, low).** The table parser (`table.go`),
+the later mermaid extractor (`mermaid.go`), and the `--lifecycle` tree walk all
+read repo-local committed text -- no network or user-supplied artifacts. The
+risk is parser robustness, not a trust boundary: each parser must be total over
+arbitrary line input (no index panics on ragged rows, bounded iteration on
+missing separators or unterminated fences) and must fail with a validation error
+or a clean "no table/diagram found" rather than panicking. The `--lifecycle`
+walk reads a fixed doc-tree root, selects by filename prefix, and parses only
+frontmatter; it must not follow symlinks out of the repo. Mitigation:
+table-driven tests over malformed input; bound the walk to the doc tree.
+
+**Permission scope (applies, medium, bounded).** The new
+`populate-issues-table.sh` reuses `create-issues-batch.sh`, which runs `gh` to
+create real GitHub issues -- a write action with effects outside the repo. The
+R14 approval gate bounds it: interactive runs stop before any issue is created;
+`--auto` runs proceed but record a loud high-priority assumed block, the
+documented trade-off backstopped by the value guard and the human's later review
+of the created issues. Implementation must-fix: the script passes manifest
+values (feature names, titles) to `gh` as discrete arguments, never interpolated
+into a shell string, so content with shell metacharacters cannot inject a
+command. The section-replacement write must edit only between a section heading
+and the next heading and write atomically (temp file plus rename) so a partial
+run cannot corrupt the doc. The new lifecycle CI workflow declares
+`permissions: contents: read` (matching the existing validator workflow); the
+gate is a read-only scan and needs no write token.
+
+**Supply chain or dependency trust (applies, low).** The first pass adds no new
+dependency -- the table parser is stdlib-only, matching the package's current
+footprint, and the design rejected a full mermaid parser, so the later increment
+adds no parsing dependency either. The new reusable lifecycle workflow follows
+the existing validator workflow's pattern: SHA-pinned actions and building the
+binary from the called workflow's own pinned ref, so it does not widen the
+supply-chain surface.
+
+**Data exposure (not applicable).** The feature operates on repo-local Markdown
+and creates issues whose content comes from those same committed docs, using the
+repo's existing `gh` credential. Validation messages quote doc content (headers,
+dependency keys) that is already public in a public repo. No secrets, tokens,
+PII, or system data enter the new code paths.
+
+## Consequences
+
+### Positive
+
+- One source of truth per shared concern (principles, table, diagram), consumed
+  by both skills -- the per-document reinvention ends, and a future sibling doc
+  type can adopt the same references.
+- The first validation pass catches malformed tables and dangling
+  cross-references with one new parser, reusing the existing CLI, the existing
+  reusable workflow, and the established pure-function check pattern (R19).
+- Reconciliation is de-risked: the spike sizes the mermaid problem before any
+  code, and notice-then-error lets the corpus converge before the check blocks.
+- The single-pr/multi-pr call is made where the reasoning is visible, anchored on
+  value rather than mechanism, with a guard that can catch a mis-decomposition.
+- The lifecycle has one terminal, enforced: Done is ephemeral, the verify-delete
+  PR forces a final human review, and the two doc modes are symmetric (both
+  CI-forced-absent at merge).
+- Both `--auto` gates are non-blocking and loud -- no deadlock, and the assumed
+  block surfaces in the PR body and terminal summary.
+
+### Negative
+
+- The whole-tree lifecycle scan re-reads unchanged docs on every PR, so an
+  unrelated PR can fail because of a doc it did not touch (a left-behind single-pr
+  plan, or a Done doc not yet deleted).
+- The references and `formats.go` express the same contract in two places and can
+  drift if edited separately.
+- The first pass leaves table-diagram disagreement uncaught until the
+  reconciliation increment lands.
+- An `--auto` run can file GitHub issues and reach a mis-decomposed draft without
+  an interactive human, because both gates record-and-proceed.
+- The corpus migration is required work before the checks go strict, not optional
+  cleanup.
+
+### Mitigations
+
+- The whole-tree re-read is the intended forcing mechanism, not a defect; the PRD
+  records it as a known limitation, and Check A failing on a present Done is how
+  the deletion becomes non-optional.
+- The Implementation Approach calls out editing the references and `formats.go`
+  together; the validator tests pin the contract `formats.go` enforces.
+- The uncaught-disagreement gap closes when the reconciliation increment ships;
+  it is a deliberate consequence of staging by blast radius (R20).
+- The `--auto` issue-creation and value-judgment risks are mitigated by the loud
+  high-priority assumed blocks (PR body + terminal summary), the value guard as a
+  backstop to the approval gate, and the human's later review of the created
+  issues; an operator who wants a hard human approval runs interactively.
+- The migration is scoped to a single early phase because the committed corpus is
+  small; it lands right after the checks exist so CI is never retroactively red.

--- a/docs/designs/DESIGN-roadmap-plan-standardization.md
+++ b/docs/designs/DESIGN-roadmap-plan-standardization.md
@@ -1,6 +1,6 @@
 ---
 schema: design/v1
-status: Proposed
+status: Accepted
 upstream: docs/prds/PRD-roadmap-plan-standardization.md
 problem: |
   The roadmap and plan workflows share an issues table, a dependency
@@ -41,7 +41,7 @@ rationale: |
 
 ## Status
 
-Proposed
+Accepted
 
 ## Context and Problem Statement
 

--- a/docs/plans/PLAN-roadmap-plan-standardization.md
+++ b/docs/plans/PLAN-roadmap-plan-standardization.md
@@ -1,6 +1,6 @@
 ---
 schema: plan/v1
-status: Draft
+status: Active
 execution_mode: multi-pr
 upstream: docs/designs/DESIGN-roadmap-plan-standardization.md
 milestone: "roadmap-plan-standardization"
@@ -11,12 +11,13 @@ issue_count: 9
 
 ## Status
 
-Draft
+Active
 
-This plan is in the pre-approval state: the full decomposition is captured below with
-`<<ISSUE:N>>` placeholders, but no GitHub milestone or issues have been created yet.
-Issue creation is a separate, human-authorized step (the R14 approval gate this feature
-itself designs). The plan transitions to Active when the issues are created.
+The milestone and nine issues exist
+([roadmap-plan-standardization](https://github.com/tsukumogami/shirabe/milestone/6),
+#111 through #119) and the plan is now Active. The decomposition below tracks the work
+across the five value-delivering PR slices; the plan retires by verify-then-delete when
+the work completes.
 
 ## Scope Summary
 
@@ -40,71 +41,70 @@ reconciliation) is captured as dependency edges rather than a skeleton.
 The nine issues group into five value-delivering PR slices, each landing observable
 incremental value on its own (the usable-value principle this work surfaces):
 
-- **Slice A (Issues 1, 2, 3)** -- table validation + corpus migration, one PR. References +
+- **Slice A (#111, #112, #113)** -- table validation + corpus migration, one PR. References +
   parser + FC05/FC06 going error-level + the corpus migrated to pass them, bundled so the
   checks never redden CI on a divergent committed doc in a gap window.
-- **Slice B (Issue 4)** -- the single-pr/multi-pr decision surfaced on the plan skill, anchored
+- **Slice B (#114)** -- the single-pr/multi-pr decision surfaced on the plan skill, anchored
   on value, with a value-confirmation guard that can fail.
-- **Slice C (Issue 5)** -- a native roadmap-to-issues script, retiring the plan re-entry's prose
+- **Slice C (#115)** -- a native roadmap-to-issues script, retiring the plan re-entry's prose
   string surgery.
-- **Slice D (Issues 6, 7)** -- the whole-tree `--lifecycle` mode plus the CI gate and the
+- **Slice D (#116, #117)** -- the whole-tree `--lifecycle` mode plus the CI gate and the
   verify-then-delete terminal wiring.
-- **Slice E (Issues 8, 9)** -- the mermaid-parser spike, then the reconciliation check as a
+- **Slice E (#118, #119)** -- the mermaid-parser spike, then the reconciliation check as a
   notice. Hard-gated: reconciliation cannot start until the spike resolves.
 
 The work-slicing (decomposition-strategy) decision above is named as separate from the
-single-pr/multi-pr execution-mode decision, which is recorded with the issues: multi-pr,
-on the incremental-value rationale, with the spike-to-reconciliation merge gate as a
-second independent justification.
+single-pr/multi-pr execution-mode decision: multi-pr, on the incremental-value rationale,
+with the spike-to-reconciliation merge gate as a second independent justification.
 
 ## Implementation Issues
 
-### Milestone: roadmap-plan-standardization
+### Milestone: [roadmap-plan-standardization](https://github.com/tsukumogami/shirabe/milestone/6)
 
 | Issue | Dependencies | Complexity |
 |-------|--------------|------------|
-| <<ISSUE:1>>: docs(references): add shared workflow-principles, issues-table, and dependency-diagram references | None | simple |
+| [#111: docs(references): add shared workflow-principles, issues-table, and dependency-diagram references](https://github.com/tsukumogami/shirabe/issues/111) | None | simple |
 | _Creates the three plugin-root shared references and trims the two skill references to cite them; finalizes the five-principle wording. The foundation every other slice consumes -- the validator is the enforcement twin of these references._ | | |
-| <<ISSUE:2>>: feat(validate): add Markdown issues-table parser and FC05/FC06 content checks | <<ISSUE:1>> | testable |
+| [#112: feat(validate): add Markdown issues-table parser and FC05/FC06 content checks](https://github.com/tsukumogami/shirabe/issues/112) | [#111](https://github.com/tsukumogami/shirabe/issues/111) | testable |
 | _Adds `table.go` (`parseIssuesTable` + `Table`) and the error-level `checkFC05` (schema) and `checkFC06` (cross-reference), wired into the Plan arm and a new Roadmap arm. The one new parser the first pass allows; its `Table` is what the later reconciliation check reuses._ | | |
-| <<ISSUE:3>>: docs(corpus): migrate committed roadmap and plan tables to the canonical profiles | <<ISSUE:2>> | testable |
-| _Migrates the divergent committed roadmap and legacy plan tables onto the canonical profiles so error-level FC05/FC06 pass on the whole corpus. Lands in the same PR as <<ISSUE:2>> so the checks never see an unmigrated corpus._ | | |
-| <<ISSUE:4>>: docs(plan): surface the single-pr/multi-pr decision and add the value-confirmation guard | <<ISSUE:1>> | testable |
-| _Lifts the single-pr/multi-pr rule onto the plan SKILL surface anchored on the usable-value principle, de-conflated from work-slicing, and adds a value-confirmation step that can fail and records-and-proceeds under `--auto`. Shares the record-and-proceed gate shape with <<ISSUE:5>>'s approval gate._ | | |
-| <<ISSUE:5>>: feat(roadmap): add native populate-issues-table script reusing create-issues-batch | <<ISSUE:1>> | testable |
+| [#113: docs(corpus): migrate committed roadmap and plan tables to the canonical profiles](https://github.com/tsukumogami/shirabe/issues/113) | [#112](https://github.com/tsukumogami/shirabe/issues/112) | testable |
+| _Migrates the divergent committed roadmap and legacy plan tables onto the canonical profiles so error-level FC05/FC06 pass on the whole corpus. Lands in the same PR as #112 so the checks never see an unmigrated corpus._ | | |
+| [#114: docs(plan): surface the single-pr/multi-pr decision and add the value-confirmation guard](https://github.com/tsukumogami/shirabe/issues/114) | [#111](https://github.com/tsukumogami/shirabe/issues/111) | testable |
+| _Lifts the single-pr/multi-pr rule onto the plan SKILL surface anchored on the usable-value principle, de-conflated from work-slicing, and adds a value-confirmation step that can fail and records-and-proceeds under `--auto`. Shares the record-and-proceed gate shape with #115's approval gate._ | | |
+| [#115: feat(roadmap): add native populate-issues-table script reusing create-issues-batch](https://github.com/tsukumogami/shirabe/issues/115) | [#111](https://github.com/tsukumogami/shirabe/issues/111) | testable |
 | _Adds `populate-issues-table.sh` that builds a per-feature manifest, reuses the generic `create-issues-batch.sh`, and writes the reserved sections by structural replacement, with issue creation routed through the R14 approval gate. Retires the plan re-entry's prose string surgery for the roadmap case._ | | |
-| <<ISSUE:6>>: feat(validate): add whole-tree --lifecycle mode with L01 and L02 checks | <<ISSUE:2>> | testable |
-| _Adds a `--lifecycle <root>` mode that walks the doc tree and runs Check A (L01: a present roadmap or multi-pr plan must be Active) and Check B (L02: no single-pr plan may exist), reusing the Doc IR and frontmatter parsing <<ISSUE:2>> exercises._ | | |
-| <<ISSUE:7>>: ci(lifecycle): add reusable lifecycle workflow and wire the verify-then-delete terminal | <<ISSUE:6>> | testable |
+| [#116: feat(validate): add whole-tree --lifecycle mode with L01 and L02 checks](https://github.com/tsukumogami/shirabe/issues/116) | [#112](https://github.com/tsukumogami/shirabe/issues/112) | testable |
+| _Adds a `--lifecycle <root>` mode that walks the doc tree and runs Check A (L01: a present roadmap or multi-pr plan must be Active) and Check B (L02: no single-pr plan may exist), reusing the Doc IR and frontmatter parsing #112 exercises._ | | |
+| [#117: ci(lifecycle): add reusable lifecycle workflow and wire the verify-then-delete terminal](https://github.com/tsukumogami/shirabe/issues/117) | [#116](https://github.com/tsukumogami/shirabe/issues/116) | testable |
 | _Adds the reusable lifecycle workflow plus self-caller (no `paths:` filter, read-only) running the `--lifecycle` mode on every PR, wires the verify-then-delete terminal into the cascade, and removes the stale move-to-done wording. Completes the lifecycle enforcement Slice D began._ | | |
-| <<ISSUE:8>>: docs(spike): mermaid-parser feasibility spike for table-diagram reconciliation | <<ISSUE:1>> | simple |
+| [#118: docs(spike): mermaid-parser feasibility spike for table-diagram reconciliation](https://github.com/tsukumogami/shirabe/issues/118) | [#111](https://github.com/tsukumogami/shirabe/issues/111) | simple |
 | _Writes the spike investigating the mermaid graph subset the corpus uses, a line-oriented extraction approach with no external dependency, and the reconciliation strictness. The explicit upstream that gates the reconciliation increment._ | | |
-| <<ISSUE:9>>: feat(validate): add mermaid extractor and checkFC07 table-diagram reconciliation as a notice | <<ISSUE:2>>, <<ISSUE:8>> | testable |
+| [#119: feat(validate): add mermaid extractor and checkFC07 table-diagram reconciliation as a notice](https://github.com/tsukumogami/shirabe/issues/119) | [#112](https://github.com/tsukumogami/shirabe/issues/112), [#118](https://github.com/tsukumogami/shirabe/issues/118) | testable |
 | _Adds `mermaid.go` and `checkFC07` reconciling the parsed `Table` against the extracted diagram, shipped as a notice via `IsNotice` so an unreconciled committed diagram does not redden CI, with a one-line path to error-level promotion after corpus reconciliation. The final, spike-gated increment._ | | |
 
 ## Dependency Graph
 
 ```mermaid
 graph TD
-    I1["#1: shared references"]
-    I2["#2: table parser + FC05/FC06"]
-    I3["#3: migrate committed corpus"]
-    I4["#4: surface decision + value guard"]
-    I5["#5: roadmap populate script"]
-    I6["#6: --lifecycle mode (L01/L02)"]
-    I7["#7: lifecycle CI + terminal wiring"]
-    I8["#8: mermaid-parser spike"]
-    I9["#9: mermaid extractor + FC07 notice"]
+    I111["#111: shared references"]
+    I112["#112: table parser + FC05/FC06"]
+    I113["#113: migrate committed corpus"]
+    I114["#114: surface decision + value guard"]
+    I115["#115: roadmap populate script"]
+    I116["#116: --lifecycle mode (L01/L02)"]
+    I117["#117: lifecycle CI + terminal wiring"]
+    I118["#118: mermaid-parser spike"]
+    I119["#119: mermaid extractor + FC07 notice"]
 
-    I1 --> I2
-    I1 --> I4
-    I1 --> I5
-    I1 --> I8
-    I2 --> I3
-    I2 --> I6
-    I2 --> I9
-    I6 --> I7
-    I8 --> I9
+    I111 --> I112
+    I111 --> I114
+    I111 --> I115
+    I111 --> I118
+    I112 --> I113
+    I112 --> I116
+    I112 --> I119
+    I116 --> I117
+    I118 --> I119
 
     classDef done fill:#c8e6c9
     classDef ready fill:#bbdefb
@@ -116,32 +116,29 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I1 ready
-    class I2,I3,I4,I5,I6,I7,I8,I9 blocked
+    class I111 ready
+    class I112,I113,I114,I115,I116,I117,I118,I119 blocked
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan
 
 ## Implementation Sequence
 
-**Critical path**: <<ISSUE:1>> -> <<ISSUE:8>> -> <<ISSUE:9>> (length 3). The reconciliation
-increment is the longest chain because it is hard-gated behind the references, the table
-parser (<<ISSUE:2>>), and the spike (<<ISSUE:8>>) -- the single genuine hard sequencing
-constraint the design names. The <<ISSUE:1>> -> <<ISSUE:2>> -> <<ISSUE:9>> path is also
-length 3; <<ISSUE:9>> waits on the later of {<<ISSUE:2>>, <<ISSUE:8>>}.
+**Critical path**: #111 -> #118 -> #119 (length 3). The reconciliation increment is the
+longest chain because it is hard-gated behind the references, the table parser (#112), and
+the spike (#118) -- the single genuine hard sequencing constraint the design names. The
+#111 -> #112 -> #119 path is also length 3; #119 waits on the later of {#112, #118}.
 
-**Immediate start**: <<ISSUE:1>> (the only no-dependency issue; the foundation).
+**Immediate start**: #111 (the only no-dependency issue; the foundation).
 
 **Parallelization**:
-- After <<ISSUE:1>>: <<ISSUE:2>>, <<ISSUE:4>>, <<ISSUE:5>>, and <<ISSUE:8>> can proceed in
-  parallel (the four direct children of the references).
-- After <<ISSUE:2>>: <<ISSUE:3>> (bundled into Slice A's PR) and <<ISSUE:6>> can proceed in
-  parallel.
-- After <<ISSUE:6>>: <<ISSUE:7>>.
-- After <<ISSUE:2>> and <<ISSUE:8>>: <<ISSUE:9>>.
+- After #111: #112, #114, #115, and #118 can proceed in parallel (the four direct children
+  of the references).
+- After #112: #113 (bundled into Slice A's PR) and #116 can proceed in parallel.
+- After #116: #117.
+- After #112 and #118: #119.
 
-**Recommended PR order**: Slice A (<<ISSUE:1>>, <<ISSUE:2>>, <<ISSUE:3>>) first, since it is
-the foundation and lands repo-wide error-level table validation. Once Slice A merges,
-Slices B (<<ISSUE:4>>), C (<<ISSUE:5>>), D (<<ISSUE:6>>, <<ISSUE:7>>), and the Slice E spike
-(<<ISSUE:8>>) can proceed in parallel; the reconciliation increment (<<ISSUE:9>>) lands last,
-after the spike resolves.
+**Recommended PR order**: Slice A (#111, #112, #113) first, since it is the foundation and
+lands repo-wide error-level table validation. Once Slice A merges, Slices B (#114), C
+(#115), D (#116, #117), and the Slice E spike (#118) can proceed in parallel; the
+reconciliation increment (#119) lands last, after the spike resolves.

--- a/docs/plans/PLAN-roadmap-plan-standardization.md
+++ b/docs/plans/PLAN-roadmap-plan-standardization.md
@@ -1,0 +1,147 @@
+---
+schema: plan/v1
+status: Draft
+execution_mode: multi-pr
+upstream: docs/designs/DESIGN-roadmap-plan-standardization.md
+milestone: "roadmap-plan-standardization"
+issue_count: 9
+---
+
+# PLAN: roadmap-plan-standardization
+
+## Status
+
+Draft
+
+This plan is in the pre-approval state: the full decomposition is captured below with
+`<<ISSUE:N>>` placeholders, but no GitHub milestone or issues have been created yet.
+Issue creation is a separate, human-authorized step (the R14 approval gate this feature
+itself designs). The plan transitions to Active when the issues are created.
+
+## Scope Summary
+
+Standardize shirabe's own `/roadmap` and `/plan` skills around shared, define-once
+conventions: three plugin-root shared references, a Markdown-table parser plus two
+error-level content checks in `internal/validate`, a migrated committed corpus, the
+single-pr/multi-pr decision surfaced with a value-confirmation guard, a native
+roadmap-to-issues script, and a whole-tree lifecycle CI gate -- with table-diagram
+reconciliation staged behind a mermaid-parser spike as a later increment.
+
+## Decomposition Strategy
+
+**Horizontal.** The design describes loosely-coupled capability slices with stable,
+already-existing interfaces (the `Doc` IR, `create-issues-batch.sh`, the `IsNotice`
+gate) and one explicit prerequisite chain -- the table parser before reconciliation, and
+the mermaid-parser spike before reconciliation. There is no thin end-to-end thread to
+thicken, so this is horizontal decomposition, not a walking skeleton: each issue builds
+one capability fully, and the single hard ordering constraint (spike before
+reconciliation) is captured as dependency edges rather than a skeleton.
+
+The nine issues group into five value-delivering PR slices, each landing observable
+incremental value on its own (the usable-value principle this work surfaces):
+
+- **Slice A (Issues 1, 2, 3)** -- table validation + corpus migration, one PR. References +
+  parser + FC05/FC06 going error-level + the corpus migrated to pass them, bundled so the
+  checks never redden CI on a divergent committed doc in a gap window.
+- **Slice B (Issue 4)** -- the single-pr/multi-pr decision surfaced on the plan skill, anchored
+  on value, with a value-confirmation guard that can fail.
+- **Slice C (Issue 5)** -- a native roadmap-to-issues script, retiring the plan re-entry's prose
+  string surgery.
+- **Slice D (Issues 6, 7)** -- the whole-tree `--lifecycle` mode plus the CI gate and the
+  verify-then-delete terminal wiring.
+- **Slice E (Issues 8, 9)** -- the mermaid-parser spike, then the reconciliation check as a
+  notice. Hard-gated: reconciliation cannot start until the spike resolves.
+
+The work-slicing (decomposition-strategy) decision above is named as separate from the
+single-pr/multi-pr execution-mode decision, which is recorded with the issues: multi-pr,
+on the incremental-value rationale, with the spike-to-reconciliation merge gate as a
+second independent justification.
+
+## Implementation Issues
+
+### Milestone: roadmap-plan-standardization
+
+| Issue | Dependencies | Complexity |
+|-------|--------------|------------|
+| <<ISSUE:1>>: docs(references): add shared workflow-principles, issues-table, and dependency-diagram references | None | simple |
+| _Creates the three plugin-root shared references and trims the two skill references to cite them; finalizes the five-principle wording. The foundation every other slice consumes -- the validator is the enforcement twin of these references._ | | |
+| <<ISSUE:2>>: feat(validate): add Markdown issues-table parser and FC05/FC06 content checks | <<ISSUE:1>> | testable |
+| _Adds `table.go` (`parseIssuesTable` + `Table`) and the error-level `checkFC05` (schema) and `checkFC06` (cross-reference), wired into the Plan arm and a new Roadmap arm. The one new parser the first pass allows; its `Table` is what the later reconciliation check reuses._ | | |
+| <<ISSUE:3>>: docs(corpus): migrate committed roadmap and plan tables to the canonical profiles | <<ISSUE:2>> | testable |
+| _Migrates the divergent committed roadmap and legacy plan tables onto the canonical profiles so error-level FC05/FC06 pass on the whole corpus. Lands in the same PR as <<ISSUE:2>> so the checks never see an unmigrated corpus._ | | |
+| <<ISSUE:4>>: docs(plan): surface the single-pr/multi-pr decision and add the value-confirmation guard | <<ISSUE:1>> | testable |
+| _Lifts the single-pr/multi-pr rule onto the plan SKILL surface anchored on the usable-value principle, de-conflated from work-slicing, and adds a value-confirmation step that can fail and records-and-proceeds under `--auto`. Shares the record-and-proceed gate shape with <<ISSUE:5>>'s approval gate._ | | |
+| <<ISSUE:5>>: feat(roadmap): add native populate-issues-table script reusing create-issues-batch | <<ISSUE:1>> | testable |
+| _Adds `populate-issues-table.sh` that builds a per-feature manifest, reuses the generic `create-issues-batch.sh`, and writes the reserved sections by structural replacement, with issue creation routed through the R14 approval gate. Retires the plan re-entry's prose string surgery for the roadmap case._ | | |
+| <<ISSUE:6>>: feat(validate): add whole-tree --lifecycle mode with L01 and L02 checks | <<ISSUE:2>> | testable |
+| _Adds a `--lifecycle <root>` mode that walks the doc tree and runs Check A (L01: a present roadmap or multi-pr plan must be Active) and Check B (L02: no single-pr plan may exist), reusing the Doc IR and frontmatter parsing <<ISSUE:2>> exercises._ | | |
+| <<ISSUE:7>>: ci(lifecycle): add reusable lifecycle workflow and wire the verify-then-delete terminal | <<ISSUE:6>> | testable |
+| _Adds the reusable lifecycle workflow plus self-caller (no `paths:` filter, read-only) running the `--lifecycle` mode on every PR, wires the verify-then-delete terminal into the cascade, and removes the stale move-to-done wording. Completes the lifecycle enforcement Slice D began._ | | |
+| <<ISSUE:8>>: docs(spike): mermaid-parser feasibility spike for table-diagram reconciliation | <<ISSUE:1>> | simple |
+| _Writes the spike investigating the mermaid graph subset the corpus uses, a line-oriented extraction approach with no external dependency, and the reconciliation strictness. The explicit upstream that gates the reconciliation increment._ | | |
+| <<ISSUE:9>>: feat(validate): add mermaid extractor and checkFC07 table-diagram reconciliation as a notice | <<ISSUE:2>>, <<ISSUE:8>> | testable |
+| _Adds `mermaid.go` and `checkFC07` reconciling the parsed `Table` against the extracted diagram, shipped as a notice via `IsNotice` so an unreconciled committed diagram does not redden CI, with a one-line path to error-level promotion after corpus reconciliation. The final, spike-gated increment._ | | |
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    I1["#1: shared references"]
+    I2["#2: table parser + FC05/FC06"]
+    I3["#3: migrate committed corpus"]
+    I4["#4: surface decision + value guard"]
+    I5["#5: roadmap populate script"]
+    I6["#6: --lifecycle mode (L01/L02)"]
+    I7["#7: lifecycle CI + terminal wiring"]
+    I8["#8: mermaid-parser spike"]
+    I9["#9: mermaid extractor + FC07 notice"]
+
+    I1 --> I2
+    I1 --> I4
+    I1 --> I5
+    I1 --> I8
+    I2 --> I3
+    I2 --> I6
+    I2 --> I9
+    I6 --> I7
+    I8 --> I9
+
+    classDef done fill:#c8e6c9
+    classDef ready fill:#bbdefb
+    classDef blocked fill:#fff9c4
+    classDef needsDesign fill:#e1bee7
+    classDef needsPrd fill:#b3e5fc
+    classDef needsSpike fill:#ffcdd2
+    classDef needsDecision fill:#d1c4e9
+    classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
+    classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
+
+    class I1 ready
+    class I2,I3,I4,I5,I6,I7,I8,I9 blocked
+```
+
+**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan
+
+## Implementation Sequence
+
+**Critical path**: <<ISSUE:1>> -> <<ISSUE:8>> -> <<ISSUE:9>> (length 3). The reconciliation
+increment is the longest chain because it is hard-gated behind the references, the table
+parser (<<ISSUE:2>>), and the spike (<<ISSUE:8>>) -- the single genuine hard sequencing
+constraint the design names. The <<ISSUE:1>> -> <<ISSUE:2>> -> <<ISSUE:9>> path is also
+length 3; <<ISSUE:9>> waits on the later of {<<ISSUE:2>>, <<ISSUE:8>>}.
+
+**Immediate start**: <<ISSUE:1>> (the only no-dependency issue; the foundation).
+
+**Parallelization**:
+- After <<ISSUE:1>>: <<ISSUE:2>>, <<ISSUE:4>>, <<ISSUE:5>>, and <<ISSUE:8>> can proceed in
+  parallel (the four direct children of the references).
+- After <<ISSUE:2>>: <<ISSUE:3>> (bundled into Slice A's PR) and <<ISSUE:6>> can proceed in
+  parallel.
+- After <<ISSUE:6>>: <<ISSUE:7>>.
+- After <<ISSUE:2>> and <<ISSUE:8>>: <<ISSUE:9>>.
+
+**Recommended PR order**: Slice A (<<ISSUE:1>>, <<ISSUE:2>>, <<ISSUE:3>>) first, since it is
+the foundation and lands repo-wide error-level table validation. Once Slice A merges,
+Slices B (<<ISSUE:4>>), C (<<ISSUE:5>>), D (<<ISSUE:6>>, <<ISSUE:7>>), and the Slice E spike
+(<<ISSUE:8>>) can proceed in parallel; the reconciliation increment (<<ISSUE:9>>) lands last,
+after the spike resolves.

--- a/docs/prds/PRD-roadmap-plan-standardization.md
+++ b/docs/prds/PRD-roadmap-plan-standardization.md
@@ -1,6 +1,6 @@
 ---
 schema: prd/v1
-status: Draft
+status: Accepted
 problem: |
   shirabe's roadmap and plan workflows are procedure-rich but
   principle-poor. The issues table has several drifting schemas, the
@@ -30,7 +30,7 @@ upstream: docs/briefs/BRIEF-roadmap-plan-standardization.md
 
 ## Status
 
-Draft
+Accepted
 
 This PRD picks up the requirements work scoped by
 `docs/briefs/BRIEF-roadmap-plan-standardization.md`. It owns the

--- a/docs/prds/PRD-roadmap-plan-standardization.md
+++ b/docs/prds/PRD-roadmap-plan-standardization.md
@@ -1,0 +1,728 @@
+---
+schema: prd/v1
+status: Draft
+problem: |
+  shirabe's roadmap and plan workflows are procedure-rich but
+  principle-poor. The issues table has several drifting schemas, the
+  dependency diagram has a canonical spec docs apply inconsistently, the
+  roadmap has no native scripted path to its own issues table, the
+  single-pr/multi-pr decision is buried and not anchored on usable
+  value, the lifecycle is contradictory and unenforced (no review gate
+  before issues are created, three-way-conflicting terminal), and
+  validation checks section presence but never table or diagram
+  contents. The shared parts were never named as shared and the few real
+  principles are each trapped in one skill.
+goals: |
+  The roadmap and plan workflows derive from one small, named principle
+  set instead of restating procedure. The issues table and dependency
+  diagram are each defined once and consumed by both workflows through
+  two altitude profiles. Validation moves from section-presence to table
+  and diagram contents, staged by blast radius. The single-pr/multi-pr
+  decision is surfaced, anchored on usable value, and de-conflated from
+  work-slicing, with a value-confirmation guard that can fail. The
+  roadmap gets a first-class scripted path to its issues table. The
+  lifecycle gates issue creation on approval and ends in one terminal,
+  verify-then-delete, enforced by two stateless CI checks.
+upstream: docs/briefs/BRIEF-roadmap-plan-standardization.md
+---
+
+# PRD: roadmap-plan-standardization
+
+## Status
+
+Draft
+
+This PRD picks up the requirements work scoped by
+`docs/briefs/BRIEF-roadmap-plan-standardization.md`. It owns the
+requirements for the principle set, the shared issues-table framework
+and its two altitude profiles, the dependency-diagram convention and its
+enforcement, the validation content checks, the decision-surfacing
+fixes, and the enforced lifecycle. Implementation specifics — the
+shared-reference file layout, the validation check codes, the
+roadmap-to-issues script interface, the mermaid-parser internals, and
+the exact principle wording — land in the downstream
+`DESIGN-roadmap-plan-standardization.md` and its plan.
+
+This PRD closes the brief's four open questions — which principles make
+the named set, how strict the first validation pass is (including the
+mermaid-parser spike), how much altitude the two table profiles share,
+and the enforcement surface for the lifecycle checks — and additionally
+settles the `--auto` behavior of the value-confirmation step, which the
+brief's decision-surfacing scope raised but did not number among its
+open questions. Positions are recorded in the Decisions and Trade-offs
+section with rationale grounded in the current skill code.
+
+## Problem Statement
+
+shirabe's tactical chain runs `/roadmap` to `/brief` to `/prd` to
+`/design` to `/plan`. The roadmap and plan workflows sit at opposite
+ends of that chain and already share more than they appear to: the same
+lifecycle vocabulary, a reserved-section handoff where the roadmap stubs
+an issues table and a dependency graph that the plan fills, and the same
+spec-driven validator. The trouble is not that the workflows are
+unrelated. It is that the shared parts were never named as shared, and
+the conventions that should hold them together have drifted.
+
+The author writing a roadmap or a plan is the affected user, and six
+gaps make the drift concrete.
+
+- **The issues table has several incompatible schemas in active use.**
+  The plan keys its table on issues (`Issue | Dependencies | Complexity`)
+  and still accepts a legacy separate-`Title` column set; the roadmap
+  keys its reserved table on features (`Feature | Issues | Status`); and
+  at least one committed roadmap diverges from even that
+  (`Feature | Status | Downstream Artifact`). One section name spans two
+  altitudes, and an author writing either doc has no single format to
+  copy, so each new table perpetuates whichever variant the author saw
+  first.
+
+- **The dependency diagram has a canonical spec docs ignore.** A solid
+  diagram spec already exists in `plan-doc-structure.md` (mermaid syntax
+  rules, a fixed status-class palette, a legend), but committed docs use
+  partial style sets, ad-hoc colors, inline-break labels, and differently
+  worded legends. The spec is correct and unenforced.
+
+- **The roadmap has no native path to its issues table.** The roadmap
+  writes empty reserved placeholders and expects them filled later. The
+  only fill path is to re-enter the plan workflow in a special mode that
+  rewrites the placeholders through in-prose string surgery — not a
+  script, the way the plan workflow populates its own table. A roadmap
+  author who wants a populated table has to drive a second workflow
+  against their own document and hope the string match holds.
+
+- **The single-pr/multi-pr decision is buried, conflated, and not
+  anchored on usable value.** The rule (default to one PR, escape to
+  multiple only on a hard constraint) lives in a lazily loaded
+  `phase-3-decomposition.md` reference, never appears on the skill
+  surface, and sits tangled with the separate work-slicing decision. It
+  also misses the thing that should drive the call: whether each PR lands
+  usable value. When the input is a roadmap the plan goes multi-pr, which
+  is the right outcome, but it reaches that outcome by mechanism (the
+  input is a roadmap) rather than by the value principle, and nothing
+  confirms each feature actually delivers observable incremental value.
+
+- **Validation checks presence, never contents.** `internal/validate/`
+  confirms required sections exist (FC04), frontmatter fields are present
+  (FC01), status is valid (FC02), and status agrees between frontmatter
+  and body (FC03). It never tokenizes a Markdown table or a fenced
+  `mermaid` block — there is no table parser and no mermaid node/edge
+  parser anywhere in the package. A doc with a malformed table, a table
+  and diagram that disagree, or a dangling cross-reference passes as long
+  as the headings are present.
+
+- **The lifecycle is inconsistent, contradictory, and unenforced.** The
+  states exist (Draft, Active, Done), but the terminal is three-way
+  contradictory: the live `/work-on` cascade deletes a completed plan
+  (`git rm`), `plan-doc-structure.md` still says move it to a
+  `docs/plans/done/` archive, and a completed roadmap is kept forever.
+  The transitions carry little discipline: a multi-pr plan or roadmap
+  creates GitHub issues with no review gate, and nothing in CI holds a
+  doc to the state its mode requires — a single-pr plan that should be
+  ephemeral can reach main, and a multi-pr doc can merge before it is
+  ready.
+
+Underneath all six is the same root: the workflows are specified as
+procedures with local rationale or none, and the few real principles
+that exist are each trapped in one skill. An author follows the steps
+without the reasons, so when a step does not fit their case they have
+nothing to reason from. Most of the machinery already exists; the gap is
+that the shared parts are not named as shared, the formats are not
+defined once, and the principles that would let an author make the right
+call are not surfaced where the call gets made.
+
+## Goals
+
+1. **Name a small, load-bearing principle set** that both workflows
+   derive from instead of restating procedure, authored to be reusable
+   by sibling doc types later but wired only to roadmap and plan in this
+   work.
+
+2. **Define the issues table once, with two altitude profiles.** One
+   canonical framework — shared columns, shared validation, shared
+   rendering — parameterized into a roadmap profile (feature-keyed) and a
+   plan profile (issue-keyed), replacing the drifting schemas while
+   preserving the altitude distinction.
+
+3. **Promote the dependency-diagram spec into a shared reference both
+   workflows consume, and enforce it in CI** so the spec stops being an
+   unheld ideal.
+
+4. **Extend validation from section-presence to table and diagram
+   contents,** staged so the checks that need no new parser land first
+   and the check that needs a mermaid parser lands later, behind a spike.
+
+5. **Surface and re-anchor the single-pr/multi-pr decision.** Lift it to
+   the skill surface, anchor it on usable value, de-conflate it from
+   work-slicing, and add a value-confirmation guard that can fail.
+
+6. **Give the roadmap a first-class scripted path to its issues table,**
+   replacing the brittle in-prose string surgery of the plan re-entry.
+
+7. **Install one enforced lifecycle with a single terminal.** Gate issue
+   creation on approval, rest at Active, reach Done, and retire by
+   verified deletion — with two stateless CI checks holding docs to the
+   states CI can observe.
+
+## User Stories
+
+**As a roadmap author who wants my issues table populated**, I want a
+first-class scripted path built for the roadmap so that I get a
+populated, correctly feature-keyed table without re-driving the plan
+workflow against my own document or depending on a fragile string match.
+
+**As a plan author deciding PR shape**, I want the single-pr/multi-pr
+principle — every PR lands usable value, default to one, split only on a
+hard constraint or genuine incremental value — on the skill surface and
+separated from the work-slicing decision, so that I land the right call
+because each PR's value is what I weighed, not the input's type.
+
+**As an author whose table or diagram has drifted**, I want validation
+to fail with a message naming the specific table or diagram defect — a
+column out of schema, a row the diagram does not account for, a
+cross-reference to a missing row — in both my local check and CI, so
+that I catch the drift before merge instead of passing on headings alone.
+
+**As an author starting a new roadmap or plan**, I want one shared
+reference that defines the table format and the diagram convention once,
+so that I copy a known-good shape parameterized to my altitude and
+produce a document that conforms by construction.
+
+**As an author moving a multi-pr doc through its lifecycle**, I want the
+draft to stop for my approval before any GitHub issue is created — with
+approval being the act that creates the issues and moves the doc to
+Active — and I want a completed doc to retire by verified deletion, so
+that issues are never filed before I sign off and a finished doc gets a
+clean end.
+
+**As an author of an ephemeral single-pr plan**, I want CI to be red
+while the plan file is present and green once I delete it, so that the
+plan never reaches main and "gone before merge" is enforced without CI
+having to know which commit is the merge.
+
+**As a maintainer running `/roadmap` or `/plan` under `--auto`**, I want
+the value-confirmation step to record its judgment and continue rather
+than deadlock waiting for a human who is not there, while still
+surfacing a failed judgment prominently, so that batch and CI invocations
+keep their non-interactive guarantee.
+
+## Requirements
+
+### Functional Requirements
+
+**R1: The named principle set.** The standardization defines exactly
+five principles in a shared reference both workflows derive from. The set
+is:
+
+1. **Usable value is the unit of work.** Every PR and every roadmap
+   feature delivers observable value on its own; split only for a hard
+   constraint or genuine incremental value, never by mechanism.
+2. **Default to the lowest ceremony.** Reach for the least machinery the
+   work needs (one PR over many; a self-contained PLAN doc over GitHub
+   issues) and escalate only when a named condition forces it.
+3. **Decisions need a durable home.** A choice that affects downstream
+   work or rests on a falsifiable assumption is recorded where a later
+   reader finds it, not left implicit in the procedure.
+4. **One canonical format per concern, defined once.** Each shared shape
+   (the issues table, the dependency diagram) has a single source both
+   workflows consume.
+5. **Strictness tracks blast radius.** How hard a rule is enforced scales
+   with the consequence of getting it wrong.
+
+Each workflow's surfaced rules reference the principle they derive from.
+The exact wording of each principle is the downstream design's to finalize;
+the set membership and the meaning of each are fixed here.
+
+**R2: Shared issues-table framework — shared core.** One issues-table
+framework is defined once and consumed by both workflows. The shared core,
+common to both profiles, is:
+
+- A **key column** in position 1 — the primary entity link. The header
+  label and link target are parameterized by profile (R3, R4).
+- A **Dependencies column** — `None` or comma-separated clickable links
+  to other rows' keys, with identical semantics at both altitudes.
+- A **Status column** — an explicit completion/lifecycle marker for the
+  row.
+
+The shared core also defines shared **rendering**: an italic description
+row of 1-3 sentences immediately following each entity row, and the
+strikethrough-on-done rule applied across the entity row, its description
+row, and a child reference row when present. (The convention that the
+description rows read as a sequential build narrative top-to-bottom is
+authoring guidance, not a validated property.)
+
+**R3: Plan profile (issue-keyed).** The plan profile parameterizes the
+shared core with:
+
+- Key column header **`Issue`**, link form `[#N: <title>](<url>)`.
+- A profile-specific **Complexity** column (`simple` / `testable` /
+  `critical`).
+- A profile-specific **child reference row** (`^_Child: ..._`) for
+  `tracks-design` / `tracks-plan` issues.
+
+The canonical plan table is the issue-keyed `Issue | Dependencies |
+Complexity` shape. The legacy separate-`Title` plan form (`Issue | Title |
+Dependencies | Complexity`) is migrated into the canonical shape by
+folding the title into the issue link text; it is not perpetuated as a
+permanent dual format.
+
+**R4: Roadmap profile (feature-keyed).** The roadmap profile
+parameterizes the shared core with:
+
+- Key column header **`Feature`**, label form naming the feature.
+- A profile-specific **Issues** column — the one-to-many fan-out (the
+  list of issue links the feature decomposed into) that encodes the
+  feature-to-issues altitude jump. This is the roadmap profile's defining
+  addition.
+
+The roadmap profile replaces the current `Feature | Issues | Status`
+reserved stub and every committed roadmap-table divergence — including the
+`Feature | Status | Downstream Artifact` and `Issue | Phase | Dependencies
+| Label` shapes in the committed corpus. Migration of these existing
+shapes into the roadmap profile is in scope; the per-document migration
+mechanics are the downstream design's.
+
+**R5: Shared dependency-diagram convention.** The existing canonical
+diagram spec (mermaid syntax rules, the fixed status-class palette, the
+legend) is promoted from `plan-doc-structure.md` into a shared reference
+both workflows consume. The convention is defined once and applies
+identically to roadmap and plan dependency graphs.
+
+**R6: Validation content check — issues-table schema conformance.**
+Validation checks that an issues table's column count and headers match
+the doc's altitude profile and that row shape (entity row, description
+row, child reference row where present) is well-formed. This check is
+error-level in the first content-validation pass. It requires a new
+Markdown table parser (none exists in `internal/validate/` today).
+
+**R7: Validation content check — cross-reference existence.** Validation
+checks that every value in a Dependencies cell names a key that exists as
+a row in the same table. This check is error-level in the first
+content-validation pass and reuses the R6 table parser. It is
+document-local; no graph model is required.
+
+**R8: Validation content check — table-diagram reconciliation (staged).**
+Validation reconciles the issues table against the dependency diagram:
+every table key appears as a diagram node and vice versa, and edges agree
+with the Dependencies column. This check is **staged into a later
+increment** than R6 and R7 because it is the only content check that
+requires a new mermaid node/edge parser, and its retrofit blast radius is
+the entire committed-diagram corpus. When it lands, it follows the
+existing schema-gate precedent: it is introduced as a non-blocking notice
+first, then promoted to error once the committed corpus conforms.
+
+**R9: Mermaid-parser spike.** Before R8 can be specified, a feasibility
+spike investigates what subset of mermaid `graph` syntax the committed
+docs actually use, how to parse it without a full mermaid grammar, and how
+strictly to reconcile (exact node-set equality versus subset). The spike
+is an explicit upstream of the R8 increment and keeps R8 off the first
+pass's path while making the dependency visible.
+
+**R10: Single-pr/multi-pr decision surfaced and re-anchored.** The plan
+workflow lifts the single-pr/multi-pr decision to the skill surface (out
+of the lazily loaded reference), anchors it on the usable-value principle
+(R1.1), and separates it from the work-slicing decision it is tangled with
+today. The surfaced rule states the default (one PR) and its named escape
+conditions (a hard constraint forces multiple, or each PR is independently
+useful). A roadmap is multi-pr because each feature should deliver
+observable incremental value as a cohesive deliverable — grounded in the
+value principle, not reached by the mechanism "the input is a roadmap."
+
+**R11: Value-confirmation guard.** A confirmation step checks that each
+unit delivers observable incremental value: every feature for a roadmap,
+and each PR for a plan whose split delivers incremental value (whether or
+not a hard constraint also forces the split). The guard can fail: a unit
+that is not a standalone increment is flagged as a mis-decomposition to
+re-scope or merge with a neighbor, not waved through. The guard names the
+specific failing unit and why it failed the value test.
+
+**R12: Value-confirmation under `--auto`.** Under `--auto`, the R11 guard
+does not hard-stop. It records a decision block per the existing
+`decision-protocol.md` and continues. A unit that clearly delivers
+standalone value is recorded with `status="confirmed"`. A unit that fails
+the value test (R11 — not a standalone increment) or that the guard cannot
+clearly classify either way (an ambiguous unit) is recorded with
+`status="assumed"` and `high` review priority, which surfaces it in the
+terminal summary and the PR body for the author to act on. Failing and
+ambiguous units route to the same recorded outcome on purpose: both are
+units the author must review, neither is waved through. The escalation
+path (`status="escalated"`, spawn `/decision`) remains available for a
+judgment ever deemed practically irreversible and is itself non-blocking
+under `--auto`.
+
+**R13: First-class roadmap-to-issues path.** The roadmap gets a scripted
+path that populates its own issues table, keyed on features at the
+roadmap's altitude, without re-driving the plan workflow against the
+document and without depending on in-prose string surgery. The path is
+native to the roadmap, mirroring how the plan workflow populates its own
+table with a script rather than prose edits.
+
+**R14: Enforced lifecycle — issue creation gated on approval.** A
+multi-pr plan or roadmap finishes its draft and stops for the author's
+approval before any GitHub issue is created. Approval is the act that
+creates the issues and moves the doc to Active; issue creation is no
+longer a silent side effect of finishing the draft.
+
+**R15: One terminal — verify-then-delete.** A multi-pr plan or roadmap
+rests at Active while the work lands, reaches Done when the work is
+complete, and is retired by deletion once the author verifies the
+delivered work. This is the single terminal for both plans and roadmaps,
+a deliberate change for roadmaps (which are kept forever today) and a
+unification of the plan's self-contradicting terminal. The stale
+move-to-`docs/plans/done/` archive wording is retired.
+
+**R16: Single-pr plan is ephemeral.** A single-pr plan lives only on its
+own PR branch and is verified and deleted before that PR merges, so it
+never reaches main.
+
+**R17: CI lifecycle enforcement surface.** The two stateless lifecycle
+checks run as a **whole-tree scan on the PR**, alongside (not replacing)
+the existing changed-files doc-validator:
+
+- **Check A — multi-pr may only merge at Active or Done.** The scan reads
+  the frontmatter status of every roadmap and multi-pr plan in the
+  checked-out tree and fails if any is present with a status that is
+  neither `Active` nor `Done`. `Active` is the state a multi-pr doc merges
+  in while the work lands; `Done` is an accepted-at-merge status because a
+  completed doc sits in the tree until its permitted human deletion (R15,
+  R18) — Check A must not fail a Done doc awaiting that deletion. The check
+  bars merging a multi-pr doc still in Draft (issues not yet created, no
+  approval). A whole-tree scan is required because a changed-files diff
+  cannot see a doc the PR does not touch.
+- **Check B — single-pr absent-at-merge.** The scan fails if any PLAN doc
+  with `execution_mode: single-pr` exists in the tree, and passes once it
+  is deleted — the stateless presence test the brief specifies, with no
+  need to identify the merge commit. A changed-files diff cannot carry
+  this check because presence-without-touch is invisible to a diff.
+
+The existing changed-files validators keep running for content and
+frontmatter checks; the lifecycle gate is a separate concern that needs
+whole-tree visibility.
+
+**R18: Verified deletion is permitted, not performed.** CI permits but
+never performs or demands the deletion of a Done multi-pr doc. Check B's
+presence test is scoped to single-pr plans only, so a Done multi-pr doc
+sitting in the tree is valid to CI; the human verifies the delivered work
+and deletes the doc as a separate, manual act that CI permits (a clean
+deletion PR) but never requires. CI enforces a single-pr plan's deletion
+(Check B fails while present) and only permits a multi-pr doc's deletion.
+
+### Non-Functional Requirements
+
+**R19: Reuse existing validation infrastructure where possible.** R6 and
+R7 extend the existing `internal/validate/` package and run through the
+existing CLI and the existing reusable validation workflow. The only new
+parsing machinery the first pass introduces is the Markdown table parser
+R6 and R7 share. The mermaid parser (R8/R9) is the sole net-new parser and
+is deferred to its own increment.
+
+**R20: Incremental rollout, no retroactive breakage on day one.** The
+first content-validation pass (R6, R7) must not turn CI red on
+already-committed docs solely because a higher-strictness check
+(reconciliation, R8) has not yet been satisfied. R8 follows the
+notice-then-error promotion path so the committed-diagram corpus can be
+reconciled before reconciliation becomes blocking.
+
+**R21: No change to sibling artifact types beyond convention adoption.**
+The roadmap and plan workflows are the drivers. Other doc types may
+consume the shared table and diagram conventions where they already have a
+table or a diagram, but reshaping their own formats, naming, or lifecycles
+is out of scope.
+
+**R22: Public-visibility cleanliness.** All shared references, surfaced
+rules, and validation messages are public-repo clean: no private repos,
+paths, filenames, issue numbers, or pre-announcement features.
+
+## Acceptance Criteria
+
+- [ ] A shared reference names exactly the five principles in R1, and both
+  the roadmap and plan workflow surfaces reference the principle each rule
+  derives from.
+- [ ] A single issues-table framework defines the shared core (key column,
+  Dependencies, Status) and the shared rendering (italic description row,
+  strikethrough-on-done) in one place, consumed by both workflows.
+- [ ] The plan profile renders `Issue | Dependencies | Complexity` with the
+  child reference row available; a legacy separate-`Title` plan table is
+  migrated into the canonical shape rather than accepted as a permanent
+  variant.
+- [ ] The roadmap profile renders a feature-keyed table with the `Issues`
+  fan-out column and replaces the prior reserved stub and every committed
+  roadmap-table divergence (including the `Feature | Status | Downstream
+  Artifact` and `Issue | Phase | Dependencies | Label` shapes).
+- [ ] The dependency-diagram convention lives in one shared reference both
+  workflows consume, and CI fails a roadmap or plan whose diagram violates
+  the palette or legend convention.
+- [ ] Running validation against an issues table whose columns do not match
+  its altitude profile fails with an error naming the schema defect (R6).
+- [ ] Running validation against a table with a Dependencies value that
+  names no existing row fails with an error naming the dangling
+  cross-reference (R7).
+- [ ] Table-diagram reconciliation (R8) is not error-level in the first
+  pass; it lands in a later increment as a notice first, gated on the
+  mermaid-parser spike (R9).
+- [ ] A mermaid-parser spike artifact exists and is named as the upstream
+  of the reconciliation increment before reconciliation is specified.
+- [ ] The plan skill surface states the single-pr/multi-pr default and its
+  named escape conditions, anchored on usable value and separated from the
+  work-slicing decision (R10).
+- [ ] The value-confirmation guard flags a roadmap feature or plan PR that
+  is not a standalone increment, naming the unit and the reason, and does
+  not wave it through (R11).
+- [ ] Under `--auto`, the value-confirmation guard records a confirmed or
+  assumed decision block (assumed at `high` review priority for a
+  failing/ambiguous unit) and continues without hard-stopping; the assumed
+  block appears in the PR body and terminal summary (R12).
+- [ ] A roadmap author populates the roadmap's issues table through a
+  scripted, feature-keyed path without re-entering the plan workflow and
+  without in-prose string surgery (R13).
+- [ ] A multi-pr plan or roadmap creates no GitHub issue until the author
+  approves; approval creates the issues and moves the doc to Active (R14).
+- [ ] A completed multi-pr plan or roadmap reaches Done and is retired by
+  deletion after the author verifies the work; the stale
+  move-to-`docs/plans/done/` wording is gone (R15).
+- [ ] A single-pr plan exists only on its PR branch and is deleted before
+  that PR merges (R16).
+- [ ] CI Check A fails when any roadmap or multi-pr plan in the tree has a
+  status that is neither Active nor Done, evaluated by a whole-tree scan,
+  and passes a Done multi-pr doc awaiting its permitted deletion (R17).
+- [ ] CI Check B fails while any `execution_mode: single-pr` PLAN exists in
+  the tree and passes once it is deleted (R17).
+- [ ] CI does not fail on, demand, or perform the deletion of a Done
+  multi-pr doc; the verified deletion is a permitted human act (R18).
+- [ ] The first content-validation pass introduces no new validation
+  binary or parallel pipeline: R6 and R7 extend the existing
+  `internal/validate/` package and run through the existing CLI and
+  reusable workflow, and the only new parser in the first pass is the
+  shared Markdown table parser (R19).
+- [ ] The first content-validation pass does not turn CI red on
+  already-committed docs solely for unmet reconciliation strictness (R20).
+- [ ] No sibling artifact type's own format, naming, or lifecycle is
+  changed by this work; sibling types are touched only where they adopt the
+  shared table or diagram convention (R21).
+- [ ] A scan of the shared references, the surfaced workflow rules, and the
+  validation messages finds no private repo names, paths, filenames, issue
+  numbers, or pre-announcement features (R22).
+
+## Out of Scope
+
+This PRD scopes the standardization of the roadmap and plan workflows
+around shared, principle-driven conventions. It explicitly excludes:
+
+- **Implementation specifics.** The shared-reference file layout, the
+  validation check codes, the roadmap-to-issues script interface, the
+  mermaid-parser internals, and the final principle wording are the
+  downstream design's job, not this PRD's.
+- **Issue-tracker mechanics.** Validation here checks a document's own
+  table and diagram contents. Network-dependent checks against live
+  issue-tracker state are a separate, optional concern that can follow as a
+  second workflow if warranted at all.
+- **Reshaping sibling artifact types.** Other doc types may adopt the
+  shared table and diagram conventions where they already have a table or a
+  diagram (R21), but changing their own formats, naming, or lifecycles is
+  out.
+- **The progress-tracking tables some docs carry.** These are a separate
+  concern from the issues table this work standardizes.
+- **A branch-protection / push-to-main gate.** The stateless PR-time
+  whole-tree scan (R17) is equivalent to an at-merge reading for both
+  checks. A branch-protection gate is held in reserve as a later hardening
+  option if a stronger at-the-merge-commit guarantee is ever needed; it is
+  not part of this work.
+- **Promoting reconciliation to error-level in the first pass.**
+  Reconciliation (R8) is deliberately staged into a later increment; making
+  it blocking on day one is out of scope.
+
+## Known Limitations
+
+- **The first pass leaves diagram drift uncaught.** Until the R8
+  reconciliation increment lands, a table and diagram that disagree pass
+  the first content-validation pass (R6/R7 catch schema and cross-reference
+  defects, not table-diagram disagreement). This is a deliberate
+  consequence of staging by blast radius; the gap closes when R8 ships.
+
+- **An `--auto` run can produce a mis-decomposed roadmap that reaches the
+  draft/PR stage.** Because R12 is record-and-proceed, a failed value
+  judgment under `--auto` does not block the run; the author must notice
+  the `high`-priority assumed block in the PR body or terminal summary and
+  act on it. The multi-pr approval gate (R14) is a second backstop before
+  issues are created.
+
+- **The whole-tree scan re-reads unchanged docs on every PR.** Check A and
+  Check B scan the full tree rather than the diff, so an unrelated PR can
+  fail because of a doc it did not touch (for example, a single-pr plan
+  left on the branch). This is the intended behavior — it is how
+  presence-without-touch becomes observable — but it means a doc's
+  lifecycle state can block a PR that has nothing to do with it.
+
+## Decisions and Trade-offs
+
+### Decision 1: Five principles, collapsing "one canonical format" and "formats defined once"
+
+**Decision.** The named set is five principles (R1). The brief's two
+candidates "one canonical format per concern" and "formats defined once"
+merge into a single principle (R1.4); the other four candidates each earn
+a place unchanged.
+
+**Alternatives considered.**
+
+- *Keep all six as distinct principles.* Rejected: "one canonical format
+  per concern" is the outcome and "formats defined once" is the mechanism
+  that produces it — the brief itself fuses them in the User Outcome.
+  Surfacing both would be the decorative move the brief warns against.
+- *Collapse "lowest-ceremony default" into "usable value."* Rejected: they
+  look adjacent but answer different questions. Lowest-ceremony governs
+  artifact ceremony (one PR or many; a PLAN doc or GitHub issues); usable
+  value governs the shape of the deliverable (does each unit land observable
+  value). They can pull in opposite directions, and an author needs both
+  visible to land the single-pr/multi-pr call.
+
+**Rationale.** Each of the five is the stated reason behind machinery
+already in the skills, so each lets an author reason at an edge the
+procedure does not cover — the brief's root-cause fix. Five clears the
+brief's "small enough to be load-bearing rather than decorative" bar, and
+the one merge removes the only genuine redundancy.
+
+### Decision 2: First validation pass is schema conformance plus cross-reference; reconciliation is staged behind a spike
+
+**Decision.** The first content-validation pass lands issues-table schema
+conformance (R6) and cross-reference existence (R7) at error-level.
+Table-diagram reconciliation (R8) is staged into a later increment, gated
+on a mermaid-parser spike (R9), and lands as a notice before being promoted
+to error.
+
+**Alternatives considered.**
+
+- *Land all three content checks strict on day one.* Rejected on two
+  grounds. Reconciliation is the only check that needs a mermaid node/edge
+  parser, which does not exist in `internal/validate/` today. And its
+  retrofit blast radius is the entire committed-diagram corpus — every
+  committed doc with a hand-built diagram that drifts from its table would
+  turn CI red on the next PR that touches it, even a prose-only PR, because
+  the validator re-checks the whole changed file.
+- *Adopt all three incrementally as notices.* Rejected: schema conformance
+  and cross-reference have a small, localized blast radius (a malformed row
+  or dangling link is rarer and more contained than diagram drift) and need
+  no new parser, so holding them back as notices would weaken the first
+  pass for no retrofit benefit.
+
+**Rationale.** This is the seam the work splits on: two checks share one
+new table parser and have a contained retrofit cost; the third needs a
+parser that does not exist and would break the committed corpus. Strictness
+tracks blast radius (R1.5), and the repo already proved incremental
+validation works via the existing schema-version notice gate.
+
+### Decision 3: Smallest table split — shared core of three columns, one profile-specific column each
+
+**Decision.** The shared core is the key column (parameterized),
+Dependencies, and Status, plus shared validation and rendering (R2). The
+plan profile adds Complexity and the child reference row (R3); the roadmap
+profile adds the Issues fan-out column (R4). The legacy separate-`Title`
+plan form is migrated, not kept as a permanent dual format.
+
+**Alternatives considered.**
+
+- *Collapse the two altitudes into one profile.* Rejected: the brief
+  requires the altitude distinction to survive (a roadmap keys on features,
+  a plan keys on issues). The framework carries two profiles rather than
+  collapsing into one.
+- *Keep the legacy separate-`Title` plan table as a permanent accepted
+  variant.* Rejected: the brief's goal is to replace the drifting schemas.
+  "Still accepted by CI" narrows to a migration path, not a perpetual second
+  format; the title folds into the issue link text the canonical form
+  already uses.
+
+**Rationale.** Three concerns are common to both altitudes — identity, a
+dependency relationship, a status marker — so they are defined once and
+validated and rendered once. The one real altitude difference is isolated
+into the key column's parameterization plus exactly one profile-specific
+column each: Complexity is an issue property (no feature equivalent), and
+the Issues fan-out is the roadmap's whole reason to exist. The child
+reference row is plan-only because it models an issue spawning a child
+artifact, which has no feature-level analogue. This is the smallest split
+that preserves the altitude distinction while ending the multi-schema drift.
+
+### Decision 4: Whole-tree scan carries both lifecycle checks; no branch-protection gate
+
+**Decision.** Both lifecycle checks run as a whole-tree scan on the PR,
+alongside the existing changed-files validator (R17). A push-to-main /
+branch-protection gate is not used in this work.
+
+**Alternatives considered.**
+
+- *Carry the checks on the existing changed-files doc-validator.* Rejected
+  for Check B: the existing validators run on the PR's changed-files diff
+  (confirmed in the workflow files), and a diff cannot see a single-pr plan
+  the PR does not touch. Presence-without-touch is invisible to a diff, so
+  the changed-files surface provably cannot enforce "absent at merge."
+- *Use a push-to-main / branch-protection gate for an at-the-merge-commit
+  reading.* Rejected for v1: both checks are stateless presence/status
+  tests, so evaluating them on the PR's checked-out tree is equivalent to
+  evaluating them at merge — the brief leans on exactly this ("without CI
+  having to know which commit is the merge"). The gate adds wiring cost for a
+  property the PR-time scan already delivers; it is held in reserve as later
+  hardening.
+
+**Rationale.** Only a whole-tree scan observes presence-without-touch,
+which collapses the choice for Check B. The same scan handles Check A's
+status reading. Scoping Check B's presence test to single-pr plans, and
+Check A's status test to multi-pr docs, is what keeps the multi-pr verified
+deletion a human act CI permits but never performs (R18).
+
+### Decision 5: Value-confirmation under `--auto` is record-and-proceed, not require-human
+
+**Decision.** Under `--auto`, the value-confirmation guard records a
+decision block and continues — confirmed on a pass, assumed at `high`
+review priority on a failing or ambiguous unit (R12). It does not
+hard-stop.
+
+**Alternatives considered.**
+
+- *Require a human even under `--auto` (hard-stop).* Rejected: it would be
+  the only decision point in these skills that breaks `--auto`'s
+  non-interactive contract — a CI or batch invocation would deadlock waiting
+  for a human who, by definition, is not there. The brief's thrust is
+  reducing special cases, not adding one.
+- *Silently pass a failed judgment under `--auto`.* Rejected: the guard must
+  stay loud. Routing a failure to `status="assumed"` with `high` review
+  priority puts it in the PR body and terminal summary so the human sees the
+  mis-decomposition prominently, just not as a blocking prompt.
+
+**Rationale.** The value-confirmation is a judgment-call approval gate whose
+consequence is reversible and already backstopped: the lifecycle gates
+issue creation on human approval for multi-pr docs (R14), so a bad
+auto-judgment produces a draft the human still approves, not silent
+irreversible harm. Record-and-proceed is the settled, shared pattern in
+`decision-protocol.md` for reversible judgment points; the trade-off (an
+`--auto` run can reach the PR stage with a mis-decomposed feature set the
+author must notice) is mitigated by the loud assumed block and the approval
+backstop.
+
+## Downstream Artifacts
+
+Forthcoming work flowing from this PRD:
+
+- **`DESIGN-roadmap-plan-standardization.md`** (in
+  `docs/designs/current/`). Implementation shape: the shared-reference
+  layout, the validation check codes, the roadmap-to-issues script
+  interface, the table parser, and the final principle wording. Picks up
+  the Decisions and Trade-offs positions and operationalizes them.
+- **A mermaid-parser spike** (R9), the named upstream of the
+  reconciliation increment (R8).
+- **Implementation issues** — created from the design via `/plan`, covering
+  the shared references, the two table profiles, the diagram-convention
+  enforcement, the schema-conformance and cross-reference checks, the
+  decision-surfacing fixes, the roadmap-to-issues path, the lifecycle
+  changes, and the CI whole-tree scan.
+
+## Related
+
+- **Upstream brief:** `docs/briefs/BRIEF-roadmap-plan-standardization.md`.
+- **Current workflows being standardized:** `/roadmap`
+  (`skills/roadmap/`), `/plan` (`skills/plan/`).
+- **Format references the standardization unifies:**
+  `skills/roadmap/references/roadmap-format.md`,
+  `skills/plan/references/quality/plan-doc-structure.md`.
+- **Validation precedents:** `internal/validate/formats.go` (Formats-map
+  pattern), `internal/validate/checks.go` (FC01-FC04 and the SCHEMA-notice
+  incremental gate).
+- **Decision-protocol precedent for `--auto`:**
+  `references/decision-protocol.md` (the record-and-proceed pattern for
+  judgment-call decision points).

--- a/docs/prds/PRD-roadmap-plan-standardization.md
+++ b/docs/prds/PRD-roadmap-plan-standardization.md
@@ -1,6 +1,6 @@
 ---
 schema: prd/v1
-status: Accepted
+status: In Progress
 problem: |
   shirabe's roadmap and plan workflows are procedure-rich but
   principle-poor. The issues table has several drifting schemas, the
@@ -30,7 +30,7 @@ upstream: docs/briefs/BRIEF-roadmap-plan-standardization.md
 
 ## Status
 
-Accepted
+In Progress
 
 This PRD picks up the requirements work scoped by
 `docs/briefs/BRIEF-roadmap-plan-standardization.md`. It owns the

--- a/docs/prds/PRD-roadmap-plan-standardization.md
+++ b/docs/prds/PRD-roadmap-plan-standardization.md
@@ -159,9 +159,11 @@ call are not surfaced where the call gets made.
    replacing the brittle in-prose string surgery of the plan re-entry.
 
 7. **Install one enforced lifecycle with a single terminal.** Gate issue
-   creation on approval, rest at Active, reach Done, and retire by
-   verified deletion — with two stateless CI checks holding docs to the
-   states CI can observe.
+   creation on approval (unless running under `--auto`, where the gate
+   records and proceeds), rest at Active while the work lands, and retire
+   by verify-then-delete — the work-completing PR marks the doc Done and
+   deletes it atomically, so Done never reaches main — with two stateless
+   CI checks holding docs to the states CI can observe.
 
 ## User Stories
 
@@ -190,9 +192,10 @@ produce a document that conforms by construction.
 **As an author moving a multi-pr doc through its lifecycle**, I want the
 draft to stop for my approval before any GitHub issue is created — with
 approval being the act that creates the issues and moves the doc to
-Active — and I want a completed doc to retire by verified deletion, so
-that issues are never filed before I sign off and a finished doc gets a
-clean end.
+Active — and I want the PR that completes the work to be the one where I
+verify the result and delete the doc, so that issues are never filed
+before I sign off and the finished doc gets a clean end with a forced
+final review.
 
 **As an author of an ephemeral single-pr plan**, I want CI to be red
 while the plan file is present and green once I delete it, so that the
@@ -200,10 +203,10 @@ plan never reaches main and "gone before merge" is enforced without CI
 having to know which commit is the merge.
 
 **As a maintainer running `/roadmap` or `/plan` under `--auto`**, I want
-the value-confirmation step to record its judgment and continue rather
-than deadlock waiting for a human who is not there, while still
-surfacing a failed judgment prominently, so that batch and CI invocations
-keep their non-interactive guarantee.
+the value-confirmation step and the issue-creation approval gate to each
+record their judgment and continue rather than deadlock waiting for a
+human who is not there, while still surfacing those judgments prominently,
+so that batch and CI invocations keep their non-interactive guarantee.
 
 ## Requirements
 
@@ -354,7 +357,10 @@ path that populates its own issues table, keyed on features at the
 roadmap's altitude, without re-driving the plan workflow against the
 document and without depending on in-prose string surgery. The path is
 native to the roadmap, mirroring how the plan workflow populates its own
-table with a script rather than prose edits.
+table with a script rather than prose edits. When this path creates
+GitHub issues, that creation is itself subject to the R14 approval gate
+and its `--auto` record-and-proceed behavior — the scripted path does not
+bypass the gate.
 
 **R14: Enforced lifecycle — issue creation gated on approval.** A
 multi-pr plan or roadmap finishes its draft and stops for the author's
@@ -362,13 +368,25 @@ approval before any GitHub issue is created. Approval is the act that
 creates the issues and moves the doc to Active; issue creation is no
 longer a silent side effect of finishing the draft.
 
-**R15: One terminal — verify-then-delete.** A multi-pr plan or roadmap
-rests at Active while the work lands, reaches Done when the work is
-complete, and is retired by deletion once the author verifies the
-delivered work. This is the single terminal for both plans and roadmaps,
-a deliberate change for roadmaps (which are kept forever today) and a
-unification of the plan's self-contradicting terminal. The stale
-move-to-`docs/plans/done/` archive wording is retired.
+Under `--auto`, the approval gate does not hard-stop. Mirroring the
+value-confirmation guard (R12), it records an `assumed` approval decision
+block per the existing `decision-protocol.md` at `high` review priority
+(surfaced in the terminal summary and the PR body), then proceeds to
+create the issues and move the doc to Active. The interactive stop is the
+default; it applies "unless running under `--auto`."
+
+**R15: One terminal — verify-then-delete, Done is ephemeral.** A multi-pr
+plan or roadmap lives at Active across however many PRs the work takes.
+The single PR that completes the work transitions the doc Active -> Done;
+in that same PR the author verifies the delivered work and deletes the
+doc — the transition, the verification, and the deletion land atomically
+in one PR, which can only merge with the deletion included. Done is the
+transient marker inside that verify-delete PR; it never reaches main. The
+verify-delete PR is the forcing function for the author's final review of
+the delivered work. This is the single terminal for both plans and
+roadmaps — a deliberate change for roadmaps (which are kept forever
+today) and a unification of the plan's self-contradicting terminal — and
+it retires the stale move-to-`docs/plans/done/` archive wording.
 
 **R16: Single-pr plan is ephemeral.** A single-pr plan lives only on its
 own PR branch and is verified and deleted before that PR merges, so it
@@ -378,16 +396,18 @@ never reaches main.
 checks run as a **whole-tree scan on the PR**, alongside (not replacing)
 the existing changed-files doc-validator:
 
-- **Check A — multi-pr may only merge at Active or Done.** The scan reads
-  the frontmatter status of every roadmap and multi-pr plan in the
-  checked-out tree and fails if any is present with a status that is
-  neither `Active` nor `Done`. `Active` is the state a multi-pr doc merges
-  in while the work lands; `Done` is an accepted-at-merge status because a
-  completed doc sits in the tree until its permitted human deletion (R15,
-  R18) — Check A must not fail a Done doc awaiting that deletion. The check
-  bars merging a multi-pr doc still in Draft (issues not yet created, no
-  approval). A whole-tree scan is required because a changed-files diff
-  cannot see a doc the PR does not touch.
+- **Check A — a present multi-pr doc must be Active.** The scan reads the
+  frontmatter status of every roadmap and multi-pr plan in the checked-out
+  tree and fails if any is present with a status other than `Active`. A
+  present Draft fails (issues not yet created, no approval). A present
+  `Done` fails too: Done must coincide with the doc's deletion in the same
+  PR (R15), so a present Done means the author marked the work complete but
+  did not delete the doc — Check A failing on that state is the forcing
+  function that drives the deletion into the verify-delete PR. At merge a
+  multi-pr doc is therefore either present-and-Active (work still landing)
+  or absent (verified and deleted); present-and-Done is never a valid merge
+  state. A whole-tree scan is required because a changed-files diff cannot
+  see a doc the PR does not touch.
 - **Check B — single-pr absent-at-merge.** The scan fails if any PLAN doc
   with `execution_mode: single-pr` exists in the tree, and passes once it
   is deleted — the stateless presence test the brief specifies, with no
@@ -398,13 +418,16 @@ The existing changed-files validators keep running for content and
 frontmatter checks; the lifecycle gate is a separate concern that needs
 whole-tree visibility.
 
-**R18: Verified deletion is permitted, not performed.** CI permits but
-never performs or demands the deletion of a Done multi-pr doc. Check B's
-presence test is scoped to single-pr plans only, so a Done multi-pr doc
-sitting in the tree is valid to CI; the human verifies the delivered work
-and deletes the doc as a separate, manual act that CI permits (a clean
-deletion PR) but never requires. CI enforces a single-pr plan's deletion
-(Check B fails while present) and only permits a multi-pr doc's deletion.
+**R18: Verified deletion is a human act CI never performs but demands
+indirectly.** CI never performs the deletion of a completed multi-pr doc.
+But it does demand the deletion indirectly: once the doc is Done, Check A
+fails while it is present, forcing the author to include the deletion in
+that same PR. This parallels Check B for single-pr plans (fail-while-
+present), making the two doc modes symmetric — a multi-pr doc at Done and
+a single-pr plan are both ephemeral and both CI-forced-absent at merge.
+The verification of the delivered work remains the human's act (CI cannot
+judge it); CI's role is to make the resulting deletion non-optional by
+failing any present non-Active (Done or Draft) multi-pr doc.
 
 ### Non-Functional Requirements
 
@@ -474,20 +497,28 @@ paths, filenames, issue numbers, or pre-announcement features.
 - [ ] A roadmap author populates the roadmap's issues table through a
   scripted, feature-keyed path without re-entering the plan workflow and
   without in-prose string surgery (R13).
-- [ ] A multi-pr plan or roadmap creates no GitHub issue until the author
-  approves; approval creates the issues and moves the doc to Active (R14).
-- [ ] A completed multi-pr plan or roadmap reaches Done and is retired by
-  deletion after the author verifies the work; the stale
+- [ ] In an interactive run, a multi-pr plan or roadmap creates no GitHub
+  issue until the author approves; approval creates the issues and moves the
+  doc to Active (R14).
+- [ ] Under `--auto`, the approval gate records an `assumed` approval
+  decision block (high review priority, in the PR body and terminal summary)
+  and creates the issues and moves the doc to Active without hard-stopping
+  (R14).
+- [ ] A multi-pr plan or roadmap lives at Active while work lands; the
+  work-completing PR transitions it to Done, verifies the work, and deletes
+  the doc atomically in that one PR, so Done never reaches main; the stale
   move-to-`docs/plans/done/` wording is gone (R15).
 - [ ] A single-pr plan exists only on its PR branch and is deleted before
   that PR merges (R16).
-- [ ] CI Check A fails when any roadmap or multi-pr plan in the tree has a
-  status that is neither Active nor Done, evaluated by a whole-tree scan,
-  and passes a Done multi-pr doc awaiting its permitted deletion (R17).
+- [ ] CI Check A fails when any roadmap or multi-pr plan present in the tree
+  has a status other than Active (a present Draft or a present Done fails),
+  evaluated by a whole-tree scan (R17).
 - [ ] CI Check B fails while any `execution_mode: single-pr` PLAN exists in
   the tree and passes once it is deleted (R17).
-- [ ] CI does not fail on, demand, or perform the deletion of a Done
-  multi-pr doc; the verified deletion is a permitted human act (R18).
+- [ ] CI never performs the deletion of a completed multi-pr doc but demands
+  it indirectly: a present Done multi-pr doc fails Check A, forcing the
+  deletion into the same PR, symmetric with single-pr fail-while-present
+  (R18).
 - [ ] The first content-validation pass introduces no new validation
   binary or parallel pipeline: R6 and R7 extend the existing
   `internal/validate/` package and run through the existing CLI and
@@ -542,15 +573,27 @@ around shared, principle-driven conventions. It explicitly excludes:
   draft/PR stage.** Because R12 is record-and-proceed, a failed value
   judgment under `--auto` does not block the run; the author must notice
   the `high`-priority assumed block in the PR body or terminal summary and
-  act on it. The multi-pr approval gate (R14) is a second backstop before
-  issues are created.
+  act on it.
+
+- **An `--auto` run can file GitHub issues without an interactive human
+  approval.** Because R14's approval gate is record-and-proceed under
+  `--auto` (mirroring R12), an auto-run creates the issues and moves the
+  doc to Active after recording an `assumed` approval block rather than
+  waiting for a human. The loud `high`-priority assumed block (PR body +
+  terminal summary) is the mitigation; the value-confirmation guard
+  (R11/R12) and the human's later review of the resulting issues are
+  backstops. This is the deliberate cost of keeping `--auto`
+  non-interactive; an operator who wants a hard human approval runs
+  interactively rather than under `--auto`.
 
 - **The whole-tree scan re-reads unchanged docs on every PR.** Check A and
   Check B scan the full tree rather than the diff, so an unrelated PR can
   fail because of a doc it did not touch (for example, a single-pr plan
-  left on the branch). This is the intended behavior — it is how
-  presence-without-touch becomes observable — but it means a doc's
-  lifecycle state can block a PR that has nothing to do with it.
+  left on the branch, or a multi-pr doc someone marked Done without
+  deleting). This is the intended behavior — it is how presence-without-
+  touch becomes observable and how the Done-must-delete forcing function
+  works — but it means a doc's lifecycle state can block a PR that has
+  nothing to do with it.
 
 ## Decisions and Trade-offs
 
@@ -639,10 +682,16 @@ reference row is plan-only because it models an issue spawning a child
 artifact, which has no feature-level analogue. This is the smallest split
 that preserves the altitude distinction while ending the multi-schema drift.
 
-### Decision 4: Whole-tree scan carries both lifecycle checks; no branch-protection gate
+### Decision 4: Whole-tree scan, Active-only Check A, and an ephemeral Done; no branch-protection gate
 
 **Decision.** Both lifecycle checks run as a whole-tree scan on the PR,
-alongside the existing changed-files validator (R17). A push-to-main /
+alongside the existing changed-files validator (R17). Check A is
+Active-only: a present multi-pr doc must be `Active`, and a present `Done`
+fails. Done is ephemeral — the work-completing PR transitions Active ->
+Done, the author verifies and deletes the doc, and all three land
+atomically in that one PR, so Done never reaches main (R15). This also
+settles how the brief's verify-then-delete / VERIFIED step is realized:
+the verify-delete PR is the forcing function. A push-to-main /
 branch-protection gate is not used in this work.
 
 **Alternatives considered.**
@@ -652,6 +701,14 @@ branch-protection gate is not used in this work.
   (confirmed in the workflow files), and a diff cannot see a single-pr plan
   the PR does not touch. Presence-without-touch is invisible to a diff, so
   the changed-files surface provably cannot enforce "absent at merge."
+- *Accept `Done` at merge — let a completed multi-pr doc linger in the tree
+  until a separate deletion PR.* Rejected: a Done doc that lingers on main
+  loses the forcing function for the author's final review of the delivered
+  work, and it splits the terminal across two PRs (mark-Done, then
+  delete-later) with nothing compelling the second. Making Done ephemeral —
+  verify and delete in the same PR that marks Done — keeps the final-review
+  gate and makes the two doc modes symmetric (a multi-pr Done doc and a
+  single-pr plan are both CI-forced-absent at merge).
 - *Use a push-to-main / branch-protection gate for an at-the-merge-commit
   reading.* Rejected for v1: both checks are stateless presence/status
   tests, so evaluating them on the PR's checked-out tree is equivalent to
@@ -661,39 +718,46 @@ branch-protection gate is not used in this work.
   hardening.
 
 **Rationale.** Only a whole-tree scan observes presence-without-touch,
-which collapses the choice for Check B. The same scan handles Check A's
-status reading. Scoping Check B's presence test to single-pr plans, and
-Check A's status test to multi-pr docs, is what keeps the multi-pr verified
-deletion a human act CI permits but never performs (R18).
+which collapses the surface choice for Check B; the same scan handles
+Check A's status reading. Active-only Check A plus an ephemeral Done makes
+the verify-delete PR a hard forcing function for the final human review and
+makes multi-pr docs and single-pr plans symmetric — both ephemeral, both
+CI-forced-absent at merge (R18). The verification stays a human act CI
+cannot judge; CI makes the resulting deletion non-optional by failing any
+present non-Active multi-pr doc.
 
-### Decision 5: Value-confirmation under `--auto` is record-and-proceed, not require-human
+### Decision 5: Both `--auto` human-judgment gates are record-and-proceed, not require-human
 
-**Decision.** Under `--auto`, the value-confirmation guard records a
-decision block and continues — confirmed on a pass, assumed at `high`
-review priority on a failing or ambiguous unit (R12). It does not
-hard-stop.
+**Decision.** Under `--auto`, both the value-confirmation guard (R12) and
+the issue-creation approval gate (R14) record a decision block and
+continue rather than hard-stop. Each records `confirmed` on a clear pass
+and `assumed` at `high` review priority otherwise — the value guard on a
+failing or ambiguous unit, the approval gate on every auto-run (an
+approval CI cannot give). Both surface in the PR body and terminal summary.
 
 **Alternatives considered.**
 
-- *Require a human even under `--auto` (hard-stop).* Rejected: it would be
-  the only decision point in these skills that breaks `--auto`'s
-  non-interactive contract — a CI or batch invocation would deadlock waiting
-  for a human who, by definition, is not there. The brief's thrust is
-  reducing special cases, not adding one.
-- *Silently pass a failed judgment under `--auto`.* Rejected: the guard must
-  stay loud. Routing a failure to `status="assumed"` with `high` review
-  priority puts it in the PR body and terminal summary so the human sees the
-  mis-decomposition prominently, just not as a blocking prompt.
+- *Require a human even under `--auto` (hard-stop).* Rejected: either gate
+  would then break `--auto`'s non-interactive contract — a CI or batch
+  invocation would deadlock waiting for a human who, by definition, is not
+  there. The brief's thrust is reducing special cases, not adding one, and
+  leaving R14 silent on `--auto` while R12 specified record-and-proceed was
+  an asymmetry worth closing.
+- *Silently pass under `--auto`.* Rejected: both gates must stay loud.
+  Routing to `status="assumed"` with `high` review priority puts the
+  judgment in the PR body and terminal summary so the human sees it
+  prominently, just not as a blocking prompt.
 
-**Rationale.** The value-confirmation is a judgment-call approval gate whose
-consequence is reversible and already backstopped: the lifecycle gates
-issue creation on human approval for multi-pr docs (R14), so a bad
-auto-judgment produces a draft the human still approves, not silent
-irreversible harm. Record-and-proceed is the settled, shared pattern in
-`decision-protocol.md` for reversible judgment points; the trade-off (an
-`--auto` run can reach the PR stage with a mis-decomposed feature set the
-author must notice) is mitigated by the loud assumed block and the approval
-backstop.
+**Rationale.** Both are judgment-call gates whose consequences are
+reversible and backstopped. The trade-off the approval gate carries is
+sharper than the value guard's: under `--auto` it files real GitHub issues
+without an interactive human approval (see Known Limitations). It is still
+the right call — record-and-proceed is the settled, shared pattern in
+`decision-protocol.md` for reversible judgment points, the loud assumed
+block makes the un-approved creation visible, and the value-confirmation
+guard plus the human's later review of the resulting issues are backstops.
+Keeping the two gates symmetric also avoids a special case authors and the
+harness would otherwise have to track.
 
 ## Downstream Artifacts
 


### PR DESCRIPTION
Add the full tactical-chain of planning artifacts for the roadmap-plan-standardization feature: BRIEF (Accepted), PRD (In Progress), DESIGN (Planned), and PLAN (Active). The plan decomposes the work into 9 atomic issues across 5 value-delivering PR slices, tracked in milestone #6.

---

## Planning Chain Highlights

This PR adds the four planning artifacts produced for the roadmap-plan-standardization feature. Each is at the lifecycle state the chain reached during planning:

| Doc | Status |
|-----|--------|
| BRIEF | Accepted |
| PRD | In Progress |
| DESIGN | Planned |
| PLAN | Active |

**The feature** standardizes shirabe's own `/roadmap` and `/plan` skills around shared, define-once conventions: three plugin-root shared references (principles, issues-table, dependency-diagram), a Markdown-table parser feeding error-level `FC05`/`FC06` content checks, a surfaced single-pr/multi-pr decision with a value-confirmation guard, a native roadmap-to-issues script, and a whole-tree `--lifecycle` CI gate (`L01`/`L02`) enforcing a verify-then-delete terminal where `Done` is ephemeral. Table-diagram reconciliation is staged behind a mermaid-parser spike.

**Implementation issues** are already filed and organized into 5 value-delivering PR slices in [milestone #6](https://github.com/tsukumogami/shirabe/milestone/6) — implementation lands in those PRs, not this one:

- Slice A (#111-#113): shared references + table parser + FC05/FC06 + corpus migration
- Slice B (#114): surfaced single-pr/multi-pr decision + value guard
- Slice C (#115): native roadmap-to-issues script
- Slice D (#116-#117): `--lifecycle` mode + CI gate + verify-then-delete wiring
- Slice E (#118 -> #119): mermaid-parser spike, then reconciliation notice (gated)
