### PR TITLE
docs: contextual-impact worktree discipline for parent skills

### DIFF
--- a/docs/designs/DESIGN-shirabe-scope-skill.md
+++ b/docs/designs/DESIGN-shirabe-scope-skill.md
@@ -645,86 +645,97 @@ into the Draft and may want preserved for re-authoring.
 
 ### Decision 4: Worktree-discipline reference content
 
-PRD R21 specifies the discipline (silent rebase before each
-Phase 2 child invocation; conflict-fallback to the team lead;
-three-option prompt only escalates to the author). PRD Decision 4
-specifies the location (`references/parent-skill-worktree-
-discipline.md` at the top-level reference root, not parent-
-specific). The question deferred to design is the detailed prose:
-rebase mechanics, the recording semantics for both clean-rebase
-and conflict-resolution cases, and how the check integrates with
-the chain-proposal prompt.
+PRD R21 specifies the discipline: attempt a rebase before each
+Phase 2 child invocation, then escalate based on whether upstream
+changes invalidate the chain's intent — NOT based on whether the
+rebase was mechanically clean. PRD Decision 4 specifies the
+location (`references/parent-skill-worktree-discipline.md` at the
+top-level reference root, not parent-specific). The question
+deferred to design is the detailed prose: rebase mechanics, the
+impact-classification taxonomy, the recording semantics, and how
+the check integrates with the chain-proposal prompt.
 
-#### Chosen: Substrate-Agnostic Top-Level Reference, Rebase-By-Default
+#### Chosen: Contextual-Impact Escalation, Not Mechanical-Conflict Escalation
 
-The reference body is parent-agnostic prose with the following
-five sections:
+The reference body is parent-agnostic prose. The core insight is
+that mechanical-conflict status (clean vs conflicted) is a poor
+escalation signal: a clean rebase can land a contract change that
+silently invalidates the chain's artifacts; a conflict can be in a
+file the chain doesn't care about. The correct signal is whether
+upstream changes touch something the chain depends on — which
+requires reading the diff and cross-referencing the chain's
+authored artifacts. Sub-agents can do this; the team lead and the
+author are bothered only when the analysis finds intent-changing
+impact.
+
+The reference has six sections:
 
 1. **Trigger Condition.** Defines "before each Phase 2 child
    invocation" precisely: after Phase 1 emits its chain-proposal
    output and the author confirms (R7.5), AND before each child
