### PR TITLE
feat(prd): transition upstream brief Draft->Accepted on /prd start

### DIFF
--- a/.github/workflows/check-brief-scripts.yml
+++ b/.github/workflows/check-brief-scripts.yml
@@ -1,0 +1,32 @@
+name: Check brief scripts
+
+on:
+  pull_request:
+    paths:
+      - 'skills/brief/scripts/**'
+
+jobs:
+  test-brief-scripts:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install jq (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y jq
+
+      - name: Install jq (macOS)
+        if: runner.os == 'macOS'
+        run: brew install jq
+
+      - name: Install bash 5 (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install bash
+          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+
+      - name: Run transition-status tests
+        run: bash skills/brief/scripts/transition-status_test.sh

--- a/skills/brief/scripts/transition-status_test.sh
+++ b/skills/brief/scripts/transition-status_test.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+#
+# transition-status_test.sh - Tests for transition-status.sh
+#
+# Exercises the Draft -> Accepted transition that /prd's setup phase runs
+# on a brief input, plus the no-op / refusal paths the workflow relies on:
+#   * Draft -> Accepted updates frontmatter and body atomically
+#   * Accepted -> Accepted is a no-op (idempotent re-runs are safe)
+#   * Done -> Accepted is refused (terminal status, no downgrade)
+#   * Path errors when invoked against a missing or non-brief target
+#
+# Usage:
+#   bash transition-status_test.sh
+#
+# Exit codes:
+#   0 - All tests passed
+#   1 - One or more tests failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRANSITION_SCRIPT="$SCRIPT_DIR/transition-status.sh"
+TEST_DIR=""
+PASS_COUNT=0
+FAIL_COUNT=0
+
+setup() {
+    TEST_DIR=$(mktemp -d)
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+fail() {
+    local test_name="$1"
+    local reason="$2"
+    echo "FAIL: $test_name - $reason" >&2
+    ((FAIL_COUNT++)) || true
+}
+
+pass() {
+    local test_name="$1"
+    echo "PASS: $test_name" >&2
+    ((PASS_COUNT++)) || true
+}
+
+write_brief() {
+    local path="$1"
+    local fm_status="$2"
+    local body_status="$3"
+
+    cat > "$path" <<EOF
+---
+status: ${fm_status}
+problem: |
+  Test problem.
+outcome: |
+  Test outcome.
+---
+
+# BRIEF: test
+
+## Status
+
+${body_status}
+
+## Problem Statement
+
+Stub.
+
+## User Outcome
+
+Stub.
+
+## User Journeys
+
+Stub.
+
+## Scope Boundary
+
+Stub.
+EOF
+}
+
+read_fm_status() {
+    local path="$1"
+    sed -n '2,/^---$/p' "$path" | grep -E '^status:' | sed 's/^status:[[:space:]]*//' | head -1
+}
+
+read_body_status() {
+    local path="$1"
+    grep -A 3 '^## Status' "$path" | grep -E '^(Draft|Accepted|Done)' | head -1
+}
+
+# Test 1: Draft brief -> Accepted transitions both frontmatter and body.
+# This is the path /prd's setup phase runs when invoked on a Draft brief.
+test_draft_to_accepted() {
+    local name="Draft brief transitions to Accepted (frontmatter + body)"
+    setup
+
+    local brief="$TEST_DIR/BRIEF-feature.md"
+    write_brief "$brief" Draft Draft
+
+    if ! "$TRANSITION_SCRIPT" "$brief" Accepted >/dev/null 2>&1; then
+        fail "$name" "script exited non-zero"
+        teardown
+        return
+    fi
+
+    local fm body
+    fm=$(read_fm_status "$brief")
+    body=$(read_body_status "$brief")
+
+    if [[ "$fm" != "Accepted" ]]; then
+        fail "$name" "frontmatter status is '$fm', expected 'Accepted'"
+        teardown
+        return
+    fi
+
+    if [[ "$body" != "Accepted" ]]; then
+        fail "$name" "body status is '$body', expected 'Accepted'"
+        teardown
+        return
+    fi
+
+    pass "$name"
+    teardown
+}
+
+# Test 2: Accepted brief -> Accepted is a no-op. /prd's setup must remain
+# idempotent so re-runs of the workflow do not error.
+test_accepted_no_op() {
+    local name="already-Accepted brief is a no-op on Accepted target"
+    setup
+
+    local brief="$TEST_DIR/BRIEF-feature.md"
+    write_brief "$brief" Accepted Accepted
+
+    local before
+    before=$(sha1sum "$brief" | awk '{print $1}')
+
+    if ! "$TRANSITION_SCRIPT" "$brief" Accepted >/dev/null 2>&1; then
+        fail "$name" "script exited non-zero on no-op call"
+        teardown
+        return
+    fi
+
+    local after
+    after=$(sha1sum "$brief" | awk '{print $1}')
+
+    if [[ "$before" != "$after" ]]; then
+        fail "$name" "file was modified on no-op call"
+        teardown
+        return
+    fi
+
+    pass "$name"
+    teardown
+}
+
+# Test 3: Done brief is terminal -- /prd must not silently downgrade it.
+# The transition script refuses; /prd's setup will see the non-zero exit
+# and surface the error rather than corrupting the brief.
+test_done_refuses_downgrade() {
+    local name="Done brief refuses Accepted target (terminal status)"
+    setup
+
+    local brief="$TEST_DIR/BRIEF-feature.md"
+    write_brief "$brief" Done Done
+
+    local before
+    before=$(sha1sum "$brief" | awk '{print $1}')
+
+    if "$TRANSITION_SCRIPT" "$brief" Accepted >/dev/null 2>&1; then
+        fail "$name" "script exited zero when refusing Done -> Accepted"
+        teardown
+        return
+    fi
+
+    local after
+    after=$(sha1sum "$brief" | awk '{print $1}')
+
+    if [[ "$before" != "$after" ]]; then
+        fail "$name" "file was modified after refused transition"
+        teardown
+        return
+    fi
+
+    pass "$name"
+    teardown
+}
+
+# Test 4: Missing file path returns a clear error. /prd's setup uses the
+# script's exit code to decide whether the transition happened.
+test_missing_file_errors() {
+    local name="missing brief path exits non-zero"
+    setup
+
+    if "$TRANSITION_SCRIPT" "$TEST_DIR/does-not-exist.md" Accepted >/dev/null 2>&1; then
+        fail "$name" "script exited zero on missing file"
+        teardown
+        return
+    fi
+
+    pass "$name"
+    teardown
+}
+
+# Test 5: Frontmatter and body are updated in the same invocation. This
+# is the FC03 invariant -- a partial update would leave the brief failing
+# `shirabe validate`. We assert both fields move together.
+test_atomic_frontmatter_and_body() {
+    local name="Draft -> Accepted updates frontmatter and body atomically"
+    setup
+
+    local brief="$TEST_DIR/BRIEF-feature.md"
+    write_brief "$brief" Draft Draft
+
+    "$TRANSITION_SCRIPT" "$brief" Accepted >/dev/null 2>&1
+
+    local fm body
+    fm=$(read_fm_status "$brief")
+    body=$(read_body_status "$brief")
+
+    if [[ "$fm" != "$body" ]]; then
+        fail "$name" "frontmatter ('$fm') and body ('$body') diverged"
+        teardown
+        return
+    fi
+
+    pass "$name"
+    teardown
+}
+
+main() {
+    test_draft_to_accepted
+    test_accepted_no_op
+    test_done_refuses_downgrade
+    test_missing_file_errors
+    test_atomic_frontmatter_and_body
+
+    echo ""
+    echo "Results: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+
+    if [[ "$FAIL_COUNT" -gt 0 ]]; then
+        exit 1
+    fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/skills/prd/SKILL.md
+++ b/skills/prd/SKILL.md
@@ -56,7 +56,13 @@ Use an explore workflow when you don't know what artifact type you need yet.
 
 From `$ARGUMENTS`:
 1. **Empty** -- ask the user what feature or capability they want to specify
-2. **Anything else** -- use as the starting topic for Phase 1 scoping
+2. **Path to BRIEF document** (matches `docs/briefs/BRIEF-*.md`) -- brief
+   input mode. The brief is treated as the upstream framing and its path is
+   stored for Phase 0 (setup) and Phase 3 (draft). When the brief's status
+   is `Draft`, Phase 0 transitions it to `Accepted` so the chain handoff
+   matches /design (which bumps PRD `Accepted -> In Progress`) and /plan
+   (which bumps DESIGN `Accepted -> Planned`). See "Execution" below.
+3. **Anything else** -- use as the starting topic for Phase 1 scoping
 
 ### Context Resolution
 
@@ -70,6 +76,8 @@ follow `references/decision-protocol.md` at all decision points. Create
 path is stored and written to frontmatter during Phase 3 (draft). Typically
 points to a Roadmap document when the PRD is part of a multi-feature
 initiative. When not provided, the upstream field is omitted from frontmatter.
+When the positional argument is itself a BRIEF path (Input Mode 2), that
+path is used as the upstream and `--upstream` is not required.
 
 Detect visibility (Private/Public) from CLAUDE.md or repo path. Infer from
 `private/` or `public/` in path if not explicit. Default to Private if unknown -- restricting is easier to undo than oversharing.
@@ -88,7 +96,7 @@ Phase 0: SETUP --> Phase 1: SCOPE --> Phase 2: DISCOVER --> Phase 3: DRAFT --> P
 
 | Phase | Purpose | Artifact |
 |-------|---------|----------|
-| 0. Setup | Create feature branch | On `docs/<topic>` branch |
+| 0. Setup | Create feature branch; in brief input mode, transition upstream brief Draft -> Accepted | On `docs/<topic>` branch; upstream brief at Accepted |
 | 1. Scope | Conversational scoping with coverage tracking | Problem statement + research leads |
 | 2. Discover | Parallel specialist agents investigate leads | Research findings in wip/ |
 | 3. Draft | Produce PRD draft, surface open questions | Complete PRD draft |
@@ -116,10 +124,29 @@ On main or unrelated branch                        -> Start at Phase 0
 
 Execute phases sequentially by reading the corresponding phase file:
 
-0. **Setup**: Ensure work happens on a feature branch
+0. **Setup**: Ensure work happens on a feature branch and, in brief input
+   mode, transition the upstream brief.
    - If already on a branch that matches the topic, skip branch creation
    - If on `main` or an unrelated branch, create `docs/<topic>` (kebab-case) -- keeps drafts off main so abandoned PRDs don't need cleanup
    - If unsure whether the current branch is related, ask the user
+   - **Upstream brief transition (brief input mode only):** if the input
+     was a BRIEF path (Input Mode 2) and the brief's status is `Draft`,
+     transition it `Draft -> Accepted` so the chain handoff is symmetric
+     with /design (PRD `Accepted -> In Progress`) and /plan (DESIGN
+     `Accepted -> Planned`). Skip when the brief is already `Accepted` or
+     `Done`, and skip entirely when /prd was invoked without a brief input
+     (empty or topic). Update both the brief frontmatter `status:` and the
+     body `## Status` line atomically so the FC03 cross-check stays
+     consistent. Use the existing brief transition script:
+
+     ```bash
+     ${CLAUDE_PLUGIN_ROOT}/skills/brief/scripts/transition-status.sh <brief-path> Accepted
+     ```
+
+     The script is a no-op when the brief is already `Accepted`, exits with
+     a clear error if asked to transition from `Done`, and updates both
+     frontmatter and body in one operation. Commit:
+     `docs(brief): mark <brief-name> accepted`
 
 1. **Scope**: Conversational scoping with coverage tracking
    - Instructions: `references/phases/phase-1-scope.md`

--- a/skills/prd/evals/evals.json
+++ b/skills/prd/evals/evals.json
@@ -83,6 +83,43 @@
         "Transcript routes the agent to cross-repo-references.md for the rule and recovery options",
         "Transcript either omits the upstream field or asks the user for a durable canonical path before proceeding"
       ]
+    },
+    {
+      "id": 11,
+      "name": "brief-input-transitions-draft-to-accepted",
+      "prompt": "/prd --auto docs/briefs/BRIEF-search-indexing.md",
+      "expected_output": "Detects Input Mode 2 (BRIEF path). Phase 0 setup transitions the brief from Draft to Accepted by invoking ${CLAUDE_PLUGIN_ROOT}/skills/brief/scripts/transition-status.sh on the brief path with target Accepted. Both frontmatter status: and the body ## Status line are updated atomically so the FC03 cross-check stays consistent. The brief path is also stored for use as the PRD's upstream in Phase 3.",
+      "files": [],
+      "expectations": [
+        "Transcript detects the input as a BRIEF path (Input Mode 2)",
+        "Transcript describes running the brief transition-status.sh script with target Accepted in Phase 0",
+        "Transcript notes that both frontmatter and body status fields are updated atomically",
+        "Transcript describes propagating the brief path forward as the PRD's upstream"
+      ]
+    },
+    {
+      "id": 12,
+      "name": "brief-input-already-accepted-no-op",
+      "prompt": "/prd --auto docs/briefs/BRIEF-already-accepted.md",
+      "expected_output": "Detects Input Mode 2 (BRIEF path). Phase 0 setup invokes transition-status.sh with target Accepted; the script detects the brief is already at Accepted and exits successfully without modifying the file. The /prd workflow proceeds to Phase 1 without error. The transition is also a no-op when the brief is at Done (terminal status), where the script refuses the transition and surfaces the error rather than corrupting the brief.",
+      "files": [],
+      "expectations": [
+        "Transcript notes that the transition is idempotent when the brief is already Accepted",
+        "Transcript describes not modifying the brief file when no transition is needed",
+        "Transcript proceeds past Phase 0 to Phase 1 without erroring on the no-op"
+      ]
+    },
+    {
+      "id": 13,
+      "name": "topic-input-skips-brief-transition",
+      "prompt": "/prd --auto checkout-redesign",
+      "expected_output": "Detects Input Mode 3 (anything-else / topic). Phase 0 setup does NOT invoke the brief transition-status.sh script because there is no BRIEF path to transition. The workflow proceeds straight from branch setup into Phase 1 scoping. The brief transition is only performed when the input is a BRIEF path.",
+      "files": [],
+      "expectations": [
+        "Transcript detects the input as a topic (Input Mode 3), not a BRIEF path",
+        "Transcript does NOT describe invoking the brief transition script",
+        "Transcript proceeds directly from Phase 0 branch setup to Phase 1 scoping"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Teach `/prd` to transition its upstream brief from Draft to Accepted when invoked on a BRIEF input, mirroring how `/design`'s Phase 0.6 transitions PRD Accepted -> In Progress and how `/plan`'s Phase 7.5 transitions DESIGN Accepted -> Planned. Reuse the existing `skills/brief/scripts/transition-status.sh` so the frontmatter `status:` and body `## Status` are updated atomically and idempotent re-runs are safe.

Closes #122. This is an independent fix off `main` — it is NOT stacked on PR #97.

---

## What this accomplishes

The tactical chain has three doc-to-doc handoffs (BRIEF -> PRD -> DESIGN -> PLAN). Two of the three downstream skills bumped their upstream on handoff; `/prd` did not. Running the chain end-to-end left the brief sitting at Draft while the PRD, design, and plan all advanced, so the chain read incoherent: the only doc at its initial status was the one furthest upstream.

After this change, `/prd` Phase 0 detects when its input is a BRIEF path and runs the brief's existing transition script with target `Accepted`. The transition is a no-op when the brief is already `Accepted` (idempotent re-runs are safe) and refused when the brief is `Done` (terminal). `/prd` skips the transition entirely when invoked without a brief input (empty or topic).

## Design notes

- **No parallel mechanism.** The transition reuses `skills/brief/scripts/transition-status.sh` rather than introducing a new script. The script already updates frontmatter and body atomically (FC03 stays consistent) and validates the lifecycle (`Draft -> Accepted` allowed; `Done` is terminal).
- **Surgical /prd change.** `/prd`'s setup is documented inline in `skills/prd/SKILL.md`; no new phase-0 reference file was added. The Input Modes section grows a BRIEF case (Mode 2), the Workflow Phases table mentions the transition, and the Execution > Setup block carries the script-invocation contract.
- **No-op semantics, not error semantics.** The script exits 0 when asked to transition `Accepted -> Accepted`, so Phase 0 re-runs from a resumed workflow do not fail. Asking the script to transition `Done -> Accepted` exits non-zero so `/prd` surfaces the error rather than silently corrupting the brief.

## Test plan

- [x] `go test ./...` green: `ok github.com/tsukumogami/shirabe/internal/validate`.
- [x] `bash skills/brief/scripts/transition-status_test.sh` 5/5: Draft -> Accepted updates frontmatter + body, Accepted no-op, Done refusal, missing-file error, and frontmatter + body stay in sync after a transition.
- [x] `shirabe validate skills/prd/SKILL.md` exit 0.
- [x] `scripts/check-sentinel.sh` PASS.

## Acceptance criteria

- [x] AC1 — When `/prd` is invoked with a BRIEF input whose `status` is `Draft`, the brief is transitioned to `Accepted` (frontmatter + body, FC03-consistent) as part of the `/prd` setup phase. Covered by the new Phase 0 step in `skills/prd/SKILL.md` (Execution > Setup) and by `test_draft_to_accepted` + `test_atomic_frontmatter_and_body` in the new test script.
- [x] AC2 — The transition is skipped (no-op) when the brief is already `Accepted` or `Done`, and when `/prd` is invoked without a brief input. Covered by `test_accepted_no_op`, `test_done_refuses_downgrade`, and the explicit "Skip when ... brief is already `Accepted` or `Done`, and skip entirely when /prd was invoked without a brief input" prose in the SKILL.md setup step.
- [x] AC3 — A test asserts the transition fires on brief input and is a no-op on non-brief input and on already-transitioned briefs. Covered by `skills/brief/scripts/transition-status_test.sh` (5 scenarios). The non-brief-input case is the /prd-level skip: the script is only invoked in Input Mode 2, so non-brief inputs never reach the transition step. Eval scenario 13 (`topic-input-skips-brief-transition`) captures the skip behavior at the /prd skill level.
- [x] AC4 — Documentation: the `/prd` skill's setup phase reference notes the transition explicitly. The Setup step in `skills/prd/SKILL.md` documents the transition, names the script, and explains the chain-handoff symmetry with `/design` and `/plan`.

## Files changed

- `skills/prd/SKILL.md` — Input Modes adds BRIEF as Mode 2; Workflow Phases table mentions the transition in Phase 0; Execution > Setup documents the transition step, names the script, and explains skip conditions.
- `skills/brief/scripts/transition-status_test.sh` — new test, 5 scenarios.
- `.github/workflows/check-brief-scripts.yml` — CI runner for the new test (Linux + macOS), modeled on `check-plan-scripts.yml`.
- `skills/prd/evals/evals.json` — three new eval scenarios (11, 12, 13) covering the brief Draft -> Accepted path, the already-Accepted no-op, and the topic-input skip.