-   invocation in `planned_chain`. The rebase attempt fires up to
-   four times per full-run chain for `/scope` (once before each
-   of `/brief`, `/prd`, `/design`, `/plan`), not once per parent
-   invocation. The trigger is bounded by chain step count, not by
-   wallclock time.
-2. **Default: Silent Rebase.** Before each child invocation, the
-   parent SHALL execute the equivalent of `git fetch && git
-   rebase origin/<tracking-branch>` against the worktree. When
-   the rebase succeeds cleanly (no conflicts), the parent records
-   an informational state-file entry naming the upstream commits
-   that landed and proceeds directly to child invocation. The
-   author is not prompted; the team lead is not prompted. The
-   parent owns the branch during the chain, so there is no
-   parallel-author work to be careful around — silent rebase is
-   safe by default. The recording exists so the team lead and any
-   future reviewer have visibility into what changed mid-chain.
-3. **Conflict Fallback: Route to Team Lead.** When the rebase
-   produces conflicts, the parent SHALL halt the chain at the
-   pre-invocation point and route the conflict to the team lead
-   with full context (which files conflict, the upstream commits
-   involved, the conflicted hunks). The team lead applies the Q2c
-   discipline: resolve from artifact context (BRIEF/PRD/DESIGN
-   citations make the resolution obvious) / delegate
-   investigation / invoke `/shirabe:decision` / escalate to the
-   author. Only when the team lead escalates does the three-
-   option prompt (resolve-and-continue / proceed-anyway-against-
-   unrebased-base / bail-per-R8) surface to the author. The
-   author is bothered only for genuine ambiguity, not for routine
-   drift.
-4. **Recording (Two Kinds).** Two state-file lists, both
-   conditional per I-5:
-   - `worktree_rebases:` — appended whenever a clean rebase
-     succeeds; entries have `{phase: <next-child-name>,
-     upstream_commits: [<sha>, …], rebased_at: <ISO-8601>}`.
-     Informational only.
-   - `worktree_divergences:` — appended only when a conflict was
-     surfaced and the resolution chose "proceed anyway against
-     the unrebased base" (rare); entries have `{phase, conflict_summary,
-     upstream_commits, accepted_at}`. The list exists so the
-     parent's finalization step can surface divergence history in
-     the terminal artifact, and so future reviewers can audit how
-     the chain interacted with an upstream conflict.
-5. **Integration with Chain-Proposal Prompt.** The check is AFTER
-   chain-proposal confirmation, not before. Running `git fetch`
-   before the author confirms the chain pays network cost on every
-   Phase 1 termination, including the ones the author rejects or
-   revises. The current order pays the cost only when the chain
-   is going to run.
+   invocation in `planned_chain`. The attempt fires up to four
+   times per full-run chain for `/scope`, bounded by chain step
+   count.
+2. **Step 1: Rebase.** The parent SHALL execute the equivalent of
+   `git fetch && git rebase origin/<tracking-branch>`. Clean
+   rebases proceed to step 2 directly. Conflicted rebases are
+   handled by the parent's conflict-resolution sub-agent using
+   artifact context (BRIEF/PRD/DESIGN citations often make the
+   correct resolution obvious); only conflicts that cannot be
+   resolved from artifact context proceed to step 2's analysis
+   with the unresolved conflict as part of the diff to classify.
+3. **Step 2: Contextual Impact Analysis.** After the rebase
+   (clean or with resolved conflicts), the parent reads the
+   upstream commits that landed and cross-references them against
+   the chain's authored artifacts (BRIEF, PRD, DESIGN, PLAN as
+   they exist at this point) AND against the inputs the next
+   child invocation will consume. The parent classifies impact at
+   one of three levels:
+   - **None**: no path, symbol, or contract the chain depends on
+     was touched.
+   - **Informational**: chain-referenced content was touched, but
+     non-substantively (typo, comment, formatting).
+   - **Intent-changing**: a contract, interface, or fact the
+     chain has committed to was altered.
+4. **Step 3: Escalate Based on Impact.** None or Informational
+   impact: record in `worktree_rebases:` and proceed silently to
+   child invocation. Intent-changing impact: route to the team
+   lead with full evidence (which artifact, which referenced
+   contract, what changed). The team lead decides whether the
+   original session intent still holds. If yes, the team lead may
+   resolve in-place (update citations, adjust artifact content,
+   then proceed). If the intent has genuinely changed, the team
+   lead escalates to the author with the three-option prompt:
+   **re-author affected artifacts** / **proceed against original
+   intent** / **bail per R8**.
+5. **Recording.** Two state-file lists, both conditional per
+   I-5: `worktree_rebases:` (informational; entries record
+   `{phase, upstream_commits, impact_classification, rebased_at}`
+   for None / Informational events) and `worktree_divergences:`
+   (decision audit; appended only when an Intent-changing event
+   escalated to the author and the author chose "proceed against
+   original intent"; entries record
+   `{phase, affected_contracts, upstream_commits, accepted_at}`).
+6. **Integration with Chain-Proposal Prompt.** The attempt is
+   AFTER chain-proposal confirmation, not before. The
+   chain-proposal prompt makes no network calls; running `git
+   fetch` before the author confirms the chain would pay network
+   cost on every Phase 1 termination.
 
-A sixth "Binding Notes" section names per-parent bindings: `/scope`
-v1 (load-bearing — 4 children, longest chain in shirabe); `/charter`
-(back-edit; 3 children, also load-bearing); `/work-on` (future;
-binding deferred to amplifier-layer parent).
+A seventh "Binding Notes" section names per-parent bindings:
+`/scope` v1 (load-bearing — 4 children, longest chain in shirabe);
+`/charter` (back-edit; 3 children, also load-bearing); `/work-on`
+(future; binding deferred to amplifier-layer parent).
 
-This is recommended because rebase-by-default eliminates the noisy
-manual-gate at every child boundary that the original design called
-for. The parent owns the branch — there is no parallel author work
-to disrupt — so silent rebase is the right default. The author is
-brought into the loop only when something actually requires their
-judgment (a conflict the team lead can't resolve). The reference's
-parent-agnostic core lets future parents inherit the discipline
-without re-deriving it.
+The escalation contract (intent-change escalates; mechanical
+status does not) is the key design choice. It means every actor
+in the chain operates at the altitude appropriate to its
+capability: sub-agents handle rebases and conflict resolution,
+the team lead handles judgment about whether intent has changed,
+and the author is brought in only when the chain's original
+direction is in question. This eliminates the "every staleness
+check bothers somebody" failure mode the manual-gate default
+would have produced.
 
 #### Alternatives Considered
 

--- a/docs/designs/DESIGN-shirabe-scope-skill.md
+++ b/docs/designs/DESIGN-shirabe-scope-skill.md
@@ -1185,8 +1185,8 @@ under the `.md` extension. Its schema extends the pattern's
 status + content-hash dual-check block), and the ephemeral
 `parent_orchestration` block (present only during child
 invocation; cleared on return). `worktree_divergences` is a
-conditional list capturing each Proceed-anyway divergence
-accepted during Phase 2.
+conditional list capturing each Proceed-against-original-intent
+divergence accepted during Phase 2.
 
 The resume ladder follows the universal meta-ladder template
 with Slot 5 spanning 9 rows in most-downstream-first first-
@@ -1498,10 +1498,11 @@ gains documented refuse-and-redirect semantics).
 
 A new top-level reference at the pattern-reference root,
 sibling to the four existing `parent-skill-*.md` references.
-The body has the four named sections described in Decision 4:
-Trigger Condition, Three-Option Prompt, Recording "Proceed
-Anyway" Divergence, Integration with Chain-Proposal Prompt.
-A fifth Binding Notes section names per-parent bindings:
+The body has six named sections described in Decision 4:
+Trigger Condition; Step 1 — Rebase; Step 2 — Contextual
+Impact Analysis; Step 3 — Escalate Based on Impact;
+Recording; Integration with Chain-Proposal Prompt. A
+seventh Binding Notes section names per-parent bindings:
 `/scope` v1 (load-bearing), `/charter` (back-edit; binding
 notes added in `/charter`'s SKILL.md reference table),
 `/work-on` (future; binding deferred to the the `/work-on` migration PR).
@@ -1624,11 +1625,22 @@ in `chain_skipped` with reason if present.
 Phase 2 detailing the child invocation loop. Key sections:
 
 7.1. **Worktree-staleness check** — fires before each child
-invocation per R21. Executes `git fetch && git status
---branch --short`; on divergence, surfaces three-option
-prompt and records "proceed anyway" divergences in the
-state file's `worktree_divergences:` list. Cites
-`references/parent-skill-worktree-discipline.md`.
+invocation per R21. Runs the three-step flow from
+`references/parent-skill-worktree-discipline.md`: (1) the
+conflict-resolution sub-agent rebases against the tracking
+branch, resolving conflicts from artifact context where
+possible; (2) upstream commits are classified at one of
+three impact levels (None / Informational / Intent-changing)
+against the chain's authored artifacts and the next child's
+inputs; (3) None and Informational silently record into
+`worktree_rebases:` and proceed, while Intent-changing halts
+and routes to the team lead with evidence. The team lead
+either resolves in-place (updating an affected citation,
+recorded as `intent-changing-resolved-in-place`) or escalates
+to the author with the three-option prompt (Re-author
+affected artifacts / Proceed against original intent / Bail).
+Divergences are recorded in `worktree_divergences:` only
+when the author selects "Proceed against original intent."
 
 7.2. **parent_orchestration: sentinel write** — writes the
 ephemeral block to `/scope`'s state file naming the child,
@@ -1825,10 +1837,15 @@ flowchart TD
     P1 -->|Proceed| P2[Phase 2: Child Invocation Loop]
     P1 -->|Adjust| P1
     P1 -->|Bail| Bail[R8 bail-handling]
-    P2 --> WSC{Worktree<br/>stale?}
-    WSC -->|Yes| WSCP[Rebase /<br/>Proceed anyway /<br/>Bail]
-    WSCP --> P2
-    WSC -->|No| Write[Write parent_orchestration]
+    P2 --> Rebase[Rebase<br/>sub-agent resolves<br/>from artifact context]
+    Rebase --> Impact{Impact<br/>classification}
+    Impact -->|None / Informational| Write[Write parent_orchestration]
+    Impact -->|Intent-changing| TL{Team-lead gate}
+    TL -->|Resolve in-place| Write
+    TL -->|Escalate to author| AuthorPrompt[Three-option prompt:<br/>Re-author affected artifacts /<br/>Proceed against original intent /<br/>Bail]
+    AuthorPrompt -->|Re-author| P2
+    AuthorPrompt -->|Proceed against original intent| Write
+    AuthorPrompt -->|Bail| Bail
     Write --> Child[Invoke child]
     Child --> FE{Artifact<br/>exists?}
     FE -->|No| Stale[STALE → R8]
@@ -1850,9 +1867,15 @@ flowchart TD
 
 The diagram covers the happy path (full-run), the
 re-evaluation rejection path (via Phase-N Reject), and the
-abandonment-forced path (via worktree-staleness Bail,
-structural-file-existence STALE, or validator failure
-routing through R8 bail-handling).
+abandonment-forced path. Bail is reached via three routes:
+the author selecting Bail in response to a team-lead
+escalation prompt on intent-changing upstream divergence;
+structural-file-existence STALE; or validator failure
+routing through R8 bail-handling. Worktree rebase itself
+contributes no direct Bail edge — None/Informational impact
+silently proceeds, and Intent-changing impact routes
+through the team-lead gate before any Bail decision can
+reach the author.
 
 ## Implementation Approach
 
@@ -1874,7 +1897,8 @@ Deliverables:
 - `references/parent-skill-resume-ladder-template.md` —
   single Slot 5 paragraph addition (Component 3).
 - `references/parent-skill-worktree-discipline.md` — new
-  reference file with five sections (Component 4).
+  reference file with six body sections plus a Binding
+  Notes section (Component 4).
 
 ### Phase B: Child-side contract extensions
 
@@ -1980,8 +2004,8 @@ interpolation; rationale content containing quotes,
 backticks, or shell metacharacters cannot reach the shell.
 The same discipline applies to any other free-form string
 the skill writes into a commit body (the author-stated
-rationale for "proceed anyway" on worktree-staleness
-divergence per Component 4).
+rationale for "Proceed against original intent" on
+worktree-staleness divergence per Component 4).
 
 ### Filesystem-write boundaries — enumerated write set and state-file enum re-validation
 
@@ -2176,7 +2200,7 @@ substring "Rationale will be committed to git history".
   is the status quo.
 - **Worktree-staleness latency** — the trigger is bounded
   to four times per full-run chain; on slow networks,
-  authors can override via Proceed-anyway.
+  authors can override via Proceed against original intent.
 - **R6 shape-predicate interpretive drift** — Component 6
   ships with 3-4 worked examples per predicate; the chain-
   proposal output includes per-predicate reasons so authors

--- a/docs/designs/DESIGN-shirabe-scope-skill.md
+++ b/docs/designs/DESIGN-shirabe-scope-skill.md
@@ -710,11 +710,17 @@ The reference has six sections:
    intent** / **bail per R8**.
 5. **Recording.** Two state-file lists, both conditional per
    I-5: `worktree_rebases:` (informational; entries record
-   `{phase, upstream_commits, impact_classification, rebased_at}`
-   for None / Informational events) and `worktree_divergences:`
-   (decision audit; appended only when an Intent-changing event
-   escalated to the author and the author chose "proceed against
-   original intent"; entries record
+   `{phase, upstream_commits, impact, rebased_at}`, appended
+   after every rebase that brought new upstream commits in,
+   regardless of classification, except when the chain bailed;
+   allowed `impact` values are `none | informational |
+   intent-changing-resolved-in-place`, where the third value is
+   recorded when the team lead resolves an intent-changing
+   impact in-place per Step 3 without escalating to the author)
+   and `worktree_divergences:` (decision audit; appended only
+   when an Intent-changing event escalated to the author and
+   the author chose "proceed against original intent"; entries
+   record
    `{phase, affected_contracts, upstream_commits, accepted_at}`).
 6. **Integration with Chain-Proposal Prompt.** The attempt is
    AFTER chain-proposal confirmation, not before. The
@@ -725,7 +731,12 @@ The reference has six sections:
 A seventh "Binding Notes" section names per-parent bindings:
 `/scope` v1 (load-bearing — 4 children, longest chain in shirabe);
 `/charter` (back-edit; 3 children, also load-bearing); `/work-on`
-(future; binding deferred to amplifier-layer parent).
+(future; binding deferred to amplifier-layer parent). The Binding
+Notes table also carries an "Analyzer actor" column capturing the
+`team_primitive` substrate-substitution surface — in v1's
+single-team-per-leader-no-nested substrate (solo mode) the parent
+does its own impact analysis; in an amplifier-layer substrate the
+analysis can be delegated to a worktree-sync-analyzer sub-agent.
 
 The escalation contract (intent-change escalates; mechanical
 status does not) is the key design choice. It means every actor

--- a/docs/designs/DESIGN-shirabe-scope-skill.md
+++ b/docs/designs/DESIGN-shirabe-scope-skill.md
@@ -645,70 +645,86 @@ into the Draft and may want preserved for re-authoring.
 
 ### Decision 4: Worktree-discipline reference content
 
-PRD R21 specifies the trigger condition (worktree-staleness
-check fires before each Phase 2 child invocation) and the
-three-option prompt (rebase / proceed anyway / bail). PRD
-Decision 4 specifies the location (`references/parent-skill-
-worktree-discipline.md` at the top-level reference root, not
-parent-specific). The question deferred to design is the
-detailed prose: rebase mechanics, the "proceed anyway" state-
-file recording semantics, and how the check integrates with the
-chain-proposal prompt.
+PRD R21 specifies the discipline (silent rebase before each
+Phase 2 child invocation; conflict-fallback to the team lead;
+three-option prompt only escalates to the author). PRD Decision 4
+specifies the location (`references/parent-skill-worktree-
+discipline.md` at the top-level reference root, not parent-
+specific). The question deferred to design is the detailed prose:
+rebase mechanics, the recording semantics for both clean-rebase
+and conflict-resolution cases, and how the check integrates with
+the chain-proposal prompt.
 
-#### Chosen: Substrate-Agnostic Top-Level Reference with Four Named Sections
+#### Chosen: Substrate-Agnostic Top-Level Reference, Rebase-By-Default
 
 The reference body is parent-agnostic prose with the following
-four sections:
+five sections:
 
 1. **Trigger Condition.** Defines "before each Phase 2 child
-   invocation" precisely: after `/scope` Phase 1 emits its
-   chain-proposal output and the author confirms (R7.5), AND
-   before each child invocation in `planned_chain`. The check
-   fires four times per full-run chain (once before each of
-   `/brief`, `/prd`, `/design`, `/plan`), not once per parent
-   invocation. The trigger is bounded by the chain step count,
-   not by wallclock time.
-2. **Three-Option Prompt.** "Rebase / Proceed anyway / Bail"
-   surfaced when `git fetch && git status --branch --short`
-   shows the upstream has new commits on the tracking branch.
-   Rebase re-fetches and rebases the feature branch (the
-   parent skill emits the `git fetch && git rebase` commands
-   and waits for the author's manual approval before running
-   them — never auto-rebases). Proceed anyway accepts the
-   risk and continues to child invocation; the state file
-   records the divergence per the Recording Section below.
-   Bail routes per the parent's own bail-handling rule (for
-   `/scope`, R8).
-3. **Recording "Proceed Anyway" Divergence.** When the author
-   selects Proceed anyway, the parent's state file gains a new
-   conditional entry under
-   `worktree_divergences:` (a list, since one chain can have
-   up to four divergence events) with `{phase: <child-name>,
-   upstream_ahead_by: <count>, accepted_at: <ISO-8601>}`. The
-   list is conditional (absent when no divergence accepted)
-   per I-5; the field tail is appended to as additional
-   divergences occur.
-4. **Integration with Chain-Proposal Prompt.** The check is
-   AFTER chain-proposal confirmation, not before — the
-   confirmation prompt itself is short and well-bounded
-   (R7.5), running `git fetch` before it would add latency
-   without proportionate value (the author hasn't decided to
-   proceed yet). The integration prose addresses the order
-   explicitly so future parents follow the same convention.
+   invocation" precisely: after Phase 1 emits its chain-proposal
+   output and the author confirms (R7.5), AND before each child
+   invocation in `planned_chain`. The rebase attempt fires up to
+   four times per full-run chain for `/scope` (once before each
+   of `/brief`, `/prd`, `/design`, `/plan`), not once per parent
+   invocation. The trigger is bounded by chain step count, not by
+   wallclock time.
+2. **Default: Silent Rebase.** Before each child invocation, the
+   parent SHALL execute the equivalent of `git fetch && git
+   rebase origin/<tracking-branch>` against the worktree. When
+   the rebase succeeds cleanly (no conflicts), the parent records
+   an informational state-file entry naming the upstream commits
+   that landed and proceeds directly to child invocation. The
+   author is not prompted; the team lead is not prompted. The
+   parent owns the branch during the chain, so there is no
+   parallel-author work to be careful around — silent rebase is
+   safe by default. The recording exists so the team lead and any
+   future reviewer have visibility into what changed mid-chain.
+3. **Conflict Fallback: Route to Team Lead.** When the rebase
+   produces conflicts, the parent SHALL halt the chain at the
+   pre-invocation point and route the conflict to the team lead
+   with full context (which files conflict, the upstream commits
+   involved, the conflicted hunks). The team lead applies the Q2c
+   discipline: resolve from artifact context (BRIEF/PRD/DESIGN
+   citations make the resolution obvious) / delegate
+   investigation / invoke `/shirabe:decision` / escalate to the
+   author. Only when the team lead escalates does the three-
+   option prompt (resolve-and-continue / proceed-anyway-against-
+   unrebased-base / bail-per-R8) surface to the author. The
+   author is bothered only for genuine ambiguity, not for routine
+   drift.
+4. **Recording (Two Kinds).** Two state-file lists, both
+   conditional per I-5:
+   - `worktree_rebases:` — appended whenever a clean rebase
+     succeeds; entries have `{phase: <next-child-name>,
+     upstream_commits: [<sha>, …], rebased_at: <ISO-8601>}`.
+     Informational only.
+   - `worktree_divergences:` — appended only when a conflict was
+     surfaced and the resolution chose "proceed anyway against
+     the unrebased base" (rare); entries have `{phase, conflict_summary,
+     upstream_commits, accepted_at}`. The list exists so the
+     parent's finalization step can surface divergence history in
+     the terminal artifact, and so future reviewers can audit how
+     the chain interacted with an upstream conflict.
+5. **Integration with Chain-Proposal Prompt.** The check is AFTER
+   chain-proposal confirmation, not before. Running `git fetch`
+   before the author confirms the chain pays network cost on every
+   Phase 1 termination, including the ones the author rejects or
+   revises. The current order pays the cost only when the chain
+   is going to run.
 
-A fifth "Binding Notes" section names per-parent bindings:
-`/scope` v1 (load-bearing — 4 children, longest chain in
-shirabe); `/charter` (back-edit; 3 children, also load-
-bearing); `/work-on` (future; binding deferred to amplifier-
-layer parent).
+A sixth "Binding Notes" section names per-parent bindings: `/scope`
+v1 (load-bearing — 4 children, longest chain in shirabe); `/charter`
+(back-edit; 3 children, also load-bearing); `/work-on` (future;
+binding deferred to amplifier-layer parent).
 
-This is recommended because the reference's parent-agnostic
-core lets future parents (the future `/work-on` migration, any
-amplifier-layer parents) inherit the discipline without re-
-deriving it — the load-bearing concern Decision 4 in the PRD
-calls out. The Binding Notes section keeps `/charter`'s back-
-edit cost bounded (a single reference-table addition plus a
-citation in `/charter`'s phase-2 doc).
+This is recommended because rebase-by-default eliminates the noisy
+manual-gate at every child boundary that the original design called
+for. The parent owns the branch — there is no parallel author work
+to disrupt — so silent rebase is the right default. The author is
+brought into the loop only when something actually requires their
+judgment (a conflict the team lead can't resolve). The reference's
+parent-agnostic core lets future parents inherit the discipline
+without re-deriving it.
 
 #### Alternatives Considered
 

--- a/docs/plans/PLAN-shirabe-scope-skill.md
+++ b/docs/plans/PLAN-shirabe-scope-skill.md
@@ -32,7 +32,7 @@ Walking-skeleton was considered and rejected: the design is documentation + conf
 | Issue | Dependencies | Complexity |
 |-------|--------------|------------|
 | [#98: docs(refs): add parent-skill-worktree-discipline reference](https://github.com/tsukumogami/shirabe/issues/98) | None | simple |
-| _New top-level pattern reference at `references/parent-skill-worktree-discipline.md` with five named sections (Trigger Condition / Three-Option Prompt / Recording "Proceed Anyway" Divergence / Integration with Chain-Proposal Prompt / Binding Notes). Parent-agnostic prose — per-parent specifics live in Binding Notes so future parents inherit the discipline without re-deriving it._ | | |
+| _New top-level pattern reference at `references/parent-skill-worktree-discipline.md` codifying how a parent skill handles upstream change across a multi-child chain. Six body sections (Trigger Condition / Rebase phase / Impact-analysis phase / Escalation phase / Recording / Binding Notes) encode the contract: escalation is driven by contextual impact (does the change invalidate intent?), not mechanical conflict status. Sub-agents handle rebase + impact classification (None / Informational / Intent-changing); team lead arbitrates intent-changing impacts; the author is bothered only when intent has genuinely shifted. Parent-agnostic prose — per-parent specifics live in Binding Notes so future parents inherit the discipline without re-deriving it._ | | |
 | [#99: docs(charter): cite worktree-discipline reference in /charter](https://github.com/tsukumogami/shirabe/issues/99) | [#98](https://github.com/tsukumogami/shirabe/issues/98) | simple |
 | _Single-row addition to `/charter`'s Reference Files table citing the new top-level reference. Scoped tightly to the back-edit per the design's Phase D; does NOT include the `--parent-orchestrated` → `parent_orchestration:` sentinel migration (separate concern, deferred to a follow-on PR per-child)._ | | |
 | [#100: feat(prd): ship Phase 4 step 4.5 3-option Reject contract](https://github.com/tsukumogami/shirabe/issues/100) | None | testable |
@@ -102,8 +102,9 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I98,I100,I102,I104,I106 ready
-    class I99,I101,I103,I105,I107,I108,I109,I110 blocked
+    class I98,I99 done
+    class I100,I102,I104,I106 ready
+    class I101,I103,I105,I107,I108,I109,I110 blocked
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan

--- a/docs/plans/PLAN-shirabe-scope-skill.md
+++ b/docs/plans/PLAN-shirabe-scope-skill.md
@@ -121,17 +121,17 @@ Estimated sequential wall time: ~5-7 hours. With parallel execution of independe
 
 ### Parallelization Tiers
 
-**Tier 0 — Immediate start (5 issues, fully parallel)**
+**Tier 0 — Immediate start (4 issues, fully parallel; #98 done in PR-1)**
 
-- #98 — new `references/parent-skill-worktree-discipline.md`
+- ~~#98~~ done — new `references/parent-skill-worktree-discipline.md`
 - #100 — `/prd` Phase 4 Reject contract
 - #102 — `/design` Phase 6 Reject contract
 - #104 — Gate Vocabulary + L13 amendment in `parent-skill-pattern.md`
 - #106 — refuse-and-redirect Slot 5 paragraph in `parent-skill-resume-ladder-template.md`
 
-**Tier 1 — After Tier 0 (4 issues, parallel within tier)**
+**Tier 1 — After Tier 0 (3 issues remaining; #99 done in PR-1)**
 
-- #99 after #98 — `/charter` cite back-edit
+- ~~#99 after #98~~ done — `/charter` cite back-edit
 - #101 after #100 — `/prd` Reject eval scenario
 - #103 after #102 — `/design` Reject eval scenario
 - #105 after #104 — `parent-skill-state-schema.md` extension
@@ -163,9 +163,8 @@ The 13 issues aggregate into 4 PRs with the following merge order:
 
 ### Recommended Starting Issues
 
-Begin with the five Tier 0 issues (marked `ready` in the dependency graph) that have no dependencies and unblock the most downstream work:
+PR-1 is complete (#98 + #99 done). Continue with the four remaining Tier 0 issues (marked `ready` in the dependency graph):
 
-- [#98](https://github.com/tsukumogami/shirabe/issues/98): unblocks #99 and the entire `/scope` body cluster
 - [#104](https://github.com/tsukumogami/shirabe/issues/104): unblocks #105 and the entire `/scope` body cluster
 - [#100](https://github.com/tsukumogami/shirabe/issues/100) and [#102](https://github.com/tsukumogami/shirabe/issues/102): unblock #108 (phase references' git-log observability) and their respective eval scenarios
-- [#106](https://github.com/tsukumogami/shirabe/issues/106): unblocks the `/scope` SKILL.md body via citation
+- [#106](https://github.com/tsukumogami/shirabe/issues/106): refuse-and-redirect Slot 5 paragraph (smallest remaining; quick land)

--- a/docs/prds/PRD-shirabe-scope-skill.md
+++ b/docs/prds/PRD-shirabe-scope-skill.md
@@ -884,16 +884,23 @@ as-priority-1 ordering at the chain-orchestration altitude: when
 two diverging is a contract violation surface, not a benign
 condition.
 
-**R21 [/scope-specific].** `/scope` SHALL run a worktree-staleness
-check before each Phase 2 child invocation (fold of observation
-#11). Before invoking `/brief`, `/prd`, `/design`, or `/plan`,
-`/scope` MUST execute the equivalent of `git fetch && git
-status --branch --short` against the worktree's tracking branch.
-If the worktree's upstream has new commits on the target branch,
-`/scope` MUST halt and surface the staleness to the author with
-three options: rebase (re-fetch and rebase the feature branch),
-proceed anyway (accept the risk; record the divergence in the
-state file), or bail (route per R8's bail-handling).
+**R21 [/scope-specific].** `/scope` SHALL keep its worktree in sync
+with upstream across the chain by attempting a silent rebase
+before each Phase 2 child invocation (fold of observation #11).
+Before invoking `/brief`, `/prd`, `/design`, or `/plan`, `/scope`
+MUST execute the equivalent of `git fetch && git rebase
+origin/<tracking-branch>` against the worktree. When the rebase
+succeeds cleanly (no conflicts), `/scope` MUST record an
+informational entry naming the upstream commits that landed and
+proceed directly to child invocation — the author is not prompted,
+the chain continues. When the rebase produces conflicts, `/scope`
+MUST halt and route the decision to the team lead with full
+conflict context (which files conflict, the upstream commits
+involved); the team lead applies the Q2c discipline (resolve from
+artifact context / delegate investigation / invoke `/shirabe:decision` /
+escalate to author). Only when the team lead escalates does the
+three-option prompt (resolve-and-continue / proceed-anyway-against-
+unrebased-base / bail-per-R8) surface to the author.
 
 The check trigger fires "before each Phase 2 child invocation"
 (not on every `/scope` invocation, not after each child completes)
@@ -1295,21 +1302,27 @@ requirement that motivates them and the user story they exercise
   routes to bail-handling rather than the happy path.
   `[automated-eval]` (R20)
 - [ ] **AC28** Before each Phase 2 child invocation, `/scope`
-  executes a worktree-staleness check (equivalent to `git fetch
-  && git status --branch --short`). When the worktree's
-  upstream has new commits on the target branch, `/scope` halts
-  and surfaces a three-option prompt: rebase, proceed anyway, or
-  bail. The observable: the SKILL.md / phase-2 reference
-  documents the trigger condition; an eval scenario verifies the
-  halt fires when upstream divergence is simulated.
-  `[automated-eval]` (R21)
+  attempts a silent rebase (equivalent to `git fetch && git
+  rebase origin/<tracking-branch>`). On clean rebase, `/scope`
+  records an informational state-file entry naming the upstream
+  commits that landed and proceeds directly to child invocation
+  (no author prompt, no team-lead prompt). On rebase conflict,
+  `/scope` halts and routes the conflict to the team lead with
+  full context. The observable: the SKILL.md / phase-2 reference
+  documents the default (silent rebase) and the conflict-fallback;
+  an eval scenario verifies clean rebase proceeds silently and a
+  second scenario verifies conflict halts and surfaces to team
+  lead. `[automated-eval]` (R21)
 - [ ] **AC28b** `references/parent-skill-worktree-discipline.md`
   exists at the top-level reference root and documents the
-  trigger condition (before each Phase 2 child invocation), the
-  three-option prompt, and the state-file recording of "proceed
-  anyway" divergence. The reference is cited from `/scope`'s
-  Phase 2 chain-orchestration reference file. `[automated-unit]`
-  (R21)
+  default behavior (attempt silent rebase before each Phase 2
+  child invocation), the informational recording of clean-rebase
+  events, the conflict-fallback routing to the team lead, and the
+  three-option escalation prompt (resolve-and-continue / proceed-
+  anyway-against-unrebased-base / bail) that surfaces only when
+  the team lead escalates to the author. The reference is cited
+  from `/scope`'s Phase 2 chain-orchestration reference file.
+  `[automated-unit]` (R21)
 - [ ] **AC29a** The motivating
   `docs/plans/PLAN-shirabe-scope-skill.md` produced as part of
   /scope's ship uses `<<ISSUE:N>>` placeholder syntax verbatim

--- a/docs/prds/PRD-shirabe-scope-skill.md
+++ b/docs/prds/PRD-shirabe-scope-skill.md
@@ -885,22 +885,52 @@ two diverging is a contract violation surface, not a benign
 condition.
 
 **R21 [/scope-specific].** `/scope` SHALL keep its worktree in sync
-with upstream across the chain by attempting a silent rebase
-before each Phase 2 child invocation (fold of observation #11).
-Before invoking `/brief`, `/prd`, `/design`, or `/plan`, `/scope`
-MUST execute the equivalent of `git fetch && git rebase
-origin/<tracking-branch>` against the worktree. When the rebase
-succeeds cleanly (no conflicts), `/scope` MUST record an
-informational entry naming the upstream commits that landed and
-proceed directly to child invocation — the author is not prompted,
-the chain continues. When the rebase produces conflicts, `/scope`
-MUST halt and route the decision to the team lead with full
-conflict context (which files conflict, the upstream commits
-involved); the team lead applies the Q2c discipline (resolve from
-artifact context / delegate investigation / invoke `/shirabe:decision` /
-escalate to author). Only when the team lead escalates does the
-three-option prompt (resolve-and-continue / proceed-anyway-against-
-unrebased-base / bail-per-R8) surface to the author.
+with upstream across the chain and SHALL escalate based on whether
+upstream changes invalidate the chain's intent, NOT on whether the
+rebase was clean (fold of observation #11). Before invoking
+`/brief`, `/prd`, `/design`, or `/plan`, `/scope` MUST:
+
+1. **Attempt rebase.** Execute the equivalent of `git fetch && git
+   rebase origin/<tracking-branch>`. Both clean rebases and
+   conflicted rebases proceed to step 2 (mechanical conflict
+   resolution is sub-agent work using artifact context; conflicts
+   that cannot be resolved from artifact context escalate via the
+   same impact-classification step below, not as a separate path).
+
+2. **Analyze contextual impact.** Read the upstream commits that
+   landed in step 1 and cross-reference them against the chain's
+   authored artifacts (BRIEF, PRD, DESIGN, PLAN as they exist at
+   this point in the chain) AND against the inputs the next child
+   invocation will consume. Classify the impact:
+   - **None**: upstream changes touch no path, symbol, or contract
+     the chain depends on.
+   - **Informational**: upstream changes touch something the chain
+     references, but the change is non-substantive (typo, comment,
+     formatting).
+   - **Intent-changing**: upstream changes alter a contract,
+     interface, or fact the chain has committed to (e.g., a child
+     skill's input format changed; a referenced file was renamed
+     or removed; a doc the BRIEF cites was rewritten).
+
+3. **Escalate based on impact.**
+   - **None or Informational**: record the rebase in
+     `worktree_rebases:` and proceed to child invocation. The team
+     lead and author are not prompted.
+   - **Intent-changing**: route to the team lead with full
+     evidence (which artifact, which referenced contract,
+     specifically what changed). The team lead decides whether the
+     original session intent still holds; if it does, the team
+     lead may resolve in-place (e.g., update a citation in the
+     chain's authored artifact, then proceed). If the intent has
+     genuinely changed, the team lead MUST escalate to the author
+     with the three-option prompt: re-author affected artifacts
+     against the new contract / proceed against the original intent
+     (recording the divergence) / bail per R8.
+
+The author is bothered ONLY when the session's original intent has
+changed. Mechanical conflicts, cosmetic upstream changes, and
+contract changes the team lead can resolve from artifact context
+never reach the author.
 
 The check trigger fires "before each Phase 2 child invocation"
 (not on every `/scope` invocation, not after each child completes)
@@ -1302,26 +1332,28 @@ requirement that motivates them and the user story they exercise
   routes to bail-handling rather than the happy path.
   `[automated-eval]` (R20)
 - [ ] **AC28** Before each Phase 2 child invocation, `/scope`
-  attempts a silent rebase (equivalent to `git fetch && git
-  rebase origin/<tracking-branch>`). On clean rebase, `/scope`
-  records an informational state-file entry naming the upstream
-  commits that landed and proceeds directly to child invocation
-  (no author prompt, no team-lead prompt). On rebase conflict,
-  `/scope` halts and routes the conflict to the team lead with
-  full context. The observable: the SKILL.md / phase-2 reference
-  documents the default (silent rebase) and the conflict-fallback;
-  an eval scenario verifies clean rebase proceeds silently and a
-  second scenario verifies conflict halts and surfaces to team
-  lead. `[automated-eval]` (R21)
+  attempts a rebase, then analyzes the contextual impact of any
+  upstream commits that landed. The observable: an eval scenario
+  with upstream changes that touch a chain-referenced contract
+  verifies `/scope` halts and routes to the team lead with
+  evidence; a second scenario with upstream changes orthogonal to
+  the chain verifies `/scope` proceeds silently without prompting
+  either the team lead or the author; a third scenario with a
+  rebase conflict in a chain-orthogonal file verifies the conflict
+  is resolved from artifact context (or by the parent's
+  conflict-resolution sub-agent) without escalation. `[automated-eval]`
+  (R21)
 - [ ] **AC28b** `references/parent-skill-worktree-discipline.md`
   exists at the top-level reference root and documents the
-  default behavior (attempt silent rebase before each Phase 2
-  child invocation), the informational recording of clean-rebase
-  events, the conflict-fallback routing to the team lead, and the
-  three-option escalation prompt (resolve-and-continue / proceed-
-  anyway-against-unrebased-base / bail) that surfaces only when
-  the team lead escalates to the author. The reference is cited
-  from `/scope`'s Phase 2 chain-orchestration reference file.
+  trigger condition (before each Phase 2 child invocation), the
+  rebase-then-analyze flow, the three-level impact classification
+  (none / informational / intent-changing), the escalation
+  contract (none/informational → proceed silently; intent-changing
+  → team lead, then author only if intent genuinely changed), and
+  the three-option author-facing prompt (re-author affected
+  artifacts / proceed against original intent / bail) that surfaces
+  only on team-lead escalation. The reference is cited from
+  `/scope`'s Phase 2 chain-orchestration reference file.
   `[automated-unit]` (R21)
 - [ ] **AC29a** The motivating
   `docs/plans/PLAN-shirabe-scope-skill.md` produced as part of

--- a/references/parent-skill-worktree-discipline.md
+++ b/references/parent-skill-worktree-discipline.md
@@ -52,23 +52,24 @@ git fetch
 git rebase origin/<tracking-branch>
 ```
 
-**Clean rebase**: proceed directly to Step 2 with the list of
-upstream commits that landed.
+**Clean rebase**: proceed directly to the impact-analysis phase
+with the list of upstream commits that landed.
 
 **Conflicted rebase**: the parent's conflict-resolution sub-agent (or
 the parent itself in solo mode) attempts to resolve the conflict
 from artifact context. BRIEF, PRD, and DESIGN citations frequently
 make the correct resolution obvious — if the chain's artifact says
 "the input format is X" and upstream changes the format to Y, the
-resolution is to align with Y. Resolved conflicts proceed to Step 2
-with the resolution noted. Conflicts that cannot be resolved from
-artifact context proceed to Step 2 anyway, carrying the unresolved
-conflict as part of the diff the analysis will classify.
+resolution is to align with Y. Resolved conflicts proceed to the
+impact-analysis phase with the resolution noted. Conflicts that
+cannot be resolved from artifact context proceed to the
+impact-analysis phase anyway, carrying the unresolved conflict as
+part of the diff the analysis will classify.
 
 ## Impact-analysis phase
 
-Read the upstream commits that landed in Step 1 and cross-reference
-them against:
+Read the upstream commits that landed in the rebase phase and
+cross-reference them against:
 
 - The chain's authored artifacts at this point (BRIEF, PRD, DESIGN,
   PLAN as they exist).

--- a/references/parent-skill-worktree-discipline.md
+++ b/references/parent-skill-worktree-discipline.md
@@ -111,11 +111,8 @@ appended to as additional divergence events occur — one entry per
 "Proceed anyway" selection, in chronological order. The list never
 shrinks within a single chain instance.
 
-The list is a Layer-2 extension over the 5-field minimum schema; it
-exists for two consumers: the parent's finalization step (which can
-mention divergence acceptance in the exit-artifact's body or
-companion Decision Record), and a future reviewer auditing how a
-chain interacted with upstream change.
+The list is a Layer-2 extension over the 5-field minimum schema
+(see [`parent-skill-state-schema.md`](parent-skill-state-schema.md)).
 
 ## Integration with Chain-Proposal Prompt
 
@@ -130,20 +127,9 @@ boundary:
    the parent run `git fetch && git status --branch --short` against
    the tracking branch.
 
-The order is load-bearing. Running `git fetch` before the author has
-decided whether to proceed adds network latency to a prompt that is
-otherwise short and well-bounded (the chain-proposal prompt itself
-makes no network calls). Reversing the order would pay that latency
-on every Phase 1 termination, even the ones the author rejects or
-revises. The current order pays the cost only when the chain is going
-to run.
-
-Future parents follow the same convention: chain-proposal first,
-staleness check second. The integration is symmetric across the
-chain — the same ordering applies to each subsequent child invocation
-within Phase 2 (the chain-proposal confirmation in step 1 establishes
-the chain once; the per-child staleness check rides on each child
-boundary inside that confirmed chain).
+The order is load-bearing: `git fetch` adds network latency the
+chain-proposal prompt itself does not pay. The current order pays
+the cost only when the chain is going to run.
 
 ## Binding Notes
 

--- a/references/parent-skill-worktree-discipline.md
+++ b/references/parent-skill-worktree-discipline.md
@@ -1,13 +1,22 @@
 # Parent-Skill Worktree Discipline
 
-The rule every parent skill follows for keeping its worktree in sync
-with upstream across a multi-child chain: before each Phase 2 child
-invocation, the parent SHALL attempt `git fetch && git rebase
-origin/<tracking-branch>` silently. Clean rebases proceed without
-prompting; conflicts route to the team lead. The author is bothered
-only when the team lead escalates an unresolved conflict. Per-parent
-bindings live in the Binding Notes section at the end; everything
-above that section is substrate-agnostic.
+The rule every parent skill follows when upstream advances mid-chain:
+**escalate based on whether upstream changes invalidate the chain's
+intent, not on whether the rebase was mechanically clean.** A clean
+rebase can silently land a contract change that breaks the chain's
+references; a mechanical conflict can be in a file the chain doesn't
+care about. The discipline below replaces mechanical-conflict
+signals with contextual-impact signals at every step.
+
+Before each Phase 2 child invocation, the parent runs a three-step
+flow: rebase, analyze impact, escalate by impact level. Every actor
+in the chain operates at its appropriate altitude — sub-agents
+handle git mechanics and conflict resolution, the team lead handles
+judgment calls about intent, and the author is brought in only when
+the original session direction is in question.
+
+Per-parent bindings live in the Binding Notes section at the end;
+everything above that section is substrate-agnostic.
 
 Companion references:
 
@@ -20,131 +29,177 @@ Companion references:
 
 ## Trigger Condition
 
-The rebase attempt fires **before each Phase 2 child invocation** —
-never once per parent invocation. Precisely:
+The flow fires **before each Phase 2 child invocation** — never once
+per parent invocation. Precisely:
 
 1. After the parent's Phase 1 emits its chain-proposal output and the
    author confirms the proposed chain.
 2. Before each child invocation in the confirmed `planned_chain`.
 
-The attempt runs once per child invocation in the chain. For a parent
-with four children in its longest chain, it fires up to four times
-across a single full-run; for three children, up to three times.
-Bounded by chain step count, not wallclock time.
+The flow runs once per child invocation in the chain. For a parent
+with four children in its longest chain, it fires up to four times;
+for three children, up to three. Bounded by chain step count, not
+wallclock time — a long-running child does not retrigger the flow on
+its own.
 
-## Default: Silent Rebase
+## Step 1 — Rebase
 
-Before each child invocation, the parent SHALL execute the equivalent
-of:
+Execute the equivalent of:
 
 ```
 git fetch
 git rebase origin/<tracking-branch>
 ```
 
-The parent owns the branch during the chain — there is no parallel-
-author work to disrupt — so silent rebase is safe by default.
+**Clean rebase**: proceed directly to Step 2 with the list of
+upstream commits that landed.
 
-**Clean rebase** (no conflicts): the parent records an informational
-entry in `worktree_rebases:` (see Recording below) naming the
-upstream commits that landed and proceeds directly to child
-invocation. The author is not prompted; the team lead is not
-prompted.
+**Conflicted rebase**: the parent's conflict-resolution sub-agent (or
+the parent itself in solo mode) attempts to resolve the conflict
+from artifact context. BRIEF, PRD, and DESIGN citations frequently
+make the correct resolution obvious — if the chain's artifact says
+"the input format is X" and upstream changes the format to Y, the
+resolution is to align with Y. Resolved conflicts proceed to Step 2
+with the resolution noted. Conflicts that cannot be resolved from
+artifact context proceed to Step 2 anyway, carrying the unresolved
+conflict as part of the diff the analysis will classify.
 
-**No-op rebase** (upstream had not advanced): the parent proceeds
-directly to child invocation. No recording, no prompt — the routine
-case.
+The point: mechanical conflict status is never the escalation
+signal. Conflicts are sub-agent work, not author work.
 
-## Conflict Fallback: Route to Team Lead
+## Step 2 — Contextual Impact Analysis
 
-When the rebase produces conflicts, the parent SHALL halt the chain
-at the pre-invocation point and route the conflict to the team lead
-with full context:
+Read the upstream commits that landed in Step 1 and cross-reference
+them against:
 
-- Which files conflict
-- The upstream commits involved (SHAs + subjects)
-- The conflicted hunks
+- The chain's authored artifacts at this point (BRIEF, PRD, DESIGN,
+  PLAN as they exist).
+- The inputs the next child invocation will consume.
 
-The team lead applies its standard discipline:
+Classify the impact at one of three levels:
 
-1. Resolve from artifact context — if the BRIEF, PRD, or DESIGN cites
-   the conflicted file and the right resolution is obvious from that
-   citation, resolve and continue.
-2. Delegate investigation — spawn a research agent to read the
-   conflicting upstream commits and report whether they change a
-   contract the chain depends on.
-3. Invoke `/shirabe:decision` — for genuine judgment calls where
-   neither artifact context nor code investigation settles the
-   question.
-4. Escalate to the author — for genuine ambiguity, the team lead
-   surfaces a three-option prompt: **Resolve and continue** (the
-   author manually resolves, the parent re-runs the rebase, then
-   proceeds to child invocation), **Proceed anyway against the
-   unrebased base** (the parent abandons the rebase, records the
-   divergence per Recording below, and continues to child invocation
-   on the original base), or **Bail** (terminate the chain per the
-   parent's own bail-handling rule).
+- **None** — upstream changes touch no path, symbol, or contract the
+  chain depends on. Examples: a recipe added to a different package;
+  a doc reformatted in a subsystem the chain doesn't reference; a
+  test added that the chain doesn't run.
 
-The author is brought into the loop only at step 4 — and only when
-the team lead cannot decide. Cosmetic upstream PRs, orthogonal
-changes, or conflicts the artifact context resolves never reach the
-author.
+- **Informational** — chain-referenced content was touched, but
+  non-substantively. Examples: a typo fix in a doc the BRIEF cites;
+  a comment added to a function the DESIGN names; a whitespace
+  change in a config file the PLAN references.
+
+- **Intent-changing** — a contract, interface, or fact the chain has
+  committed to was altered. Examples: a child skill's input format
+  changed (BRIEF/PRD cited the old format); a referenced file was
+  renamed or removed; a doc the BRIEF cites was rewritten such that
+  the citation no longer supports the BRIEF's claim; a recipe the
+  PLAN expects to ship was withdrawn.
+
+The classification is what an analyzer agent would produce after
+reading the upstream commits and the chain's artifacts. It is not a
+purely syntactic check — it requires judgment about whether a
+referenced change is substantive enough to alter what the chain is
+doing.
+
+## Step 3 — Escalate Based on Impact
+
+**None or Informational**: record the rebase in `worktree_rebases:`
+(see Recording) and proceed to child invocation. The team lead is
+not prompted; the author is not prompted.
+
+**Intent-changing**: halt and route to the team lead with full
+evidence — which authored artifact, which referenced contract, what
+specifically changed, and the analyzer's classification reasoning.
+The team lead decides whether the original session intent still
+holds against the new upstream reality:
+
+- If yes — the chain is still doing the right thing, but a citation
+  or a small claim in an artifact needs adjusting — the team lead
+  resolves in-place. Update the affected citation or claim, then
+  proceed to child invocation. Record in `worktree_rebases:` with
+  classification `intent-changing-resolved-in-place`.
+- If no — the intent has genuinely shifted — the team lead escalates
+  to the author with a three-option prompt:
+  - **Re-author affected artifacts** against the new contract, then
+    continue the chain.
+  - **Proceed against original intent**: keep the chain pointed at
+    the prior contract, accept that the eventual PR will need to
+    address the divergence at review time. Recorded in
+    `worktree_divergences:`.
+  - **Bail** per the parent's own bail-handling rule.
+
+The author is brought into the loop only at the last branch — and
+only when the team lead has concluded that intent has changed.
+Mechanical conflicts, cosmetic upstream changes, and contract
+changes the team lead can resolve from artifact context never reach
+the author.
 
 ## Recording
 
 Two conditional state-file lists, both extensions over the 5-field
 minimum schema (see [`parent-skill-state-schema.md`](parent-skill-state-schema.md)).
 
-**`worktree_rebases:`** — informational. Appended on every clean
-rebase that brought new upstream commits in. Absent if no rebase ever
-brought commits in.
+**`worktree_rebases:`** — appended after every rebase that brought
+new upstream commits in (regardless of classification, except when
+the chain bailed). Informational. Entries:
 
 ```yaml
 worktree_rebases:
   - phase: <next-child-name>
     upstream_commits: [<sha>, <sha>, ...]
+    impact: none | informational | intent-changing-resolved-in-place
     rebased_at: <ISO-8601 timestamp>
+    notes: <optional — e.g., which citation was updated for in-place resolution>
 ```
 
 **`worktree_divergences:`** — decision audit. Appended only when the
-conflict-fallback escalated to the author and the author chose
-"Proceed anyway against the unrebased base." Absent in the common
-case (no conflict, or conflict resolved without escalation).
+team lead escalated an intent-changing event to the author and the
+author chose "proceed against original intent." Absent in the common
+case. Entries:
 
 ```yaml
 worktree_divergences:
   - phase: <next-child-name>
-    conflict_summary: <files + nature>
+    affected_contracts: [<artifact + cite>, ...]
     upstream_commits: [<sha>, <sha>, ...]
     accepted_at: <ISO-8601 timestamp>
 ```
 
 Both lists are appended in chronological order and never shrink
-within a chain instance. They exist so the parent's finalization step
-can surface upstream-interaction history in the terminal artifact,
-and so future reviewers can audit how the chain handled upstream
-change.
+within a chain instance. They exist so the parent's finalization
+step can surface upstream-interaction history in the terminal
+artifact, and so future reviewers can audit how the chain handled
+upstream change.
 
 ## Integration with Chain-Proposal Prompt
 
-The rebase attempt fires **after** chain-proposal confirmation, not
-before. The chain-proposal prompt itself makes no network calls;
-running `git fetch` before the author confirms would pay network
-latency on every Phase 1 termination, including the ones the author
-rejects or revises. The current order pays the cost only when the
-chain is going to run.
+The flow fires **after** chain-proposal confirmation, not before.
+The chain-proposal prompt itself makes no network calls; running
+`git fetch` before the author confirms would pay network latency on
+every Phase 1 termination, including the ones the author rejects or
+revises. The current order pays the cost only when the chain is
+going to run.
 
 ## Binding Notes
 
-The body above is parent-agnostic. Per-parent bindings live here. New
-parents inherit the discipline by adding a binding-notes row rather
-than re-authoring the body.
+The body above is parent-agnostic. Per-parent bindings live here.
+New parents inherit the discipline by adding a binding-notes row
+rather than re-authoring the body.
 
-| Parent | Status | Chain length | Bail target |
-|--------|--------|--------------|-------------|
-| `/scope` v1 | load-bearing | 4 children (longest chain in shirabe) | the parent's own bail-handling rule in `skills/scope/SKILL.md` |
-| `/charter` | load-bearing (back-edit) | 3 children | the parent's own bail-handling rule in `skills/charter/SKILL.md` |
-| `/work-on` | future | TBD | binding deferred to the amplifier-layer parent migration |
+| Parent | Status | Chain length | Bail target | Analyzer actor |
+|--------|--------|--------------|-------------|----------------|
+| `/scope` v1 | load-bearing | 4 children (longest chain in shirabe) | the parent's own bail-handling rule in `skills/scope/SKILL.md` | parent itself (solo mode); team-lead-spawned sub-agent (amplifier mode) |
+| `/charter` | load-bearing (back-edit) | 3 children | the parent's own bail-handling rule in `skills/charter/SKILL.md` | parent itself (solo); team-lead-spawned sub-agent (amplifier) |
+| `/work-on` | future | TBD | binding deferred to the amplifier-layer parent migration | binding deferred |
+
+The "Analyzer actor" column reflects the team-primitive substitution
+surface (see `parent-skill-pattern.md`). In v1's
+`single-team-per-leader-no-nested` substrate, the parent skill is
+single-agent and does the impact analysis itself. In an amplifier-
+layer substrate where the parent can dispatch sub-agents, the
+analysis can be delegated to a worktree-sync-analyzer sub-agent that
+reports back to the parent. The discipline is identical across
+substrates; only the actor changes.
 
 The "Bail target" column intentionally names the per-parent SKILL.md
 rather than reproducing the bail logic here. Naming a specific

--- a/references/parent-skill-worktree-discipline.md
+++ b/references/parent-skill-worktree-discipline.md
@@ -1,138 +1,138 @@
 # Parent-Skill Worktree Discipline
 
-The rule every parent skill follows for keeping its working tree in
-sync with its tracking branch across a multi-child chain: before each
-Phase 2 child invocation, the parent SHALL check whether the upstream
-tracking branch has advanced since the chain started, and SHALL
-surface a three-option prompt (Rebase / Proceed anyway / Bail) when it
-has. The check is parent-agnostic infrastructure: this document
-defines the trigger, the prompt shape, the state-file recording
-convention for divergence acceptance, and the integration order with
-the chain-proposal prompt. Per-parent bindings live in the Binding
-Notes section at the end; everything above that section is
-substrate-agnostic.
+The rule every parent skill follows for keeping its worktree in sync
+with upstream across a multi-child chain: before each Phase 2 child
+invocation, the parent SHALL attempt `git fetch && git rebase
+origin/<tracking-branch>` silently. Clean rebases proceed without
+prompting; conflicts route to the team lead. The author is bothered
+only when the team lead escalates an unresolved conflict. Per-parent
+bindings live in the Binding Notes section at the end; everything
+above that section is substrate-agnostic.
 
 Companion references:
 
-- [`parent-skill-pattern.md`](parent-skill-pattern.md) — the contract surface
-  this rule sits inside (Phase 2 child invocation loop, exit-path
-  enumeration).
+- [`parent-skill-pattern.md`](parent-skill-pattern.md) — the contract
+  surface this rule sits inside (Phase 2 child invocation loop,
+  exit-path enumeration).
 - [`parent-skill-state-schema.md`](parent-skill-state-schema.md) — the
-  conditional-field extension discipline the `worktree_divergences:`
-  list rides on.
+  conditional-field extension discipline `worktree_rebases:` and
+  `worktree_divergences:` ride on.
 
 ## Trigger Condition
 
-The worktree-staleness check fires **before each Phase 2 child
-invocation** — never once per parent invocation. Precisely:
+The rebase attempt fires **before each Phase 2 child invocation** —
+never once per parent invocation. Precisely:
 
 1. After the parent's Phase 1 emits its chain-proposal output and the
    author confirms the proposed chain.
 2. Before each child invocation in the confirmed `planned_chain`.
 
-The check therefore runs once per child invocation in the chain. For
-a parent with four children in its longest chain, the check fires up
-to four times across a single full-run; for a parent with three
-children, up to three times. The trigger is bounded by chain step
-count, not by wallclock time — a long-running child does not retrigger
-the check on its own. The next check fires when the parent moves on
-to the next child.
+The attempt runs once per child invocation in the chain. For a parent
+with four children in its longest chain, it fires up to four times
+across a single full-run; for three children, up to three times.
+Bounded by chain step count, not wallclock time.
 
-The check itself is two commands against the current branch:
+## Default: Silent Rebase
+
+Before each child invocation, the parent SHALL execute the equivalent
+of:
 
 ```
 git fetch
-git status --branch --short
+git rebase origin/<tracking-branch>
 ```
 
-If the porcelain output reports the upstream tracking branch is ahead
-of the local branch (any non-zero "behind" count), the staleness
-condition is met and the prompt below surfaces. Otherwise the parent
-proceeds directly to child invocation.
+The parent owns the branch during the chain — there is no parallel-
+author work to disrupt — so silent rebase is safe by default.
 
-## Three-Option Prompt
+**Clean rebase** (no conflicts): the parent records an informational
+entry in `worktree_rebases:` (see Recording below) naming the
+upstream commits that landed and proceeds directly to child
+invocation. The author is not prompted; the team lead is not
+prompted.
 
-When staleness is detected, the parent surfaces a three-option prompt
-labeled exactly:
+**No-op rebase** (upstream had not advanced): the parent proceeds
+directly to child invocation. No recording, no prompt — the routine
+case.
 
-- **Rebase** — bring the worktree forward before invoking the next
-  child. The parent emits the commands `git fetch && git rebase` for
-  the author and waits for the author's manual approval before running
-  them. The parent SHALL NOT auto-rebase: the rebase only runs after
-  the author confirms. After a successful rebase, the parent re-runs
-  the check (the rebase itself may surface new upstream commits) and
-  then proceeds to child invocation.
-- **Proceed anyway** — accept the divergence and continue to child
-  invocation. The parent SHALL record the divergence event in its
-  state file per the Recording section below. The child then runs
-  against the diverged worktree.
-- **Bail** — terminate the chain at this point. Bail routes per the
-  parent's own bail-handling rule. This document does not name the
-  bail target inline; it is parent-specific and lives in the parent's
-  own SKILL.md (see Binding Notes for the per-parent mapping).
+## Conflict Fallback: Route to Team Lead
 
-The prompt is presented as a single three-option AskUserQuestion. The
-options' labels are stable across parents: "Rebase", "Proceed anyway",
-and "Bail". Future parents bind to the same three labels so the
-discipline reads identically from the author's perspective regardless
-of which chain they are running.
+When the rebase produces conflicts, the parent SHALL halt the chain
+at the pre-invocation point and route the conflict to the team lead
+with full context:
 
-## Recording "Proceed Anyway" Divergence
+- Which files conflict
+- The upstream commits involved (SHAs + subjects)
+- The conflicted hunks
 
-When the author selects "Proceed anyway", the parent's state file
-gains an entry under a conditional list named `worktree_divergences:`.
-Each entry has the shape:
+The team lead applies its standard discipline:
+
+1. Resolve from artifact context — if the BRIEF, PRD, or DESIGN cites
+   the conflicted file and the right resolution is obvious from that
+   citation, resolve and continue.
+2. Delegate investigation — spawn a research agent to read the
+   conflicting upstream commits and report whether they change a
+   contract the chain depends on.
+3. Invoke `/shirabe:decision` — for genuine judgment calls where
+   neither artifact context nor code investigation settles the
+   question.
+4. Escalate to the author — for genuine ambiguity, the team lead
+   surfaces a three-option prompt: **Resolve and continue** (the
+   author manually resolves, the parent re-runs the rebase, then
+   proceeds to child invocation), **Proceed anyway against the
+   unrebased base** (the parent abandons the rebase, records the
+   divergence per Recording below, and continues to child invocation
+   on the original base), or **Bail** (terminate the chain per the
+   parent's own bail-handling rule).
+
+The author is brought into the loop only at step 4 — and only when
+the team lead cannot decide. Cosmetic upstream PRs, orthogonal
+changes, or conflicts the artifact context resolves never reach the
+author.
+
+## Recording
+
+Two conditional state-file lists, both extensions over the 5-field
+minimum schema (see [`parent-skill-state-schema.md`](parent-skill-state-schema.md)).
+
+**`worktree_rebases:`** — informational. Appended on every clean
+rebase that brought new upstream commits in. Absent if no rebase ever
+brought commits in.
+
+```yaml
+worktree_rebases:
+  - phase: <next-child-name>
+    upstream_commits: [<sha>, <sha>, ...]
+    rebased_at: <ISO-8601 timestamp>
+```
+
+**`worktree_divergences:`** — decision audit. Appended only when the
+conflict-fallback escalated to the author and the author chose
+"Proceed anyway against the unrebased base." Absent in the common
+case (no conflict, or conflict resolved without escalation).
 
 ```yaml
 worktree_divergences:
-  - phase: <child-name>
-    upstream_ahead_by: <integer>
+  - phase: <next-child-name>
+    conflict_summary: <files + nature>
+    upstream_commits: [<sha>, <sha>, ...]
     accepted_at: <ISO-8601 timestamp>
 ```
 
-The fields are:
-
-- **`phase`** — the next-child name the parent was about to invoke
-  when the divergence was accepted (e.g., the child slot in
-  `planned_chain` that the check ran against). The value is the
-  child's name, not its index.
-- **`upstream_ahead_by`** — the integer commit count by which the
-  upstream tracking branch was ahead at the time of acceptance,
-  parsed from `git status --branch --short`. Recorded once at
-  acceptance time; the parent does not re-poll.
-- **`accepted_at`** — ISO-8601 timestamp at which the author selected
-  "Proceed anyway".
-
-The list is **conditional** in the sense of the conditional-field
-discipline named in `parent-skill-state-schema.md`: the
-`worktree_divergences:` key is absent from the state file entirely
-when no divergence has been accepted in this chain. The list is
-appended to as additional divergence events occur — one entry per
-"Proceed anyway" selection, in chronological order. The list never
-shrinks within a single chain instance.
-
-The list is a Layer-2 extension over the 5-field minimum schema
-(see [`parent-skill-state-schema.md`](parent-skill-state-schema.md)).
-It exists so the parent's finalization step can surface divergence
-history in the terminal artifact, and so future reviewers can audit
-how the chain interacted with upstream change.
+Both lists are appended in chronological order and never shrink
+within a chain instance. They exist so the parent's finalization step
+can surface upstream-interaction history in the terminal artifact,
+and so future reviewers can audit how the chain handled upstream
+change.
 
 ## Integration with Chain-Proposal Prompt
 
-The staleness check fires **after** chain-proposal confirmation, not
-before. Two checks happen in sequence at the Phase 1 to Phase 2
-boundary:
-
-1. The chain-proposal prompt: the parent surfaces the proposed chain
-   (which children will run, in what order) and the author confirms,
-   revises, or rejects it.
-2. The staleness check: only after the author confirms the chain does
-   the parent run `git fetch && git status --branch --short` against
-   the tracking branch.
-
-The order is load-bearing: `git fetch` adds network latency the
-chain-proposal prompt itself does not pay. The current order pays
-the cost only when the chain is going to run.
+The rebase attempt fires **after** chain-proposal confirmation, not
+before. The chain-proposal prompt itself makes no network calls;
+running `git fetch` before the author confirms would pay network
+latency on every Phase 1 termination, including the ones the author
+rejects or revises. The current order pays the cost only when the
+chain is going to run.
 
 ## Binding Notes
 
@@ -147,8 +147,6 @@ than re-authoring the body.
 | `/work-on` | future | TBD | binding deferred to the amplifier-layer parent migration |
 
 The "Bail target" column intentionally names the per-parent SKILL.md
-rather than reproducing the bail logic here. The body section above
-says "the parent's own bail-handling rule" for the same reason —
-naming a specific parent's bail rule (such as `/scope` R8) inline
-would couple the body to one parent's vocabulary and force a rewrite
-when a second parent's bail rule diverges.
+rather than reproducing the bail logic here. Naming a specific
+parent's bail rule (such as `/scope` R8) inline would couple the
+body to one parent's vocabulary.

--- a/references/parent-skill-worktree-discipline.md
+++ b/references/parent-skill-worktree-discipline.md
@@ -1,0 +1,165 @@
+# Parent-Skill Worktree Discipline
+
+The rule every parent skill follows for keeping its working tree in
+sync with its tracking branch across a multi-child chain: before each
+Phase 2 child invocation, the parent SHALL check whether the upstream
+tracking branch has advanced since the chain started, and SHALL
+surface a three-option prompt (Rebase / Proceed anyway / Bail) when it
+has. The check is parent-agnostic infrastructure: this document
+defines the trigger, the prompt shape, the state-file recording
+convention for divergence acceptance, and the integration order with
+the chain-proposal prompt. Per-parent bindings live in the Binding
+Notes section at the end; everything above that section is
+substrate-agnostic.
+
+Companion references:
+
+- [`parent-skill-pattern.md`](parent-skill-pattern.md) — the contract surface
+  this rule sits inside (Phase 2 child invocation loop, exit-path
+  enumeration).
+- [`parent-skill-state-schema.md`](parent-skill-state-schema.md) — the
+  conditional-field extension discipline the `worktree_divergences:`
+  list rides on.
+
+## Trigger Condition
+
+The worktree-staleness check fires **before each Phase 2 child
+invocation** — never once per parent invocation. Precisely:
+
+1. After the parent's Phase 1 emits its chain-proposal output and the
+   author confirms the proposed chain.
+2. Before each child invocation in the confirmed `planned_chain`.
+
+The check therefore runs once per child invocation in the chain. For
+a parent with four children in its longest chain, the check fires up
+to four times across a single full-run; for a parent with three
+children, up to three times. The trigger is bounded by chain step
+count, not by wallclock time — a long-running child does not retrigger
+the check on its own. The next check fires when the parent moves on
+to the next child.
+
+The check itself is two commands against the current branch:
+
+```
+git fetch
+git status --branch --short
+```
+
+If the porcelain output reports the upstream tracking branch is ahead
+of the local branch (any non-zero "behind" count), the staleness
+condition is met and the prompt below surfaces. Otherwise the parent
+proceeds directly to child invocation.
+
+## Three-Option Prompt
+
+When staleness is detected, the parent surfaces a three-option prompt
+labeled exactly:
+
+- **Rebase** — bring the worktree forward before invoking the next
+  child. The parent emits the commands `git fetch && git rebase` for
+  the author and waits for the author's manual approval before running
+  them. The parent SHALL NOT auto-rebase: the rebase only runs after
+  the author confirms. After a successful rebase, the parent re-runs
+  the check (the rebase itself may surface new upstream commits) and
+  then proceeds to child invocation.
+- **Proceed anyway** — accept the divergence and continue to child
+  invocation. The parent SHALL record the divergence event in its
+  state file per the Recording section below. The child then runs
+  against the diverged worktree.
+- **Bail** — terminate the chain at this point. Bail routes per the
+  parent's own bail-handling rule. This document does not name the
+  bail target inline; it is parent-specific and lives in the parent's
+  own SKILL.md (see Binding Notes for the per-parent mapping).
+
+The prompt is presented as a single three-option AskUserQuestion. The
+options' labels are stable across parents: "Rebase", "Proceed anyway",
+and "Bail". Future parents bind to the same three labels so the
+discipline reads identically from the author's perspective regardless
+of which chain they are running.
+
+## Recording "Proceed Anyway" Divergence
+
+When the author selects "Proceed anyway", the parent's state file
+gains an entry under a conditional list named `worktree_divergences:`.
+Each entry has the shape:
+
+```yaml
+worktree_divergences:
+  - phase: <child-name>
+    upstream_ahead_by: <integer>
+    accepted_at: <ISO-8601 timestamp>
+```
+
+The fields are:
+
+- **`phase`** — the next-child name the parent was about to invoke
+  when the divergence was accepted (e.g., the child slot in
+  `planned_chain` that the check ran against). The value is the
+  child's name, not its index.
+- **`upstream_ahead_by`** — the integer commit count by which the
+  upstream tracking branch was ahead at the time of acceptance,
+  parsed from `git status --branch --short`. Recorded once at
+  acceptance time; the parent does not re-poll.
+- **`accepted_at`** — ISO-8601 timestamp at which the author selected
+  "Proceed anyway".
+
+The list is **conditional** in the sense of the conditional-field
+discipline named in `parent-skill-state-schema.md`: the
+`worktree_divergences:` key is absent from the state file entirely
+when no divergence has been accepted in this chain. The list is
+appended to as additional divergence events occur — one entry per
+"Proceed anyway" selection, in chronological order. The list never
+shrinks within a single chain instance.
+
+The list is a Layer-2 extension over the 5-field minimum schema; it
+exists for two consumers: the parent's finalization step (which can
+mention divergence acceptance in the exit-artifact's body or
+companion Decision Record), and a future reviewer auditing how a
+chain interacted with upstream change.
+
+## Integration with Chain-Proposal Prompt
+
+The staleness check fires **after** chain-proposal confirmation, not
+before. Two checks happen in sequence at the Phase 1 to Phase 2
+boundary:
+
+1. The chain-proposal prompt: the parent surfaces the proposed chain
+   (which children will run, in what order) and the author confirms,
+   revises, or rejects it.
+2. The staleness check: only after the author confirms the chain does
+   the parent run `git fetch && git status --branch --short` against
+   the tracking branch.
+
+The order is load-bearing. Running `git fetch` before the author has
+decided whether to proceed adds network latency to a prompt that is
+otherwise short and well-bounded (the chain-proposal prompt itself
+makes no network calls). Reversing the order would pay that latency
+on every Phase 1 termination, even the ones the author rejects or
+revises. The current order pays the cost only when the chain is going
+to run.
+
+Future parents follow the same convention: chain-proposal first,
+staleness check second. The integration is symmetric across the
+chain — the same ordering applies to each subsequent child invocation
+within Phase 2 (the chain-proposal confirmation in step 1 establishes
+the chain once; the per-child staleness check rides on each child
+boundary inside that confirmed chain).
+
+## Binding Notes
+
+The body above is parent-agnostic. Per-parent bindings live here. New
+parents inherit the discipline by adding a binding-notes row rather
+than re-authoring the body.
+
+| Parent | Status | Chain length | Bail target |
+|--------|--------|--------------|-------------|
+| `/scope` v1 | load-bearing | 4 children (longest chain in shirabe) | the parent's own bail-handling rule in `skills/scope/SKILL.md` |
+| `/charter` | load-bearing (back-edit) | 3 children | the parent's own bail-handling rule in `skills/charter/SKILL.md` |
+| `/work-on` | future | TBD | binding deferred to the amplifier-layer parent migration |
+
+The "Bail target" column intentionally names the per-parent SKILL.md
+rather than reproducing the bail logic here. The body section above
+says "the parent's own bail-handling rule" for the same reason —
+naming a specific parent's bail rule (such as `/scope` R8) inline
+would couple the body to one parent's vocabulary and force a rewrite
+when a second parent's bail rule diverges.

--- a/references/parent-skill-worktree-discipline.md
+++ b/references/parent-skill-worktree-discipline.md
@@ -113,6 +113,9 @@ shrinks within a single chain instance.
 
 The list is a Layer-2 extension over the 5-field minimum schema
 (see [`parent-skill-state-schema.md`](parent-skill-state-schema.md)).
+It exists so the parent's finalization step can surface divergence
+history in the terminal artifact, and so future reviewers can audit
+how the chain interacted with upstream change.
 
 ## Integration with Chain-Proposal Prompt
 

--- a/references/parent-skill-worktree-discipline.md
+++ b/references/parent-skill-worktree-discipline.md
@@ -40,9 +40,10 @@ The flow runs once per child invocation in the chain. For a parent
 with four children in its longest chain, it fires up to four times;
 for three children, up to three. Bounded by chain step count, not
 wallclock time — a long-running child does not retrigger the flow on
-its own.
+its own. The flow fires after chain-proposal confirmation, not
+before, for reasons documented in DESIGN Decision 4.
 
-## Step 1 — Rebase
+## Rebase phase
 
 Execute the equivalent of:
 
@@ -64,10 +65,7 @@ with the resolution noted. Conflicts that cannot be resolved from
 artifact context proceed to Step 2 anyway, carrying the unresolved
 conflict as part of the diff the analysis will classify.
 
-The point: mechanical conflict status is never the escalation
-signal. Conflicts are sub-agent work, not author work.
-
-## Step 2 — Contextual Impact Analysis
+## Impact-analysis phase
 
 Read the upstream commits that landed in Step 1 and cross-reference
 them against:
@@ -101,7 +99,7 @@ purely syntactic check — it requires judgment about whether a
 referenced change is substantive enough to alter what the chain is
 doing.
 
-## Step 3 — Escalate Based on Impact
+## Escalation phase
 
 **None or Informational**: record the rebase in `worktree_rebases:`
 (see Recording) and proceed to child invocation. The team lead is
@@ -128,13 +126,9 @@ holds against the new upstream reality:
     `worktree_divergences:`.
   - **Bail** per the parent's own bail-handling rule.
 
-The author is brought into the loop only at the last branch — and
-only when the team lead has concluded that intent has changed.
-Mechanical conflicts, cosmetic upstream changes, and contract
-changes the team lead can resolve from artifact context never reach
-the author.
-
 ## Recording
+
+Per I-5 (see [`parent-skill-state-schema.md`](parent-skill-state-schema.md)), these fields MUST be absent when no rebases or divergences have occurred — never null, empty list, or placeholder.
 
 Two conditional state-file lists, both extensions over the 5-field
 minimum schema (see [`parent-skill-state-schema.md`](parent-skill-state-schema.md)).
@@ -171,15 +165,6 @@ step can surface upstream-interaction history in the terminal
 artifact, and so future reviewers can audit how the chain handled
 upstream change.
 
-## Integration with Chain-Proposal Prompt
-
-The flow fires **after** chain-proposal confirmation, not before.
-The chain-proposal prompt itself makes no network calls; running
-`git fetch` before the author confirms would pay network latency on
-every Phase 1 termination, including the ones the author rejects or
-revises. The current order pays the cost only when the chain is
-going to run.
-
 ## Binding Notes
 
 The body above is parent-agnostic. Per-parent bindings live here.
@@ -200,8 +185,3 @@ layer substrate where the parent can dispatch sub-agents, the
 analysis can be delegated to a worktree-sync-analyzer sub-agent that
 reports back to the parent. The discipline is identical across
 substrates; only the actor changes.
-
-The "Bail target" column intentionally names the per-parent SKILL.md
-rather than reproducing the bail logic here. Naming a specific
-parent's bail rule (such as `/scope` R8) inline would couple the
-body to one parent's vocabulary.

--- a/skills/charter/SKILL.md
+++ b/skills/charter/SKILL.md
@@ -207,6 +207,7 @@ N. **Finalization** — set the `exit:` field to one of `full-run`,
 | `${CLAUDE_PLUGIN_ROOT}/references/parent-skill-state-schema.md` | Phase 0 (slug regex), Phase 2 (state writes), Phase N (R9 check) |
 | `${CLAUDE_PLUGIN_ROOT}/references/parent-skill-resume-ladder-template.md` | Resume Logic — meta-ladder rows 1-4 and 9-10 |
 | `${CLAUDE_PLUGIN_ROOT}/references/parent-skill-child-inspection.md` | Phase 2 — child-doc inspection (R14 widened rule, dual-check drift detection) |
+| `${CLAUDE_PLUGIN_ROOT}/references/parent-skill-worktree-discipline.md` | Phase 2 — per-child worktree-staleness check (Rebase / Proceed anyway / Bail prompt, divergence recording) |
 | `skills/charter/references/phases/phase-0-setup.md` | Phase 0 |
 | `skills/charter/references/phases/phase-1-discovery.md` | Phase 1 |
 | `skills/charter/references/phases/phase-2-chain-orchestration.md` | Phase 2 |


### PR DESCRIPTION
Adds a new top-level reference `references/parent-skill-worktree-discipline.md` codifying how a parent skill handles upstream change across a multi-child chain. Updates `skills/charter/SKILL.md` to cite the new reference in its Reference Files table. Also revises `docs/prds/PRD-shirabe-scope-skill.md` (R21 + AC28 + AC28b) and `docs/designs/DESIGN-shirabe-scope-skill.md` (Decision 4) to encode the chosen contract: escalation is driven by **contextual impact** (does the upstream change invalidate the chain's intent?), not by **mechanical conflict status** (did `git rebase` complain?).

The flow before each Phase 2 child invocation: rebase → analyze impact → escalate by impact level. Sub-agents handle the git mechanics and conflict resolution from artifact context. The team lead is involved only when the impact analyzer classifies upstream changes as intent-changing. The author is involved only when the team lead concludes that the original session intent has genuinely shifted.

---

## What This Enables

Future parent skills (the next chain skill in the planning sequence, and the eventual `/work-on` migration) inherit the discipline without re-deriving it. The new reference is the first piece of the implementation sequence following [#120](https://github.com/tsukumogami/shirabe/pull/120) (planning artifacts).

## Design note

The original spec (in PR-120) called for a manual three-option prompt fired against the author on every staleness check. The first review surfaced that the manual-gate default was wrong because the parent owns the branch during a chain — there's no parallel-author work to disrupt, so silent rebase is safe. The second review surfaced that even silent-rebase-with-conflict-fallback was using the wrong escalation criterion: a clean rebase can silently land a contract change that breaks chain references; a conflict can be in a file the chain doesn't care about. The criterion that actually matters is whether upstream changes invalidate the chain's intent — which requires reading the diff and cross-referencing the chain's authored artifacts. This PR encodes that contract.

## Issues addressed

- Closes #98 — `docs(refs): add parent-skill-worktree-discipline reference`
- Closes #99 — `docs(charter): cite worktree-discipline reference in /charter`
