### PR TITLE
feat(validate): add issues-table validation (FC05/FC06), shared references, and migrate committed corpus

### DIFF
--- a/docs/plans/PLAN-roadmap-plan-standardization.md
+++ b/docs/plans/PLAN-roadmap-plan-standardization.md
@@ -63,12 +63,12 @@ with the spike-to-reconciliation merge gate as a second independent justificatio
 
 | Issue | Dependencies | Complexity |
 |-------|--------------|------------|
-| [#111: docs(references): add shared workflow-principles, issues-table, and dependency-diagram references](https://github.com/tsukumogami/shirabe/issues/111) | None | simple |
-| _Creates the three plugin-root shared references and trims the two skill references to cite them; finalizes the five-principle wording. The foundation every other slice consumes -- the validator is the enforcement twin of these references._ | | |
-| [#112: feat(validate): add Markdown issues-table parser and FC05/FC06 content checks](https://github.com/tsukumogami/shirabe/issues/112) | [#111](https://github.com/tsukumogami/shirabe/issues/111) | testable |
-| _Adds `table.go` (`parseIssuesTable` + `Table`) and the error-level `checkFC05` (schema) and `checkFC06` (cross-reference), wired into the Plan arm and a new Roadmap arm. The one new parser the first pass allows; its `Table` is what the later reconciliation check reuses._ | | |
-| [#113: docs(corpus): migrate committed roadmap and plan tables to the canonical profiles](https://github.com/tsukumogami/shirabe/issues/113) | [#112](https://github.com/tsukumogami/shirabe/issues/112) | testable |
-| _Migrates the divergent committed roadmap and legacy plan tables onto the canonical profiles so error-level FC05/FC06 pass on the whole corpus. Lands in the same PR as #112 so the checks never see an unmigrated corpus._ | | |
+| ~~[#111: docs(references): add shared workflow-principles, issues-table, and dependency-diagram references](https://github.com/tsukumogami/shirabe/issues/111)~~ | ~~None~~ | ~~simple~~ |
+| ~~_Creates the three plugin-root shared references and trims the two skill references to cite them; finalizes the five-principle wording. The foundation every other slice consumes -- the validator is the enforcement twin of these references._~~ | | |
+| ~~[#112: feat(validate): add Markdown issues-table parser and FC05/FC06 content checks](https://github.com/tsukumogami/shirabe/issues/112)~~ | ~~[#111](https://github.com/tsukumogami/shirabe/issues/111)~~ | ~~testable~~ |
+| ~~_Adds `table.go` (`parseIssuesTable` + `Table`) and the error-level `checkFC05` (schema) and `checkFC06` (cross-reference), wired into the Plan arm and a new Roadmap arm. The one new parser the first pass allows; its `Table` is what the later reconciliation check reuses._~~ | | |
+| ~~[#113: docs(corpus): migrate committed roadmap and plan tables to the canonical profiles](https://github.com/tsukumogami/shirabe/issues/113)~~ | ~~[#112](https://github.com/tsukumogami/shirabe/issues/112)~~ | ~~testable~~ |
+| ~~_Migrates the divergent committed roadmap and legacy plan tables onto the canonical profiles so error-level FC05/FC06 pass on the whole corpus. Lands in the same PR as #112 so the checks never see an unmigrated corpus._~~ | | |
 | [#114: docs(plan): surface the single-pr/multi-pr decision and add the value-confirmation guard](https://github.com/tsukumogami/shirabe/issues/114) | [#111](https://github.com/tsukumogami/shirabe/issues/111) | testable |
 | _Lifts the single-pr/multi-pr rule onto the plan SKILL surface anchored on the usable-value principle, de-conflated from work-slicing, and adds a value-confirmation step that can fail and records-and-proceeds under `--auto`. Shares the record-and-proceed gate shape with #115's approval gate._ | | |
 | [#115: feat(roadmap): add native populate-issues-table script reusing create-issues-batch](https://github.com/tsukumogami/shirabe/issues/115) | [#111](https://github.com/tsukumogami/shirabe/issues/111) | testable |

--- a/docs/roadmaps/ROADMAP-koto-adoption.md
+++ b/docs/roadmaps/ROADMAP-koto-adoption.md
@@ -1,4 +1,5 @@
 ---
+schema: roadmap/v1
 status: Active
 theme: |
   Convert shirabe skills from prose-based workflow management to koto-orchestrated
@@ -147,42 +148,56 @@ gates for version validation. Converts last.
 
 ### Milestone: [Koto Adoption](https://github.com/tsukumogami/shirabe/milestone/3)
 
-| Issue | Phase | Dependencies | Label |
-|-------|-------|-------------|-------|
-| [#49: review-plan fast-path](https://github.com/tsukumogami/shirabe/issues/49) | 1 | None | `needs-design` |
-| [#50: decision (degraded)](https://github.com/tsukumogami/shirabe/issues/50) | 1 | None | `needs-design` |
-| ~~[#51: file koto requests](https://github.com/tsukumogami/shirabe/issues/51)~~ | 1 | None | Done |
-| [#52: prd conversion](https://github.com/tsukumogami/shirabe/issues/52) | 2 | tsukumogami/koto#65, tsukumogami/koto#87 | `needs-design` |
-| [#53: plan conversion](https://github.com/tsukumogami/shirabe/issues/53) | 2 | tsukumogami/koto#65 | `needs-design` |
-| [#54: explore basic](https://github.com/tsukumogami/shirabe/issues/54) | 2 | tsukumogami/koto#65, tsukumogami/koto#87 | `needs-design` |
-| [#55: design linear](https://github.com/tsukumogami/shirabe/issues/55) | 2 | tsukumogami/koto#65 | `needs-design` |
-| [#56: explore full loops](https://github.com/tsukumogami/shirabe/issues/56) | 3 | #54, tsukumogami/koto#105 | `needs-design` |
-| [#57: review-plan adversarial](https://github.com/tsukumogami/shirabe/issues/57) | 3 | #49, tsukumogami/koto#106 | `needs-design` |
-| [#58: decision full validators](https://github.com/tsukumogami/shirabe/issues/58) | 3 | #50 | `needs-spike` |
-| [#59: design parallel](https://github.com/tsukumogami/shirabe/issues/59) | 3 | #55, tsukumogami/koto#106 | `needs-design` |
-| [#60: release conversion](https://github.com/tsukumogami/shirabe/issues/60) | 3 | tsukumogami/koto#104, tsukumogami/koto#107 | `needs-design` |
+| Feature | Issues | Dependencies | Status |
+|---------|--------|--------------|--------|
+| Feature 1: review-plan fast-path | [#49](https://github.com/tsukumogami/shirabe/issues/49) | None | needs-design |
+| _Phase 1. Adds a degraded-mode review-plan that runs against koto's current capabilities, validating the conversion pattern before harder conversions._ | | | |
+| Feature 2: decision (degraded) | [#50](https://github.com/tsukumogami/shirabe/issues/50) | None | needs-design |
+| _Phase 1. Adds a degraded /decision conversion using koto today, validating the pattern alongside Feature 1._ | | | |
+| ~~Feature 3: file koto requests~~ | ~~[#51](https://github.com/tsukumogami/shirabe/issues/51)~~ | ~~None~~ | ~~Done~~ |
+| ~~_Phase 1. Filed the koto feature requests the rest of the conversions depend on._~~ | | | |
+| Feature 4: prd conversion | [#52](https://github.com/tsukumogami/shirabe/issues/52) | tsukumogami/koto#65, tsukumogami/koto#87 | needs-design |
+| _Phase 2. Converts the /prd skill to koto. Needs koto#65 (variables) and koto#87 (evidence promotion) to ship first._ | | | |
+| Feature 5: plan conversion | [#53](https://github.com/tsukumogami/shirabe/issues/53) | tsukumogami/koto#65 | needs-design |
+| _Phase 2. Converts the /plan skill to koto, gated on koto#65._ | | | |
+| Feature 6: explore basic | [#54](https://github.com/tsukumogami/shirabe/issues/54) | tsukumogami/koto#65, tsukumogami/koto#87 | needs-design |
+| _Phase 2. Basic /explore conversion -- linear pipeline only, no loops. Gated on koto#65 and koto#87._ | | | |
+| Feature 7: design linear | [#55](https://github.com/tsukumogami/shirabe/issues/55) | tsukumogami/koto#65 | needs-design |
+| _Phase 2. Linear /design conversion, gated on koto#65. Parallel /design lands later as Feature 11._ | | | |
+| Feature 8: explore full loops | [#56](https://github.com/tsukumogami/shirabe/issues/56) | Feature 6: explore basic, tsukumogami/koto#105 | needs-design |
+| _Phase 3. Adds the loop variant to /explore on top of Feature 6, gated on koto#105 (bounded iteration)._ | | | |
+| Feature 9: review-plan adversarial | [#57](https://github.com/tsukumogami/shirabe/issues/57) | Feature 1: review-plan fast-path, tsukumogami/koto#106 | needs-design |
+| _Phase 3. Adversarial variant on top of Feature 1, gated on koto#106 (glob gate)._ | | | |
+| Feature 10: decision full validators | [#58](https://github.com/tsukumogami/shirabe/issues/58) | Feature 2: decision (degraded) | needs-spike |
+| _Phase 3. Full-validator /decision on top of Feature 2. Carries the spike for validator integration._ | | | |
+| Feature 11: design parallel | [#59](https://github.com/tsukumogami/shirabe/issues/59) | Feature 7: design linear, tsukumogami/koto#106 | needs-design |
+| _Phase 3. Adds parallel-track support to /design on top of Feature 7, gated on koto#106._ | | | |
+| Feature 12: release conversion | [#60](https://github.com/tsukumogami/shirabe/issues/60) | tsukumogami/koto#104, tsukumogami/koto#107 | needs-design |
+| _Phase 3. The poorest koto fit -- 15+ external commands and heavy external state. Gated on koto#104 (polling) and koto#107 (content-match). Converts last._ | | | |
+
+## Dependency Graph
 
 ```mermaid
 graph LR
-    I49["#49<br/>review-plan<br/>fast-path"]
-    I50["#50<br/>decision<br/>degraded"]
-    I51["#51<br/>file koto<br/>requests"]
-    I52["#52<br/>prd"]
-    I53["#53<br/>plan"]
-    I54["#54<br/>explore<br/>basic"]
-    I55["#55<br/>design<br/>linear"]
-    I56["#56<br/>explore<br/>full loops"]
-    I57["#57<br/>review-plan<br/>adversarial"]
-    I58["#58<br/>decision<br/>full validators"]
-    I59["#59<br/>design<br/>parallel"]
-    I60["#60<br/>release"]
+    I49["#49: review-plan fast-path"]
+    I50["#50: decision (degraded)"]
+    I51["#51: file koto requests"]
+    I52["#52: prd"]
+    I53["#53: plan"]
+    I54["#54: explore basic"]
+    I55["#55: design linear"]
+    I56["#56: explore full loops"]
+    I57["#57: review-plan adversarial"]
+    I58["#58: decision full validators"]
+    I59["#59: design parallel"]
+    I60["#60: release"]
 
-    K65["koto#65<br/>variables"]
-    K87["koto#87<br/>evidence<br/>promotion"]
-    K104["koto#104<br/>polling gate"]
-    K105["koto#105<br/>bounded<br/>iteration"]
-    K106["koto#106<br/>glob gate"]
-    K107["koto#107<br/>content-match"]
+    K65["koto#65: variables"]
+    K87["koto#87: evidence promotion"]
+    K104["koto#104: polling gate"]
+    K105["koto#105: bounded iteration"]
+    K106["koto#106: glob gate"]
+    K107["koto#107: content-match"]
 
     I49 --> I57
     I50 --> I58

--- a/docs/roadmaps/ROADMAP-strategic-pipeline.md
+++ b/docs/roadmaps/ROADMAP-strategic-pipeline.md
@@ -1,4 +1,5 @@
 ---
+schema: roadmap/v1
 status: Active
 theme: |
   Complete the strategic-to-tactical pipeline by adding the missing inception
@@ -396,17 +397,43 @@ Feature 12 (Artifact Type Decision Reference) --- independent
 
 ## Progress
 
-| Feature | Status | Downstream Artifact |
-|---------|--------|-------------------|
-| Feature 1: VISION Artifact Type | Done | DESIGN-vision-artifact-type.md (Current) |
-| Feature 2: Roadmap Creation Skill | Done | PRD-roadmap-skill.md (Done), DESIGN-roadmap-creation-skill.md (Current) |
-| Feature 3: Artifact Traceability | Done | PRD-artifact-traceability.md (Done), DESIGN-artifact-traceability.md (Current) |
-| Feature 4: Complexity Routing Expansion | Done | PRD-complexity-routing-expansion.md (Done), DESIGN-complexity-routing-expansion.md (Current) |
-| Feature 5: Plan Skill Rework | Done | PRD-plan-skill-rework.md (Done), DESIGN-plan-skill-rework.md (Current) |
-| Feature 6: Pipeline Documentation | Done | PRD-pipeline-documentation.md (Done) |
-| Feature 7: Crystallize Framework Calibration | Not Started | -- |
-| Feature 8: Completion Cascade Automation | In Progress | DESIGN-work-on-koto-unification.md (Current) |
-| Feature 9: Upstream Context Propagation | Not Started | -- |
-| Feature 10: Progress Consistency | Not Started | -- |
-| Feature 11: Lifecycle Script Hardening | Not Started | -- |
-| Feature 12: Artifact Type Decision Reference | Not Started | -- |
+The per-feature lifecycle state and any downstream artifact references
+live in the Features section above. The canonical Implementation
+Issues table below carries the current Status for each feature; this
+section is kept as the roadmap-format-required narrative slot for
+ad-hoc progress notes and is currently empty.
+
+## Implementation Issues
+
+| Feature | Issues | Dependencies | Status |
+|---------|--------|--------------|--------|
+| Feature 1: VISION Artifact Type | None | None | Done |
+| _DESIGN-vision-artifact-type.md (Current). Adds the VISION artifact type as the strategic root of the pipeline._ | | | |
+| Feature 2: Roadmap Creation Skill | None | None | Done |
+| _PRD-roadmap-skill.md (Done), DESIGN-roadmap-creation-skill.md (Current). Adds the /roadmap skill that sequences features into a coordinated initiative._ | | | |
+| Feature 3: Artifact Traceability | None | Feature 1: VISION Artifact Type | Done |
+| _PRD-artifact-traceability.md (Done), DESIGN-artifact-traceability.md (Current). Adds upstream frontmatter linking artifacts up the chain._ | | | |
+| Feature 4: Complexity Routing Expansion | None | Feature 1: VISION Artifact Type | Done |
+| _PRD-complexity-routing-expansion.md (Done), DESIGN-complexity-routing-expansion.md (Current). Adds the Strategic complexity level so a VISION can route work through the pipeline._ | | | |
+| Feature 5: Plan Skill Rework | None | Feature 2: Roadmap Creation Skill | Done |
+| _PRD-plan-skill-rework.md (Done), DESIGN-plan-skill-rework.md (Current). Reworks /plan so a roadmap can drive decomposition without a special re-entry mode._ | | | |
+| Feature 6: Pipeline Documentation | None | Feature 1: VISION Artifact Type, Feature 2: Roadmap Creation Skill, Feature 3: Artifact Traceability, Feature 4: Complexity Routing Expansion | Done |
+| _PRD-pipeline-documentation.md (Done). Documents the completed pipeline end-to-end._ | | | |
+| Feature 7: Crystallize Framework Calibration | None | None | Not Started |
+| _Independent calibration work that benefits from Feature 4 but does not require it._ | | | |
+| Feature 8: Completion Cascade Automation | None | Feature 5: Plan Skill Rework | In Progress |
+| _DESIGN-work-on-koto-unification.md (Current). Automates the completion cascade so the /plan output flows into /work-on cleanly._ | | | |
+| Feature 9: Upstream Context Propagation | None | Feature 5: Plan Skill Rework | Not Started |
+| _Propagates upstream context across the plan-to-implementation seam. Depends on the rewored /plan output shape._ | | | |
+| Feature 10: Progress Consistency | None | Feature 8: Completion Cascade Automation | Not Started |
+| _Shares the milestone-detection problem the cascade automation solves; lands after it._ | | | |
+| Feature 11: Lifecycle Script Hardening | None | None | Not Started |
+| _Hardens the lifecycle scripts independently of the rest of the roadmap._ | | | |
+| Feature 12: Artifact Type Decision Reference | None | None | Not Started |
+| _Reference work for the artifact-type decision. Benefits from Feature 4's signal-based routing but lands independently._ | | | |
+
+## Dependency Graph
+
+```mermaid
+graph TD
+```

--- a/internal/validate/checks.go
+++ b/internal/validate/checks.go
@@ -166,6 +166,168 @@ func checkFC04(doc Doc, spec FormatSpec) []ValidationError {
 	return errs
 }
 
+// legacyPlanTableColumns is the historic four-column plan-table shape
+// (Issue | Title | Dependencies | Complexity). FC05 recognizes it
+// specially to emit a migration hint pointing the author at the
+// canonical three-column shape.
+var legacyPlanTableColumns = []string{"Issue", "Title", "Dependencies", "Complexity"}
+
+// checkFC05 validates that the Implementation Issues table header
+// matches the format's required column contract (R6). The profile is
+// selected by spec.IssuesTableColumns -- absent (empty) means the
+// format has no issues table and the check is a no-op.
+//
+// FC05 is error-level. A legacy plan-table shape (Issue | Title |
+// Dependencies | Complexity) emits a migration-hint message rather
+// than a generic schema-mismatch message, pointing the author at the
+// canonical three-column shape.
+func checkFC05(doc Doc, spec FormatSpec) []ValidationError {
+	if len(spec.IssuesTableColumns) == 0 {
+		return nil
+	}
+	table, ok := parseIssuesTable(doc)
+	if !ok {
+		return nil
+	}
+
+	// Detect the legacy plan-table shape and emit a migration hint.
+	if spec.SchemaVersion == "plan/v1" && stringSlicesEqual(table.Columns, legacyPlanTableColumns) {
+		return []ValidationError{
+			{
+				File:    doc.Path,
+				Line:    table.HeaderLine,
+				Code:    "FC05",
+				Message: `[FC05] legacy plan table shape "Issue | Title | Dependencies | Complexity" found; migrate by folding the Title cell into the issue link text: "[#N: <title>](url) | <deps> | <complexity>"`,
+			},
+		}
+	}
+
+	if stringSlicesEqual(table.Columns, spec.IssuesTableColumns) {
+		return validateRowShape(doc, table)
+	}
+
+	want := strings.Join(spec.IssuesTableColumns, " | ")
+	got := strings.Join(table.Columns, " | ")
+	return []ValidationError{
+		{
+			File:    doc.Path,
+			Line:    table.HeaderLine,
+			Code:    "FC05",
+			Message: fmt.Sprintf(`[FC05] issues-table header %q does not match the %s profile (expected %q)`, got, spec.Name, want),
+		},
+	}
+}
+
+// validateRowShape checks that table rows are well-formed. Every entity
+// row must be followed by an italic description row; a child reference
+// row may sit between them.
+func validateRowShape(doc Doc, table Table) []ValidationError {
+	var errs []ValidationError
+
+	// Each entity row must be followed by a description row, optionally
+	// with one child reference row between them.
+	for i, row := range table.Rows {
+		if row.Kind != RowEntity {
+			continue
+		}
+		next := i + 1
+		// Skip a single child reference row if present.
+		if next < len(table.Rows) && table.Rows[next].Kind == RowChild {
+			next++
+		}
+		if next >= len(table.Rows) || table.Rows[next].Kind != RowDescription {
+			errs = append(errs, ValidationError{
+				File:    doc.Path,
+				Line:    row.Line,
+				Code:    "FC05",
+				Message: fmt.Sprintf(`[FC05] entity row at line %d is missing its description row (expected an italic "_..._" row immediately after)`, row.Line),
+			})
+		}
+	}
+
+	return errs
+}
+
+// checkFC06 verifies that every Dependencies value in an entity row
+// names a key that exists as an entity row in the same table (R7). The
+// check is document-local (no graph model). FC06 is error-level.
+//
+// FC06 is a no-op when the format has no issues table or the table is
+// absent.
+func checkFC06(doc Doc, spec FormatSpec) []ValidationError {
+	if len(spec.IssuesTableColumns) == 0 {
+		return nil
+	}
+	table, ok := parseIssuesTable(doc)
+	if !ok {
+		return nil
+	}
+
+	// Build the entity-row key set.
+	keys := make(map[string]bool, len(table.Rows))
+	for _, row := range table.Rows {
+		if row.Kind == RowEntity && row.Key != "" {
+			keys[row.Key] = true
+		}
+	}
+
+	var errs []ValidationError
+	for _, row := range table.Rows {
+		if row.Kind != RowEntity {
+			continue
+		}
+		for _, dep := range row.Deps {
+			if dep == "" {
+				continue
+			}
+			// Cross-repo refs (`tsukumogami/<repo>#N`, `owner/repo#N`)
+			// and bare external URLs are out of scope for the
+			// document-local check. We only flag intra-doc references
+			// that look like the doc's own key form but don't match.
+			if !isLocalKey(dep) {
+				continue
+			}
+			if !keys[dep] {
+				errs = append(errs, ValidationError{
+					File:    doc.Path,
+					Line:    row.Line,
+					Code:    "FC06",
+					Message: fmt.Sprintf(`[FC06] dependency %q in row %q names no row in this table`, dep, row.Key),
+				})
+			}
+		}
+	}
+	return errs
+}
+
+// isLocalKey reports whether dep looks like a document-local key (a
+// bare `#N` token or a feature label). Cross-repo references with a
+// slash before the `#` are not local.
+func isLocalKey(dep string) bool {
+	if strings.HasPrefix(dep, "#") {
+		return true
+	}
+	// A feature label is local; a `owner/repo#N` is not (it has a `/`).
+	if strings.Contains(dep, "/") {
+		return false
+	}
+	return true
+}
+
+// stringSlicesEqual reports whether two slices have the same length
+// and the same elements in order.
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // checkPlanUpstream (R6) verifies that a Plan doc's upstream field points at a
 // file that exists on disk and is tracked by git. The field is optional; an
 // absent upstream value returns nil. The git tracking check runs `git ls-files

--- a/internal/validate/doc.go
+++ b/internal/validate/doc.go
@@ -26,6 +26,6 @@ type Section struct {
 type ValidationError struct {
 	File    string
 	Line    int
-	Code    string // "FC01", "FC02", "FC03", "FC04", "R6", "R7", "SCHEMA"
+	Code    string // "FC01", "FC02", "FC03", "FC04", "FC05", "FC06", "R6", "R7", "R8", "SCHEMA"
 	Message string
 }

--- a/internal/validate/formats.go
+++ b/internal/validate/formats.go
@@ -10,14 +10,19 @@ type FormatSpec struct {
 	RequiredFields   []string
 	ValidStatuses    []string
 	RequiredSections []string
+	// IssuesTableColumns is the ordered list of required column headers
+	// for the doc's Implementation Issues table, per the canonical
+	// issues-table profile. Empty for formats without an issues table.
+	// FC05 checks the doc's table header against this list.
+	IssuesTableColumns []string
 }
 
 // Formats maps schema version strings to their FormatSpec.
 var Formats = map[string]FormatSpec{
 	"design/v1": {
-		Name:          "Design",
-		Prefix:        "DESIGN-",
-		SchemaVersion: "design/v1",
+		Name:           "Design",
+		Prefix:         "DESIGN-",
+		SchemaVersion:  "design/v1",
 		RequiredFields: []string{"status", "problem", "decision", "rationale"},
 		ValidStatuses:  []string{"Proposed", "Accepted", "Planned", "Current", "Superseded"},
 		RequiredSections: []string{
@@ -33,9 +38,9 @@ var Formats = map[string]FormatSpec{
 		},
 	},
 	"prd/v1": {
-		Name:          "PRD",
-		Prefix:        "PRD-",
-		SchemaVersion: "prd/v1",
+		Name:           "PRD",
+		Prefix:         "PRD-",
+		SchemaVersion:  "prd/v1",
 		RequiredFields: []string{"status", "problem", "goals"},
 		ValidStatuses:  []string{"Draft", "Accepted", "In Progress", "Done"},
 		RequiredSections: []string{
@@ -49,9 +54,9 @@ var Formats = map[string]FormatSpec{
 		},
 	},
 	"vision/v1": {
-		Name:          "VISION",
-		Prefix:        "VISION-",
-		SchemaVersion: "vision/v1",
+		Name:           "VISION",
+		Prefix:         "VISION-",
+		SchemaVersion:  "vision/v1",
 		RequiredFields: []string{"status", "thesis", "scope"},
 		ValidStatuses:  []string{"Draft", "Accepted", "Active", "Sunset"},
 		RequiredSections: []string{
@@ -65,9 +70,9 @@ var Formats = map[string]FormatSpec{
 		},
 	},
 	"roadmap/v1": {
-		Name:          "Roadmap",
-		Prefix:        "ROADMAP-",
-		SchemaVersion: "roadmap/v1",
+		Name:           "Roadmap",
+		Prefix:         "ROADMAP-",
+		SchemaVersion:  "roadmap/v1",
 		RequiredFields: []string{"status", "theme", "scope"},
 		ValidStatuses:  []string{"Draft", "Active", "Done"},
 		RequiredSections: []string{
@@ -79,11 +84,12 @@ var Formats = map[string]FormatSpec{
 			"Implementation Issues",
 			"Dependency Graph",
 		},
+		IssuesTableColumns: []string{"Feature", "Issues", "Dependencies", "Status"},
 	},
 	"plan/v1": {
-		Name:          "Plan",
-		Prefix:        "PLAN-",
-		SchemaVersion: "plan/v1",
+		Name:           "Plan",
+		Prefix:         "PLAN-",
+		SchemaVersion:  "plan/v1",
 		RequiredFields: []string{"status", "execution_mode", "milestone", "issue_count"},
 		ValidStatuses:  []string{"Draft", "Active", "Done"},
 		RequiredSections: []string{
@@ -94,11 +100,12 @@ var Formats = map[string]FormatSpec{
 			"Dependency Graph",
 			"Implementation Sequence",
 		},
+		IssuesTableColumns: []string{"Issue", "Dependencies", "Complexity"},
 	},
 	"strategy/v1": {
-		Name:          "Strategy",
-		Prefix:        "STRATEGY-",
-		SchemaVersion: "strategy/v1",
+		Name:           "Strategy",
+		Prefix:         "STRATEGY-",
+		SchemaVersion:  "strategy/v1",
 		RequiredFields: []string{"status", "bet", "scope"},
 		ValidStatuses:  []string{"Draft", "Accepted", "Active", "Sunset"},
 		RequiredSections: []string{
@@ -113,9 +120,9 @@ var Formats = map[string]FormatSpec{
 		},
 	},
 	"brief/v1": {
-		Name:          "Brief",
-		Prefix:        "BRIEF-",
-		SchemaVersion: "brief/v1",
+		Name:           "Brief",
+		Prefix:         "BRIEF-",
+		SchemaVersion:  "brief/v1",
 		RequiredFields: []string{"status", "problem", "outcome"},
 		ValidStatuses:  []string{"Draft", "Accepted", "Done"},
 		RequiredSections: []string{

--- a/internal/validate/table.go
+++ b/internal/validate/table.go
@@ -1,0 +1,380 @@
+package validate
+
+import (
+	"regexp"
+	"strings"
+)
+
+// RowKind classifies an issues-table body row.
+type RowKind int
+
+const (
+	// RowEntity is a primary entity row (an Issue row for the plan profile,
+	// a Feature row for the roadmap profile).
+	RowEntity RowKind = iota
+	// RowDescription is an italic 1-3 sentence description row that follows
+	// an entity row. First cell is `_..._`, remaining cells empty.
+	RowDescription
+	// RowChild is a child reference row used for tracks-design / tracks-plan
+	// issues. First cell starts with `^_...`, remaining cells empty.
+	RowChild
+)
+
+// Row is one body row of an issues table.
+type Row struct {
+	// Kind classifies the row.
+	Kind RowKind
+	// Key is the row's primary key token, used to resolve cross-references.
+	//
+	// For RowEntity in the plan profile, Key is the `#N` issue number
+	// (e.g., `#42`). For RowEntity in the roadmap profile, Key is the
+	// feature label text from the first cell (with any markdown link
+	// syntax stripped). For RowDescription and RowChild, Key is empty.
+	Key string
+	// Deps is the parsed dependency targets from the Dependencies cell of
+	// an entity row -- one entry per comma-separated link or the string
+	// "None". For non-entity rows, Deps is nil.
+	Deps []string
+	// Line is the 1-indexed absolute line number of the row in the doc.
+	Line int
+	// Raw is the row's raw text including leading and trailing pipes.
+	Raw string
+}
+
+// Table is the parsed issues table from a single Markdown doc.
+type Table struct {
+	// Columns is the header column names in order, with surrounding
+	// whitespace trimmed and markdown stripped.
+	Columns []string
+	// Rows is every body row in order (entity, description, child).
+	Rows []Row
+	// HeaderLine is the 1-indexed absolute line number of the header row.
+	HeaderLine int
+}
+
+// implementationIssuesHeading matches the Implementation Issues section
+// heading. The validator finds the table inside this section's body.
+const implementationIssuesHeading = "## Implementation Issues"
+
+// strikethroughPattern strips `~~...~~` markers so a struck-through row
+// classifies the same way as an open row.
+var strikethroughPattern = regexp.MustCompile(`~~([^~]*)~~`)
+
+// issueRefPattern extracts the `#N` token from a plan-profile entity
+// cell. Matches `#` followed by one or more digits.
+var issueRefPattern = regexp.MustCompile(`#(\d+)`)
+
+// parseIssuesTable locates the GFM pipe table under the Implementation
+// Issues section of doc and parses it into a Table.
+//
+// Returns (Table, true) if a table is found. Returns (Table{}, false)
+// when the section is absent, the section has no table, or the table is
+// malformed (no header / no separator row). The parser is total over
+// arbitrary line input: it never panics on ragged rows, unterminated
+// sections, or missing separators.
+func parseIssuesTable(doc Doc) (Table, bool) {
+	startIdx, endIdx, headerLine, ok := findIssuesTableSection(doc)
+	if !ok {
+		return Table{}, false
+	}
+
+	// Find the header row inside [startIdx, endIdx).
+	hdrIdx := -1
+	for i := startIdx; i < endIdx; i++ {
+		line := doc.Body[i]
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if isTableRow(trimmed) {
+			hdrIdx = i
+			break
+		}
+	}
+	if hdrIdx < 0 {
+		return Table{}, false
+	}
+
+	// The line immediately after the header must be a separator row
+	// (`| --- | --- | ... |`). If absent, treat as no-table-found.
+	sepIdx := hdrIdx + 1
+	if sepIdx >= endIdx {
+		return Table{}, false
+	}
+	if !isSeparatorRow(strings.TrimSpace(doc.Body[sepIdx])) {
+		return Table{}, false
+	}
+
+	columns := splitRow(doc.Body[hdrIdx])
+	if len(columns) == 0 {
+		return Table{}, false
+	}
+
+	table := Table{
+		Columns:    columns,
+		HeaderLine: headerLine,
+	}
+
+	// Find the Dependencies column index by header. Missing/legacy
+	// shapes that have no Dependencies column produce depCol == -1; FC05
+	// reports the schema mismatch and FC06 simply finds no targets to
+	// validate.
+	depCol := -1
+	for i, c := range columns {
+		if c == "Dependencies" {
+			depCol = i
+			break
+		}
+	}
+
+	// Iterate body rows until we hit a blank line or the section ends.
+	for i := sepIdx + 1; i < endIdx; i++ {
+		raw := doc.Body[i]
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" {
+			// A blank line ends the table body.
+			break
+		}
+		if !isTableRow(trimmed) {
+			// A non-pipe line ends the table body.
+			break
+		}
+		cells := splitRow(raw)
+		row := classifyRow(cells, depCol)
+		// Absolute line = headerLine offset by (i - hdrIdx).
+		row.Line = headerLine + (i - hdrIdx)
+		row.Raw = doc.Body[i]
+		table.Rows = append(table.Rows, row)
+	}
+
+	return table, true
+}
+
+// findIssuesTableSection returns the [start, end) body indices that
+// bound the Implementation Issues section, and the absolute line of
+// its heading. Returns false if the section is absent.
+func findIssuesTableSection(doc Doc) (start, end, headingLine int, ok bool) {
+	// Section heading must appear in Doc.Sections (## level) under the
+	// name "Implementation Issues".
+	headingSec := -1
+	for _, sec := range doc.Sections {
+		if sec.Name == "Implementation Issues" {
+			headingLine = sec.Line
+			headingSec = headingLine
+			break
+		}
+	}
+	if headingSec < 0 {
+		return 0, 0, 0, false
+	}
+
+	// Walk Body to find the heading line index and the next ## heading.
+	startIdx := -1
+	endIdx := len(doc.Body)
+	for i, line := range doc.Body {
+		if startIdx < 0 {
+			if strings.TrimRight(line, " \t") == implementationIssuesHeading {
+				startIdx = i + 1
+			}
+			continue
+		}
+		// Past the heading -- watch for the next ## heading.
+		if strings.HasPrefix(line, "## ") {
+			endIdx = i
+			break
+		}
+	}
+	if startIdx < 0 {
+		return 0, 0, 0, false
+	}
+	return startIdx, endIdx, headingLine, true
+}
+
+// isTableRow reports whether trimmed is a GFM pipe-table row -- starts
+// with `|` and contains at least one cell separator.
+func isTableRow(trimmed string) bool {
+	if !strings.HasPrefix(trimmed, "|") {
+		return false
+	}
+	// A valid table row has at least two `|` characters.
+	return strings.Count(trimmed, "|") >= 2
+}
+
+// isSeparatorRow reports whether trimmed is a GFM separator row -- each
+// cell contains only dashes, colons, and whitespace.
+func isSeparatorRow(trimmed string) bool {
+	if !isTableRow(trimmed) {
+		return false
+	}
+	cells := splitRow(trimmed)
+	if len(cells) == 0 {
+		return false
+	}
+	for _, c := range cells {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			return false
+		}
+		for _, r := range c {
+			if r != '-' && r != ':' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// splitRow splits a raw GFM pipe row into its cells. Surrounding pipes
+// are removed and each cell is whitespace-trimmed. Empty trailing cells
+// from `| a | | |` are preserved.
+func splitRow(raw string) []string {
+	trimmed := strings.TrimSpace(raw)
+	if !strings.HasPrefix(trimmed, "|") {
+		return nil
+	}
+	// Remove leading and trailing pipes.
+	trimmed = strings.TrimPrefix(trimmed, "|")
+	trimmed = strings.TrimSuffix(trimmed, "|")
+	parts := strings.Split(trimmed, "|")
+	cells := make([]string, len(parts))
+	for i, p := range parts {
+		cells[i] = strings.TrimSpace(p)
+	}
+	return cells
+}
+
+// classifyRow inspects the cells of a body row and produces a Row with
+// its kind, key, and dependency targets populated. depCol is the index
+// of the Dependencies column in the table header (-1 if absent).
+func classifyRow(cells []string, depCol int) Row {
+	if len(cells) == 0 {
+		return Row{Kind: RowEntity}
+	}
+	first := stripStrikethrough(cells[0])
+
+	// Child reference row: first cell starts with `^_` and remaining
+	// cells are empty (after strikethrough strip).
+	if strings.HasPrefix(first, "^_") {
+		if restEmpty(cells[1:]) {
+			return Row{Kind: RowChild}
+		}
+	}
+
+	// Description row: first cell is wrapped in italic markers `_..._`
+	// (single underscores) and remaining cells are empty.
+	if isItalicCell(first) && restEmpty(cells[1:]) {
+		return Row{Kind: RowDescription}
+	}
+
+	// Otherwise it's an entity row.
+	row := Row{Kind: RowEntity}
+	row.Key = extractEntityKey(first)
+	if depCol >= 0 && depCol < len(cells) {
+		row.Deps = extractDeps(stripStrikethrough(cells[depCol]))
+	}
+	return row
+}
+
+// extractDeps parses a Dependencies cell value into a list of targets.
+// `None` (case-insensitive) and the empty string both yield nil.
+// Otherwise the cell is split on commas; each token is normalized to its
+// `#N` issue token if present, else to the feature-label text inside the
+// link. Cross-repo references (`owner/repo#N`) preserve the slash so
+// FC06 can recognize them as non-local and skip them.
+func extractDeps(cell string) []string {
+	c := strings.TrimSpace(cell)
+	if c == "" {
+		return nil
+	}
+	if strings.EqualFold(c, "none") {
+		return nil
+	}
+	parts := strings.Split(c, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		// A `#N` token: only normalize to `#N` if no slash precedes it
+		// in the token (cross-repo refs like `owner/repo#N` keep the
+		// slash so FC06 treats them as non-local).
+		if loc := issueRefPattern.FindStringIndex(p); loc != nil {
+			before := p[:loc[0]]
+			// Strip leading markdown-link `[`.
+			before = strings.TrimLeft(before, "[")
+			if !strings.Contains(before, "/") {
+				out = append(out, p[loc[0]:loc[1]])
+				continue
+			}
+			// Preserve the cross-repo form for non-local detection.
+			out = append(out, strings.TrimSpace(p))
+			continue
+		}
+		// Otherwise use the link text or the raw cell content.
+		out = append(out, normalizeFeatureRef(p))
+	}
+	return out
+}
+
+// extractEntityKey returns the entity row's primary key from the first
+// cell.
+//
+// For a plan-profile entity row, the cell looks like
+// `[#N: <title>](<url>)`; the key is `#N`. For a roadmap-profile entity
+// row, the cell is a feature label (free text, possibly with a markdown
+// link to a per-feature anchor); the key is the normalized label.
+func extractEntityKey(cell string) string {
+	c := stripStrikethrough(cell)
+	if m := issueRefPattern.FindString(c); m != "" {
+		return m
+	}
+	return normalizeFeatureRef(c)
+}
+
+// normalizeFeatureRef strips markdown link syntax to produce a stable
+// label suitable for cross-reference lookup.
+func normalizeFeatureRef(s string) string {
+	s = strings.TrimSpace(s)
+	// `[label](url)` -> `label`
+	if strings.HasPrefix(s, "[") {
+		if end := strings.Index(s, "]("); end > 0 {
+			s = s[1:end]
+		}
+	}
+	return strings.TrimSpace(s)
+}
+
+// stripStrikethrough removes `~~..~~` markers so a struck-through cell
+// classifies the same as an open cell.
+func stripStrikethrough(s string) string {
+	return strikethroughPattern.ReplaceAllString(s, "$1")
+}
+
+// isItalicCell reports whether s is wrapped in single underscores. The
+// description row's first cell is `_...some text..._`.
+func isItalicCell(s string) bool {
+	s = strings.TrimSpace(s)
+	if len(s) < 2 {
+		return false
+	}
+	if !strings.HasPrefix(s, "_") || !strings.HasSuffix(s, "_") {
+		return false
+	}
+	// Reject `__text__` (bold) -- description rows use single underscores.
+	if strings.HasPrefix(s, "__") {
+		return false
+	}
+	return true
+}
+
+// restEmpty reports whether every cell in tail is empty after
+// strikethrough is stripped.
+func restEmpty(tail []string) bool {
+	for _, c := range tail {
+		if strings.TrimSpace(stripStrikethrough(c)) != "" {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/validate/table_test.go
+++ b/internal/validate/table_test.go
@@ -1,0 +1,632 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+)
+
+// docFromMarkdown is a test helper that simulates parseDocBytes for
+// table-test inputs. It splits frontmatter (if present) and scans the
+// body for ## sections, matching the production scanner's behavior.
+func docFromMarkdown(t *testing.T, md string) Doc {
+	t.Helper()
+	doc, err := parseDocBytes("test.md", []byte(md))
+	if err != nil {
+		t.Fatalf("parseDocBytes failed: %v", err)
+	}
+	return doc
+}
+
+// --- parseIssuesTable ---
+
+func TestParseIssuesTable_CanonicalPlanProfile(t *testing.T) {
+	doc := docFromMarkdown(t, `---
+schema: plan/v1
+status: Active
+execution_mode: multi-pr
+milestone: "foo"
+issue_count: 2
+---
+
+# PLAN: foo
+
+## Status
+
+Active
+
+## Implementation Issues
+
+| Issue | Dependencies | Complexity |
+|-------|--------------|------------|
+| [#1: first](https://example.com/1) | None | simple |
+| _First description._ | | |
+| [#2: second](https://example.com/2) | [#1](https://example.com/1) | testable |
+| _Second description._ | | |
+`)
+
+	table, ok := parseIssuesTable(doc)
+	if !ok {
+		t.Fatal("expected to find a table, got false")
+	}
+	wantCols := []string{"Issue", "Dependencies", "Complexity"}
+	if !stringSlicesEqual(table.Columns, wantCols) {
+		t.Errorf("columns: got %v, want %v", table.Columns, wantCols)
+	}
+	if len(table.Rows) != 4 {
+		t.Fatalf("expected 4 rows (2 entity + 2 desc), got %d", len(table.Rows))
+	}
+	if table.Rows[0].Kind != RowEntity || table.Rows[0].Key != "#1" {
+		t.Errorf("row[0]: got kind=%v key=%q, want entity #1", table.Rows[0].Kind, table.Rows[0].Key)
+	}
+	if table.Rows[1].Kind != RowDescription {
+		t.Errorf("row[1]: got kind=%v, want description", table.Rows[1].Kind)
+	}
+	if table.Rows[2].Kind != RowEntity || table.Rows[2].Key != "#2" {
+		t.Errorf("row[2]: got kind=%v key=%q, want entity #2", table.Rows[2].Kind, table.Rows[2].Key)
+	}
+	if len(table.Rows[2].Deps) != 1 || table.Rows[2].Deps[0] != "#1" {
+		t.Errorf("row[2] deps: got %v, want [#1]", table.Rows[2].Deps)
+	}
+}
+
+func TestParseIssuesTable_CanonicalRoadmapProfile(t *testing.T) {
+	doc := docFromMarkdown(t, `---
+schema: roadmap/v1
+status: Active
+theme: |
+  theme
+scope: |
+  scope
+---
+
+# ROADMAP: foo
+
+## Status
+
+Active
+
+## Implementation Issues
+
+| Feature | Issues | Dependencies | Status |
+|---------|--------|--------------|--------|
+| Feature 1: alpha | [#10](https://example.com/10) | None | In Progress |
+| _Alpha description._ | | | |
+| Feature 2: beta | [#11](https://example.com/11) | Feature 1: alpha | Not Started |
+| _Beta description._ | | | |
+`)
+
+	table, ok := parseIssuesTable(doc)
+	if !ok {
+		t.Fatal("expected to find a table, got false")
+	}
+	wantCols := []string{"Feature", "Issues", "Dependencies", "Status"}
+	if !stringSlicesEqual(table.Columns, wantCols) {
+		t.Errorf("columns: got %v, want %v", table.Columns, wantCols)
+	}
+	if len(table.Rows) != 4 {
+		t.Fatalf("expected 4 rows (2 entity + 2 desc), got %d", len(table.Rows))
+	}
+	if table.Rows[0].Kind != RowEntity || table.Rows[0].Key != "Feature 1: alpha" {
+		t.Errorf("row[0]: got kind=%v key=%q, want entity 'Feature 1: alpha'", table.Rows[0].Kind, table.Rows[0].Key)
+	}
+	if table.Rows[2].Key != "Feature 2: beta" {
+		t.Errorf("row[2] key: got %q, want 'Feature 2: beta'", table.Rows[2].Key)
+	}
+	if len(table.Rows[2].Deps) != 1 || table.Rows[2].Deps[0] != "Feature 1: alpha" {
+		t.Errorf("row[2] deps: got %v, want [Feature 1: alpha]", table.Rows[2].Deps)
+	}
+}
+
+func TestParseIssuesTable_StrikethroughOnDoneClassifies(t *testing.T) {
+	doc := docFromMarkdown(t, `---
+schema: plan/v1
+status: Active
+execution_mode: multi-pr
+milestone: "foo"
+issue_count: 1
+---
+
+# PLAN: foo
+
+## Status
+
+Active
+
+## Implementation Issues
+
+| Issue | Dependencies | Complexity |
+|-------|--------------|------------|
+| ~~[#1: done item](https://example.com/1)~~ | ~~None~~ | ~~simple~~ |
+| ~~_A struck-through description._~~ | | |
+`)
+
+	table, ok := parseIssuesTable(doc)
+	if !ok {
+		t.Fatal("expected to find a table")
+	}
+	if len(table.Rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(table.Rows))
+	}
+	if table.Rows[0].Kind != RowEntity {
+		t.Errorf("struck entity row should classify as RowEntity, got %v", table.Rows[0].Kind)
+	}
+	if table.Rows[0].Key != "#1" {
+		t.Errorf("expected key '#1' (stripped from strikethrough), got %q", table.Rows[0].Key)
+	}
+	if table.Rows[1].Kind != RowDescription {
+		t.Errorf("struck description row should classify as RowDescription, got %v", table.Rows[1].Kind)
+	}
+}
+
+func TestParseIssuesTable_ChildReferenceRow(t *testing.T) {
+	doc := docFromMarkdown(t, `---
+schema: plan/v1
+status: Active
+execution_mode: multi-pr
+milestone: "foo"
+issue_count: 1
+---
+
+# PLAN: foo
+
+## Status
+
+Active
+
+## Implementation Issues
+
+| Issue | Dependencies | Complexity |
+|-------|--------------|------------|
+| [#1: tracks-design item](https://example.com/1) | None | simple |
+| ^_Child: [DESIGN-foo.md](./DESIGN-foo.md)_ | | | |
+| _Description._ | | |
+`)
+
+	table, ok := parseIssuesTable(doc)
+	if !ok {
+		t.Fatal("expected to find a table")
+	}
+	if len(table.Rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(table.Rows))
+	}
+	if table.Rows[1].Kind != RowChild {
+		t.Errorf("middle row should be RowChild, got %v", table.Rows[1].Kind)
+	}
+}
+
+func TestParseIssuesTable_NoSectionReturnsFalse(t *testing.T) {
+	doc := docFromMarkdown(t, `---
+schema: plan/v1
+status: Active
+---
+
+# PLAN: foo
+
+## Status
+
+Active
+
+## Other Section
+
+Some text.
+`)
+
+	if _, ok := parseIssuesTable(doc); ok {
+		t.Error("expected (Table{}, false) when no Implementation Issues section")
+	}
+}
+
+func TestParseIssuesTable_EmptySectionReturnsFalse(t *testing.T) {
+	doc := docFromMarkdown(t, `---
+schema: roadmap/v1
+status: Draft
+---
+
+# ROADMAP: foo
+
+## Status
+
+Draft
+
+## Implementation Issues
+
+<!-- Populated by /plan during decomposition. Do not fill manually. -->
+
+## Dependency Graph
+`)
+
+	if _, ok := parseIssuesTable(doc); ok {
+		t.Error("expected (Table{}, false) when section is empty")
+	}
+}
+
+func TestParseIssuesTable_NoSeparatorRowReturnsFalse(t *testing.T) {
+	// A table with a header row but no separator (`| --- | --- |`) is
+	// malformed and should be treated as no-table-found.
+	doc := docFromMarkdown(t, `---
+schema: plan/v1
+status: Active
+---
+
+## Implementation Issues
+
+| Issue | Dependencies | Complexity |
+| [#1: only row](https://example.com/1) | None | simple |
+`)
+
+	if _, ok := parseIssuesTable(doc); ok {
+		t.Error("expected false when separator row is missing")
+	}
+}
+
+func TestParseIssuesTable_RaggedRowsDoNotPanic(t *testing.T) {
+	// Defensive: a row with fewer cells than the header must not panic.
+	doc := docFromMarkdown(t, `---
+schema: plan/v1
+status: Active
+---
+
+## Implementation Issues
+
+| Issue | Dependencies | Complexity |
+|-------|--------------|------------|
+| [#1: ragged](https://example.com/1) |
+| _Description._ |
+`)
+
+	// Should not panic; if it parses, fine; if not, fine.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("parseIssuesTable panicked on ragged rows: %v", r)
+		}
+	}()
+	parseIssuesTable(doc)
+}
+
+func TestParseIssuesTable_DivergentRoadmapStrategicPipeline(t *testing.T) {
+	// The ROADMAP-strategic-pipeline.md committed shape. parseIssuesTable
+	// should return the table (parsing is profile-agnostic); FC05 then
+	// flags it.
+	doc := docFromMarkdown(t, `---
+schema: roadmap/v1
+status: Active
+---
+
+## Implementation Issues
+
+| Feature | Status | Downstream Artifact |
+|---------|--------|---------------------|
+| Feature 1: VISION Artifact Type | Done | DESIGN-vision-artifact-type.md (Current) |
+| Feature 2: Roadmap Creation Skill | Done | PRD-roadmap-skill.md (Done), DESIGN-roadmap-creation-skill.md (Current) |
+`)
+
+	table, ok := parseIssuesTable(doc)
+	if !ok {
+		t.Fatal("expected parseIssuesTable to find the divergent table")
+	}
+	wantCols := []string{"Feature", "Status", "Downstream Artifact"}
+	if !stringSlicesEqual(table.Columns, wantCols) {
+		t.Errorf("columns: got %v, want %v", table.Columns, wantCols)
+	}
+}
+
+// --- checkFC05 ---
+
+func TestCheckFC05_CanonicalPlanPasses(t *testing.T) {
+	doc := docFromMarkdown(t, `---
+schema: plan/v1
+status: Active
+execution_mode: multi-pr
+milestone: "foo"
+issue_count: 1
+---
+
+## Implementation Issues
+
+| Issue | Dependencies | Complexity |
+|-------|--------------|------------|
+| [#1: alpha](https://example.com/1) | None | simple |
+| _Alpha description._ | | |
+`)
+
+	errs := checkFC05(doc, Formats["plan/v1"])
+	if len(errs) != 0 {
+		t.Errorf("expected no FC05 errors on canonical plan, got %v", errs)
+	}
+}
+
+func TestCheckFC05_CanonicalRoadmapPasses(t *testing.T) {
+	doc := docFromMarkdown(t, `---
+schema: roadmap/v1
+status: Active
+---
+
+## Implementation Issues
+
+| Feature | Issues | Dependencies | Status |
+|---------|--------|--------------|--------|
+| Feature 1: alpha | [#10](https://example.com/10) | None | In Progress |
+| _Alpha description._ | | | |
+`)
+
+	errs := checkFC05(doc, Formats["roadmap/v1"])
+	if len(errs) != 0 {
+		t.Errorf("expected no FC05 errors on canonical roadmap, got %v", errs)
+	}
+}
+
+func TestCheckFC05_LegacyPlanTitleColumnEmitsMigrationHint(t *testing.T) {
+	doc := docFromMarkdown(t, `---
+schema: plan/v1
+status: Active
+execution_mode: multi-pr
+milestone: "foo"
+issue_count: 1
+---
+
+## Implementation Issues
+
+| Issue | Title | Dependencies | Complexity |
+|-------|-------|--------------|------------|
+| [#1](https://example.com/1) | first item | None | simple |
+| _First description._ | | | |
+`)
+
+	errs := checkFC05(doc, Formats["plan/v1"])
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 FC05 error, got %d: %v", len(errs), errs)
+	}
+	if errs[0].Code != "FC05" {
+		t.Errorf("code: got %q, want FC05", errs[0].Code)
+	}
+	if !strings.Contains(errs[0].Message, "legacy plan table shape") {
+		t.Errorf("message should mention legacy migration, got %q", errs[0].Message)
+	}
+	if !strings.Contains(errs[0].Message, "[#N: <title>](url)") {
+		t.Errorf("message should show the canonical link form, got %q", errs[0].Message)
+	}
+}
+
+func TestCheckFC05_DivergentRoadmapFeatureStatusDownstreamArtifact(t *testing.T) {
+	doc := docFromMarkdown(t, `---
+schema: roadmap/v1
+status: Active
+---
+
+## Implementation Issues
+
+| Feature | Status | Downstream Artifact |
+|---------|--------|---------------------|
+| Feature 1: foo | Done | PRD-foo.md |
+| _Description._ | | |
+`)
+
+	errs := checkFC05(doc, Formats["roadmap/v1"])
+	if len(errs) == 0 {
+		t.Fatal("expected FC05 to fail on divergent roadmap shape")
+	}
+	if errs[0].Code != "FC05" {
+		t.Errorf("code: got %q, want FC05", errs[0].Code)
+	}
+	if !strings.Contains(errs[0].Message, "does not match the Roadmap profile") {
+		t.Errorf("message should name the profile, got %q", errs[0].Message)
+	}
+}
+
+func TestCheckFC05_DivergentRoadmapIssuePhaseDependenciesLabel(t *testing.T) {
+	doc := docFromMarkdown(t, `---
+schema: roadmap/v1
+status: Active
+---
+
+## Implementation Issues
+
+| Issue | Phase | Dependencies | Label |
+|-------|-------|--------------|-------|
+| [#49: foo](https://example.com/49) | 1 | None | needs-design |
+| _Description._ | | | |
+`)
+
+	errs := checkFC05(doc, Formats["roadmap/v1"])
+	if len(errs) == 0 {
+		t.Fatal("expected FC05 to fail on Issue|Phase|Dependencies|Label roadmap shape")
+	}
+}
+
+func TestCheckFC05_MissingDescriptionRowReported(t *testing.T) {
+	doc := docFromMarkdown(t, `---
+schema: plan/v1
+status: Active
+execution_mode: multi-pr
+milestone: "foo"
+issue_count: 2
+---
+
+## Implementation Issues
+
+| Issue | Dependencies | Complexity |
+|-------|--------------|------------|
+| [#1: alpha](https://example.com/1) | None | simple |
+| [#2: beta](https://example.com/2) | None | simple |
+| _Beta description._ | | |
+`)
+
+	errs := checkFC05(doc, Formats["plan/v1"])
+	if len(errs) == 0 {
+		t.Fatal("expected FC05 to report missing description row for #1")
+	}
+	if !strings.Contains(errs[0].Message, "missing its description row") {
+		t.Errorf("message should mention missing description row, got %q", errs[0].Message)
+	}
+}
+
+func TestCheckFC05_NoIssuesTableSpecIsNoOp(t *testing.T) {
+	// Formats without an issues table (Design, PRD, etc.) must not run FC05.
+	doc := docFromMarkdown(t, `---
+schema: design/v1
+status: Accepted
+---
+
+## Implementation Issues
+
+| Some | Random | Headers |
+|------|--------|---------|
+| a | b | c |
+`)
+	errs := checkFC05(doc, Formats["design/v1"])
+	if len(errs) != 0 {
+		t.Errorf("FC05 should be a no-op for design/v1, got %v", errs)
+	}
+}
+
+// --- checkFC06 ---
+
+func TestCheckFC06_AllReferencesResolve(t *testing.T) {
+	doc := docFromMarkdown(t, `---
+schema: plan/v1
+status: Active
+execution_mode: multi-pr
+milestone: "foo"
+issue_count: 2
+---
+
+## Implementation Issues
+
+| Issue | Dependencies | Complexity |
+|-------|--------------|------------|
+| [#1: alpha](https://example.com/1) | None | simple |
+| _Alpha._ | | |
+| [#2: beta](https://example.com/2) | [#1](https://example.com/1) | testable |
+| _Beta._ | | |
+`)
+
+	errs := checkFC06(doc, Formats["plan/v1"])
+	if len(errs) != 0 {
+		t.Errorf("expected no FC06 errors, got %v", errs)
+	}
+}
+
+func TestCheckFC06_DanglingCrossReferenceFires(t *testing.T) {
+	doc := docFromMarkdown(t, `---
+schema: plan/v1
+status: Active
+execution_mode: multi-pr
+milestone: "foo"
+issue_count: 2
+---
+
+## Implementation Issues
+
+| Issue | Dependencies | Complexity |
+|-------|--------------|------------|
+| [#1: alpha](https://example.com/1) | None | simple |
+| _Alpha._ | | |
+| [#2: beta](https://example.com/2) | [#99](https://example.com/99) | testable |
+| _Beta._ | | |
+`)
+
+	errs := checkFC06(doc, Formats["plan/v1"])
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 FC06 error, got %d: %v", len(errs), errs)
+	}
+	if errs[0].Code != "FC06" {
+		t.Errorf("code: got %q, want FC06", errs[0].Code)
+	}
+	if !strings.Contains(errs[0].Message, `"#99"`) {
+		t.Errorf("message should name the dangling key '#99', got %q", errs[0].Message)
+	}
+	if !strings.Contains(errs[0].Message, `"#2"`) {
+		t.Errorf("message should name the source row '#2', got %q", errs[0].Message)
+	}
+}
+
+func TestCheckFC06_CrossRepoReferenceSkipped(t *testing.T) {
+	// `tsukumogami/repo#N` is a cross-repo reference -- out of scope for
+	// the document-local check.
+	doc := docFromMarkdown(t, `---
+schema: plan/v1
+status: Active
+execution_mode: multi-pr
+milestone: "foo"
+issue_count: 1
+---
+
+## Implementation Issues
+
+| Issue | Dependencies | Complexity |
+|-------|--------------|------------|
+| [#1: alpha](https://example.com/1) | someorg/somerepo#5 | simple |
+| _Alpha._ | | |
+`)
+
+	errs := checkFC06(doc, Formats["plan/v1"])
+	if len(errs) != 0 {
+		t.Errorf("FC06 should skip cross-repo refs, got %v", errs)
+	}
+}
+
+func TestCheckFC06_RoadmapFeatureKeyResolves(t *testing.T) {
+	doc := docFromMarkdown(t, `---
+schema: roadmap/v1
+status: Active
+---
+
+## Implementation Issues
+
+| Feature | Issues | Dependencies | Status |
+|---------|--------|--------------|--------|
+| Feature 1: alpha | [#10](https://example.com/10) | None | Done |
+| _Alpha._ | | | |
+| Feature 2: beta | [#11](https://example.com/11) | Feature 1: alpha | In Progress |
+| _Beta._ | | | |
+`)
+
+	errs := checkFC06(doc, Formats["roadmap/v1"])
+	if len(errs) != 0 {
+		t.Errorf("expected no FC06 errors for resolving feature ref, got %v", errs)
+	}
+}
+
+func TestCheckFC06_NoIssuesTableSpecIsNoOp(t *testing.T) {
+	doc := docFromMarkdown(t, `---
+schema: design/v1
+status: Accepted
+---
+
+## Implementation Issues
+
+| Some | Random | Headers |
+|------|--------|---------|
+| a | b | c |
+`)
+	errs := checkFC06(doc, Formats["design/v1"])
+	if len(errs) != 0 {
+		t.Errorf("FC06 should be a no-op for design/v1, got %v", errs)
+	}
+}
+
+// --- Defensive parsing ---
+
+func TestParseIssuesTable_NoSectionInEmptyDoc(t *testing.T) {
+	doc := docFromMarkdown(t, ``)
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked on empty doc: %v", r)
+		}
+	}()
+	if _, ok := parseIssuesTable(doc); ok {
+		t.Error("expected false on empty doc")
+	}
+}
+
+func TestParseIssuesTable_UnterminatedSectionDoesNotPanic(t *testing.T) {
+	// Section heading with no body, no closing section.
+	doc := docFromMarkdown(t, `## Implementation Issues
+`)
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panicked on unterminated section: %v", r)
+		}
+	}()
+	parseIssuesTable(doc)
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -37,6 +37,11 @@ func ValidateFile(doc Doc, spec FormatSpec, cfg Config) []ValidationError {
 	switch spec.Name {
 	case "Plan":
 		errs = append(errs, checkPlanUpstream(doc)...)
+		errs = append(errs, checkFC05(doc, spec)...)
+		errs = append(errs, checkFC06(doc, spec)...)
+	case "Roadmap":
+		errs = append(errs, checkFC05(doc, spec)...)
+		errs = append(errs, checkFC06(doc, spec)...)
 	case "VISION":
 		errs = append(errs, checkVisionPublic(doc, cfg)...)
 	case "Strategy":

--- a/references/dependency-diagram.md
+++ b/references/dependency-diagram.md
@@ -1,0 +1,166 @@
+# Dependency Diagram
+
+The one dependency-diagram convention both roadmap and plan workflows
+consume. Defines the mermaid syntax rules, the fixed status-class
+palette, the node format, and the legend.
+
+Cited by P4 in `workflow-principles.md`.
+
+## Table of Contents
+
+- [Mermaid Syntax Rules](#mermaid-syntax-rules)
+- [Status Classes](#status-classes)
+- [Node Format](#node-format)
+- [Class Assignment](#class-assignment)
+- [Initial Status](#initial-status)
+- [Status Updates](#status-updates)
+- [Legend](#legend)
+- [Child Reference Row Invariant](#child-reference-row-invariant)
+
+## Mermaid Syntax Rules
+
+These rules prevent common mermaid rendering failures.
+
+### 1. Use `graph`, not `flowchart`
+
+```
+graph TD    # Correct
+flowchart TD  # Wrong -- less portable
+```
+
+### 2. Direction
+
+- `LR` (left-right): Preferred for simple diagrams with few sequential
+  levels.
+- `TD` (top-down): Use when dependencies span five or more sequential
+  levels (horizontal becomes unreadable).
+
+### 3. Subgraphs for phases (optional)
+
+```
+subgraph Phase1["Phase 1: Name"]
+    I488["#488: Title"]
+    I489["#489: Title"]
+end
+```
+
+### 4. Edges MUST be outside subgraphs
+
+```
+# Wrong -- edges inside subgraph (will not render)
+subgraph Phase1
+    A --> B
+end
+
+# Correct -- edges after all subgraphs
+subgraph Phase1
+    A["..."]
+    B["..."]
+end
+A --> B
+```
+
+### 5. Class definitions at the end
+
+```
+graph TD
+    # ... nodes and edges ...
+
+    classDef done fill:#c8e6c9
+    classDef ready fill:#bbdefb
+    classDef blocked fill:#fff9c4
+    classDef needsDesign fill:#e1bee7
+    classDef needsPrd fill:#b3e5fc
+    classDef needsSpike fill:#ffcdd2
+    classDef needsDecision fill:#d1c4e9
+    classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
+    classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
+
+    class I488 ready
+    class I489,I490 blocked
+```
+
+## Status Classes
+
+Fixed palette. Never change these colors or class names.
+
+| Status | Class | Fill Color | Meaning |
+|--------|-------|------------|---------|
+| done | `done` | `#c8e6c9` (light green) | Issue or feature is closed |
+| ready | `ready` | `#bbdefb` (light blue) | Open, no blocking dependencies |
+| blocked | `blocked` | `#fff9c4` (light yellow) | Open, has open blockers |
+| needs-design | `needsDesign` | `#e1bee7` (light purple) | Future work, not yet designed |
+| needs-prd | `needsPrd` | `#b3e5fc` (light blue) | Future work, needs requirements definition |
+| needs-spike | `needsSpike` | `#ffcdd2` (light red) | Future work, needs feasibility investigation |
+| needs-decision | `needsDecision` | `#d1c4e9` (light indigo) | Future work, needs architectural choice |
+| tracks-design | `tracksDesign` | `#FFE0B2` (light orange), stroke `#F57C00` | Has spawned a child design in progress |
+| tracks-plan | `tracksPlan` | `#FFE0B2` (light orange), stroke `#F57C00` | PLAN created, implementation underway |
+
+## Node Format
+
+- **Node ID:** `I<issue-number>` for plan diagrams (e.g., `I417`); use
+  a stable mnemonic for roadmap features (e.g., `F1`, `F2`).
+- **Node label:** `#<N>: <short-title>` for issues; the feature
+  label for roadmap features. Maximum 40 characters.
+- **Quotes around labels:** Always use `["..."]`.
+
+### Node Label Rules
+
+- Maximum 40 characters total.
+- Truncate at last word boundary, add `...` if too long.
+- Replace `[` `]` with `(` `)`, remove backticks.
+- Example: `I417["#417: Add structured logging..."]`
+
+## Class Assignment
+
+Use the `class` directive (not inline `:::`):
+
+```
+# Wrong -- inline syntax less maintainable
+I488:::ready --> I489:::blocked
+
+# Correct -- class directive at end
+I488 --> I489
+class I488 ready
+class I489 blocked
+```
+
+Group multiple nodes with the same status:
+
+```
+class I489,I490,I491 blocked
+```
+
+## Initial Status
+
+When `/plan` or `/roadmap` creates the diagram:
+
+- Nodes with no dependencies: `ready`
+- Nodes with dependencies: `blocked`
+- Future work needing upstream artifacts: `needsDesign`, `needsPrd`,
+  `needsSpike`, or `needsDecision`
+- Nodes with accepted child designs: `tracksDesign` or `tracksPlan`
+- No nodes start as `done`
+
+## Status Updates
+
+When `/work-on` completes an issue:
+
+- The completed node changes to `done`
+- Downstream nodes are recalculated: if all blockers are done, change
+  to `ready`
+
+## Legend
+
+Include a legend line after the diagram:
+
+```markdown
+**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan
+```
+
+## Child Reference Row Invariant
+
+`tracksDesign` and `tracksPlan` nodes must have a corresponding child
+reference row in the Implementation Issues table (see
+`issues-table.md`). Nodes without a tracking class must not have a
+child reference row.

--- a/references/issues-table.md
+++ b/references/issues-table.md
@@ -1,0 +1,228 @@
+# Issues Table
+
+The one issues-table framework both roadmap and plan workflows consume.
+Parameterized into two altitude profiles -- the plan profile keys on
+issues, the roadmap profile keys on features -- so the altitude
+distinction survives while the shared core stays defined once.
+
+Cited by P4 in `workflow-principles.md`.
+
+## Table of Contents
+
+- [Shared Core](#shared-core)
+- [Shared Rendering](#shared-rendering)
+- [Plan Profile](#plan-profile)
+- [Roadmap Profile](#roadmap-profile)
+- [Migration Rules](#migration-rules)
+- [Validation](#validation)
+
+## Shared Core
+
+Both profiles render a GFM pipe table whose columns include the same
+three core concerns, in this order:
+
+1. **Key column** (position 1) -- the primary entity link. Header
+   label and link target are profile-specific (see below).
+2. **Dependencies column** -- `None` or comma-separated clickable
+   links to other rows' keys. Same semantics at both altitudes.
+3. **Status column** -- an explicit completion or lifecycle marker
+   for the row.
+
+A profile may add **one** profile-specific column. The position of
+profile-specific columns is fixed per profile (see each profile
+below).
+
+## Shared Rendering
+
+Both profiles share these rendering rules.
+
+### Description row
+
+Every entity row is followed immediately by an italic description row
+of 1-3 sentences in the first cell, with empty remaining cells:
+
+```markdown
+| <entity row> | <deps> | <status> |
+| _<1-3 sentences explaining what this entity delivers and how it
+  connects to the rest of the work>_ | | |
+```
+
+**Writing guidelines:**
+
+- Don't repeat the entity title -- explain what the entity delivers.
+- Be concrete: mention specific files, patterns, or interfaces.
+- Each description builds on the previous one; a reader going
+  top-to-bottom should get the full build sequence.
+- Keep to 1-3 sentences.
+
+### Strikethrough on done
+
+When an entity reaches a terminal state, strike through every row
+associated with it -- the entity row, its description row, and any
+child reference row between them. Use `~~text~~` markdown syntax.
+
+```markdown
+| ~~<entity row>~~ | ~~<deps>~~ | ~~<status>~~ |
+| ~~^_<child reference, if present>_~~ | | | |
+| ~~_<description>_~~ | | |
+```
+
+All row types (when present) must be struck through together. The
+description remains readable (just with strikethrough styling) to
+preserve the build narrative.
+
+## Plan Profile
+
+The plan profile parameterizes the shared core with:
+
+- **Key column header:** `Issue`
+- **Key link form:** `[#N: <title>](<url>)` where `N` is the GitHub
+  issue number and the link points at the issue
+- **Profile-specific column:** `Complexity` (position 3, between
+  Dependencies and Status if a Status column is present; the
+  canonical plan table uses `Issue | Dependencies | Complexity`
+  without a separate Status column -- Complexity carries the
+  routing role)
+- **Child reference row:** for issues with a `tracks-design` or
+  `tracks-plan` label, a child reference row is inserted between
+  the entity row and its description row
+
+### Canonical plan table shape
+
+```markdown
+| Issue | Dependencies | Complexity |
+|-------|--------------|------------|
+| [#N: <title>](<url>) | None | simple |
+| _<description>_ | | |
+| [#M: <title>](<url>) | [#N](<url>) | testable |
+| _<description>_ | | |
+```
+
+### Complexity values
+
+`simple`, `testable`, or `critical`.
+
+### Child reference row
+
+When a `tracks-design` or `tracks-plan` issue spawns a child design,
+a child reference row links readers to the child without importing
+its details:
+
+```markdown
+| [#N: <title>](<url>) | None | simple |
+| ^_Child: [DESIGN-<name>.md](<relative-path>)_ | | | |
+| _<description text>_ | | |
+```
+
+The `^` prefix distinguishes child reference rows from description
+rows. Only issues with a tracking label may carry a child reference
+row -- this invariant is bidirectional and may be enforced in CI.
+
+### Milestone heading
+
+In multi-pr mode, the Implementation Issues section includes a
+milestone heading immediately above the table:
+
+```markdown
+## Implementation Issues
+
+### Milestone: [<Name>](<milestone-url>)
+
+| Issue | Dependencies | Complexity |
+|-------|--------------|------------|
+...
+```
+
+## Roadmap Profile
+
+The roadmap profile parameterizes the shared core with:
+
+- **Key column header:** `Feature`
+- **Key form:** the feature label naming the feature (free text
+  identifying the feature; not a clickable link by itself, though
+  the label may contain a link to the per-feature body section)
+- **Profile-specific column:** `Issues` -- the one-to-many fan-out
+  of clickable issue links the feature decomposed into, encoding
+  the feature-to-issues altitude jump. This is the roadmap
+  profile's defining addition.
+
+### Canonical roadmap table shape
+
+```markdown
+| Feature | Issues | Dependencies | Status |
+|---------|--------|--------------|--------|
+| <feature label> | [#N](<url>), [#M](<url>) | None | In Progress |
+| _<description>_ | | | |
+| <feature label> | [#P](<url>) | <feature> | Done |
+| _<description>_ | | | |
+```
+
+### Status values
+
+Free-text lifecycle marker matching the feature's state in the
+roadmap's Progress section -- typically `Not Started`, `In Progress`,
+`Done`, or a `needs-*` annotation when the feature is awaiting an
+upstream artifact (`needs-prd`, `needs-design`, `needs-spike`,
+`needs-decision`).
+
+### Issues fan-out column
+
+The Issues column lists every issue the feature decomposed into, as
+comma-separated clickable links. `None` is allowed before the feature
+has been decomposed (the empty placeholder state at roadmap creation
+time).
+
+## Migration Rules
+
+The corpus carries pre-standardization table shapes. Migration brings
+them into the canonical profile without losing information.
+
+### Plan: legacy `Title` column
+
+A legacy `Issue | Title | Dependencies | Complexity` shape folds the
+`Title` column into the issue link text of the canonical shape:
+
+- Source: `| [#N](<url>) | <title text> | <deps> | <complexity> |`
+- Target: `| [#N: <title text>](<url>) | <deps> | <complexity> |`
+
+The legacy shape is not perpetuated as a permanent dual format. The
+validator's `FC05` message points the author at this migration.
+
+### Roadmap: divergent committed shapes
+
+Two shapes are known to exist in the committed corpus and migrate
+into the canonical roadmap profile:
+
+- `Feature | Status | Downstream Artifact` -- the `Downstream Artifact`
+  column is dropped during migration (the per-feature body sections
+  above the table already carry the artifact references). Add an
+  `Issues` fan-out column (empty `None` if the feature has not yet
+  been decomposed into issues).
+- `Issue | Phase | Dependencies | Label` -- this issue-keyed shape
+  migrates to feature-keyed. Each row becomes one feature whose
+  `Issues` column holds the original issue link. The `Phase` column
+  is dropped (phase grouping moves to body prose). The `Label`
+  column folds into `Status`: `needs-design` becomes `Status =
+  needs-design`, `Done` becomes `Status = Done`, and similar.
+
+In every migration, no issue link or dependency relationship is
+dropped or altered in meaning; only the table shape changes.
+
+## Validation
+
+The Go validator in `internal/validate/` enforces the
+machine-checkable subset of this reference:
+
+- **FC05** -- issues-table schema conformance. Profile is selected by
+  the doc's schema (plan/v1 or roadmap/v1). Header columns must match
+  the profile's required columns in order; rows must be
+  well-formed (entity, description, optional child reference).
+- **FC06** -- cross-reference existence. Every value in a
+  Dependencies cell must name an entity-row key that exists in the
+  same table.
+
+Both checks are error-level. A doc that names itself a roadmap or a
+plan (via filename prefix `ROADMAP-` or `PLAN-`) must declare its
+schema in frontmatter (`schema: roadmap/v1` or `schema: plan/v1`) for
+these checks to engage; the SCHEMA gate fires a notice on a missing
+or mismatched schema and skips the FC checks.

--- a/references/workflow-principles.md
+++ b/references/workflow-principles.md
@@ -1,0 +1,99 @@
+# Workflow Principles
+
+Five principles the roadmap and plan workflows derive from. Each
+principle states the rule, names the consequence, and lists the
+specific workflow rules that flow from it. Skill surfaces reference
+these by name -- when a surfaced rule cites a principle, it's citing
+this file.
+
+The set is intentionally small enough to hold in mind. Use it to
+reason at the edges where a procedure doesn't fit.
+
+## P1: Usable value is the unit of work
+
+Every PR and every roadmap feature delivers observable value on its
+own. Default to one PR; split only for a hard constraint or genuine
+incremental value, never by mechanism (e.g., "because the input is
+a roadmap").
+
+**Rules derived from this:**
+
+- The plan workflow defaults to single-pr execution. Multi-pr requires
+  a named escape condition: a hard constraint forces multiple PRs
+  (cross-repo landing order, a workflow that must reach main before
+  it can be invoked) or each PR is independently useful.
+- A roadmap is multi-pr because each feature should deliver
+  observable incremental value as a cohesive deliverable, not
+  because "the input is a roadmap."
+- A value-confirmation step checks every roadmap feature, and every
+  PR for a plan whose split delivers incremental value. The step can
+  fail: a unit that isn't a standalone increment is flagged for
+  re-scoping, not waved through.
+
+## P2: Default to the lowest ceremony
+
+Reach for the least machinery the work needs. Escalate only when a
+named condition forces it.
+
+**Rules derived from this:**
+
+- One PR over many (see P1).
+- A self-contained PLAN doc over GitHub issues when the work is
+  single-pr.
+- Don't promote a check to error-level when a notice suffices for the
+  current corpus state (see P5 for the inverse: strictness when blast
+  radius warrants).
+
+## P3: Decisions need a durable home
+
+A choice that affects downstream work or rests on a falsifiable
+assumption gets recorded where a later reader finds it, not left
+implicit in the procedure.
+
+**Rules derived from this:**
+
+- Decision blocks captured in the design doc carry their assumptions
+  and consequences forward.
+- Under `--auto`, judgment-call gates record `confirmed` or `assumed`
+  (the latter at high review priority) rather than hard-stopping.
+  Recording is the durable home; the loud surfacing in the PR body and
+  terminal summary is the visibility.
+- An implicit decision called out in the design's Implementation
+  Approach makes the assumption visible to the plan author.
+
+## P4: One canonical format per concern, defined once
+
+Each shared shape (the issues table, the dependency diagram) has a
+single source both workflows consume. Per-skill restatement is the
+drift source the standardization removes.
+
+**Rules derived from this:**
+
+- The issues-table framework lives in
+  `${CLAUDE_PLUGIN_ROOT}/references/issues-table.md`, parameterized by
+  altitude into a plan profile (issue-keyed) and a roadmap profile
+  (feature-keyed).
+- The dependency-diagram convention lives in
+  `${CLAUDE_PLUGIN_ROOT}/references/dependency-diagram.md`.
+- The two skill references (`plan-doc-structure.md`, `roadmap-format.md`)
+  cite the shared references and keep only their profile-specific
+  deltas and lifecycle content.
+
+## P5: Strictness tracks blast radius
+
+How hard a rule is enforced scales with the consequence of getting it
+wrong. A check whose retrofit cost is contained can land strict; a
+check whose retrofit cost is corpus-wide lands as a notice first, then
+is promoted to error once the corpus conforms.
+
+**Rules derived from this:**
+
+- Issues-table schema conformance (FC05) and cross-reference
+  existence (FC06) land at error-level on day one -- their retrofit
+  cost is contained to a small migration.
+- Table-diagram reconciliation (FC07) is staged into a later
+  increment behind a feasibility spike and ships as a notice, then is
+  promoted to error after the committed-diagram corpus is reconciled.
+- The lifecycle CI checks (L01/L02) are error-level because their
+  function is to force the deletion of a Done multi-pr doc or a
+  single-pr plan; a notice can't carry that forcing function.

--- a/skills/plan/references/quality/plan-doc-structure.md
+++ b/skills/plan/references/quality/plan-doc-structure.md
@@ -1,25 +1,53 @@
 # PLAN Artifact Format Specification
 
-Reference for constructing `PLAN-<topic>.md` artifacts. This format owns all implementation tracking: issue tables, Mermaid dependency graphs, decomposition strategy, sequencing, and issue outlines.
+Reference for constructing `PLAN-<topic>.md` artifacts. The plan
+profile of the shared issues-table framework owns table shape and
+strikethrough rules; the shared dependency-diagram convention owns
+the mermaid graph. This file carries the plan-specific deltas, the
+plan lifecycle, and the issue-outline / decomposition-strategy
+content that has no shared analogue.
 
 ## Table of Contents
 
+- [Shared References](#shared-references)
 - [File Location](#file-location)
 - [Frontmatter](#frontmatter)
 - [Lifecycle](#lifecycle)
 - [Required Sections](#required-sections)
-- [Implementation Issues Table Format](#implementation-issues-table-format)
-- [Issue Descriptions](#issue-descriptions)
-- [Child Reference Row](#child-reference-row)
-- [Strikethrough Rules](#strikethrough-rules)
-- [Dependency Graph](#dependency-graph) (Mermaid syntax, status classes, node format)
+- [Execution Mode Differences](#execution-mode-differences)
+- [Decomposition Strategies](#decomposition-strategies)
 - [Section Placement](#section-placement-legacy-context)
 - [Examples](#examples) (in `plan-doc-examples.md`)
 
+## Shared References
+
+Both the issues-table format (plan profile) and the dependency-diagram
+convention live at the plugin root and are consumed by both the plan
+and roadmap workflows:
+
+- `${CLAUDE_PLUGIN_ROOT}/references/issues-table.md` -- the shared
+  issues-table framework. The plan profile keys on issues with the
+  `Issue | Dependencies | Complexity` shape, the `[#N: <title>](url)`
+  link form, the Complexity values (`simple`, `testable`,
+  `critical`), and the child reference row for `tracks-design` and
+  `tracks-plan` issues. This reference owns table shape, description
+  rows, child reference rows, strikethrough rules, and the milestone
+  heading.
+
+- `${CLAUDE_PLUGIN_ROOT}/references/dependency-diagram.md` -- the
+  shared dependency-diagram convention. Owns the mermaid syntax
+  rules, the fixed status-class palette, node format, class
+  assignment, initial status, status updates, and legend.
+
+- `${CLAUDE_PLUGIN_ROOT}/references/workflow-principles.md` -- the
+  five principles both workflows derive from. The single-pr default
+  (P1) and the lowest-ceremony principle (P2) drive the execution
+  mode choice below.
+
 ## File Location
 
-PLAN artifacts live at `docs/plans/PLAN-<topic>.md`. When a PLAN reaches Done
-status, move it to `docs/plans/done/PLAN-<topic>.md`.
+PLAN artifacts live at `docs/plans/PLAN-<topic>.md`. When a PLAN
+reaches Done status, move it to `docs/plans/done/PLAN-<topic>.md`.
 
 ## Frontmatter
 
@@ -34,11 +62,14 @@ issue_count: <N>
 ---
 ```
 
-**Required fields:** `schema`, `status`, `execution_mode`, `milestone`, `issue_count`.
+**Required fields:** `schema`, `status`, `execution_mode`,
+`milestone`, `issue_count`.
 
-**Optional fields:** `upstream` -- path to the design doc, PRD, or roadmap that this plan decomposes.
+**Optional fields:** `upstream` -- path to the design doc, PRD, or
+roadmap that this plan decomposes.
 
-The `milestone` field is always present (it names the logical work unit) but GitHub milestone creation only happens in multi-pr mode.
+The `milestone` field is always present (it names the logical work
+unit) but GitHub milestone creation only happens in multi-pr mode.
 
 ## Lifecycle
 
@@ -66,20 +97,25 @@ Every PLAN artifact has these 7 sections, in order:
 2. **Scope Summary** -- 1-2 sentence description of what this plan covers
 3. **Decomposition Strategy** -- walking skeleton, horizontal, or feature-by-feature planning, with rationale
 4. **Issue Outlines** -- brief description of each issue before full bodies exist (populated in single-pr mode)
-5. **Implementation Issues** -- table with issue links, dependencies, complexity (populated in multi-pr mode)
-6. **Dependency Graph** -- Mermaid diagram showing issue relationships
+5. **Implementation Issues** -- table with issue links, dependencies, complexity (populated in multi-pr mode). See `${CLAUDE_PLUGIN_ROOT}/references/issues-table.md` for the canonical plan profile shape, description rows, child reference rows, and strikethrough rules.
+6. **Dependency Graph** -- Mermaid diagram showing issue relationships. See `${CLAUDE_PLUGIN_ROOT}/references/dependency-diagram.md` for syntax rules, status classes, node format, and legend.
 7. **Implementation Sequence** -- critical path and parallelization opportunities
 
-### Execution Mode Differences
+## Execution Mode Differences
 
 | Section | single-pr | multi-pr |
 |---------|-----------|----------|
 | Issue Outlines | Populated with structured outlines (goal, acceptance criteria, dependencies) | Empty or omitted |
 | Implementation Issues | Empty or omitted (no GitHub issues to link) | Populated with issue table |
 
-In single-pr mode, Phase 4 agents produce structured outlines that become sub-sections under Issue Outlines. These give /work-on the decomposition it needs without creating GitHub artifacts. The PLAN doc stays at Draft and transitions to Active when /work-on starts.
+In single-pr mode, Phase 4 agents produce structured outlines that
+become sub-sections under Issue Outlines. These give /work-on the
+decomposition it needs without creating GitHub artifacts. The PLAN
+doc stays at Draft and transitions to Active when /work-on starts.
 
-In multi-pr mode, Phase 4 agents write full issue body files. Phase 7 creates GitHub issues and milestones, populates the Implementation Issues table with links, and transitions the PLAN doc to Active.
+In multi-pr mode, Phase 4 agents write full issue body files. Phase 7
+creates GitHub issues and milestones, populates the Implementation
+Issues table with links, and transitions the PLAN doc to Active.
 
 ### Issue Outline Format
 
@@ -101,31 +137,38 @@ Each issue under `## Issue Outlines` follows this structure:
 
 **`**Type**:`** (optional)
 
-Valid values: `code`, `docs`, `task`. When absent, the `ISSUE_TYPE` template variable
-is omitted entirely when the child workflow is initialized.
+Valid values: `code`, `docs`, `task`. When absent, the `ISSUE_TYPE`
+template variable is omitted entirely when the child workflow is
+initialized.
 
-This is a hint for the analysis agent, not a binding declaration. The analysis agent
-may confirm or override this classification based on what the work actually entails.
-Routing at `implementation` is determined by the agent's confirmed type,
-not the PLAN author's annotation.
+This is a hint for the analysis agent, not a binding declaration.
+The analysis agent may confirm or override this classification based
+on what the work actually entails. Routing at `implementation` is
+determined by the agent's confirmed type, not the PLAN author's
+annotation.
 
-- `code` — implementation that runs through the full scrutiny/review/QA pipeline
-- `docs` — writing, structure, and clarity changes that skip the code review panels
-- `task` — operational work (run commands, execute scripts) that produces no meaningful
-  code or doc artifacts for review; skips code review panels
+- `code` -- implementation that runs through the full
+  scrutiny/review/QA pipeline
+- `docs` -- writing, structure, and clarity changes that skip the
+  code review panels
+- `task` -- operational work (run commands, execute scripts) that
+  produces no meaningful code or doc artifacts for review; skips
+  code review panels
 
 **`**Files**:`** (optional)
 
-Comma-separated list of file paths, each enclosed in backticks. Declares which files
-this issue intends to write to. `plan-to-tasks.sh` parses this field and wires a star
-topology to prevent concurrent overwrites: the first outline to declare a file becomes
-its owner; every later outline that shares that file gets a `waits_on` edge pointing to
-the owner. Two non-owner outlines that share the same file do NOT wait on each other —
-only on the owner.
+Comma-separated list of file paths, each enclosed in backticks.
+Declares which files this issue intends to write to.
+`plan-to-tasks.sh` parses this field and wires a star topology to
+prevent concurrent overwrites: the first outline to declare a file
+becomes its owner; every later outline that shares that file gets a
+`waits_on` edge pointing to the owner. Two non-owner outlines that
+share the same file do NOT wait on each other -- only on the owner.
 
-This field is opt-in — add it only when concurrent file conflicts are plausible. Omitting
-it does not prevent parallel execution; it means the author accepts responsibility for
-ensuring no conflicts exist.
+This field is opt-in -- add it only when concurrent file conflicts
+are plausible. Omitting it does not prevent parallel execution; it
+means the author accepts responsibility for ensuring no conflicts
+exist.
 
 Example with both optional fields:
 
@@ -143,7 +186,7 @@ Example with both optional fields:
 **Files**: `skills/work-on/koto-templates/work-on.md`, `skills/work-on/SKILL.md`
 ```
 
-### Decomposition Strategies
+## Decomposition Strategies
 
 Three decomposition strategies are available:
 
@@ -153,7 +196,12 @@ Three decomposition strategies are available:
 | Horizontal | Refactoring, documentation, loosely coupled components | Code implementation issues |
 | Feature-by-feature planning | Roadmap input (`input_type: roadmap`) | Planning issues (artifact production) |
 
-**Feature-by-feature planning** maps each roadmap feature 1:1 to a planning issue. The issues track artifact creation (PRDs, designs, spikes, decisions) rather than code implementation. All planning issues are `simple` complexity. Each issue carries a `needs_label` indicating what upstream artifact the feature requires (needs-prd, needs-design, needs-spike, or needs-decision).
+**Feature-by-feature planning** maps each roadmap feature 1:1 to a
+planning issue. The issues track artifact creation (PRDs, designs,
+spikes, decisions) rather than code implementation. All planning
+issues are `simple` complexity. Each issue carries a `needs_label`
+indicating what upstream artifact the feature requires (needs-prd,
+needs-design, needs-spike, or needs-decision).
 
 The strategy section in the PLAN doc should explain the mapping:
 
@@ -165,252 +213,15 @@ the creation of its required upstream artifact. The per-feature `needs-*` label 
 what type of artifact each feature requires next.
 ```
 
-## Implementation Issues Table Format
-
-| Column | Content |
-|--------|---------|
-| Issue | Link with title: `[#N: <title>](<url>)` |
-| Dependencies | `None` or comma-separated links: `[#X](<url>), [#Y](<url>)` |
-| Complexity | Validation complexity: `simple`, `testable`, or `critical` |
-
-**Template:**
-
-```markdown
-| Issue | Dependencies | Complexity |
-|-------|--------------|------------|
-| [#N: <title>](<url>) | None | simple |
-| _<description>_ | | |
-| [#M: <title>](<url>) | [#N](<url>) | testable |
-| _<description>_ | | |
-| [#P: <title>](<url>) | [#M](<url>), [#N](<url>) | critical |
-| _<description>_ | | |
-```
-
-**Key points:**
-- Issue column combines number and title in the link text: `[#N: <title>](<url>)`
-- Dependencies column uses **clickable issue links**, not plain text like `#N`
-- Link to milestone in heading for context
-
-**Legacy format (still accepted by CI):**
-
-Older design docs may use a separate Title column: `| Issue | Title | Dependencies | Complexity |`. Both formats are valid.
-
-### Milestone Heading
-
-In multi-pr mode, the Implementation Issues section includes a milestone heading:
-
-```markdown
-## Implementation Issues
-
-### Milestone: [<Name>](<milestone-url>)
-
-| Issue | Dependencies | Complexity |
-|-------|--------------|------------|
-...
-```
-
-## Issue Descriptions
-
-Each issue row gets a 1-3 sentence description placed immediately after it. When an issue is marked as done, both the issue row and its description row are struck through (using `~~text~~` markdown syntax). This preserves the narrative context while visually indicating completion.
-
-**Purpose:** Reading the descriptions top-to-bottom gives a sequential understanding of what the project builds and in what order. Each description builds on the previous one.
-
-**Format:**
-
-```markdown
-| [#N: <title>](<url>) | None | testable |
-| _<1-3 sentences explaining what this issue delivers and how it connects to the rest of the work. Don't repeat the title.>_ | | |
-| [#M: <title>](<url>) | [#N](<url>) | testable |
-| _<1-3 sentences. Reference what #N established and explain what this issue adds on top of it.>_ | | |
-```
-
-Description rows use italics (`_..._`) in the first cell with empty remaining cells.
-
-**Writing guidelines:**
-- Don't repeat the issue title -- explain what the issue delivers
-- Be concrete: mention specific files, patterns, or interfaces
-- Each description should build on the previous ones -- a reader going top-to-bottom should get the full build sequence
-- Keep to 1-3 sentences; this isn't the full issue spec
-
-### Description Row Requirements
-
-Every issue row must have a description row immediately after it (or after the child reference row, if one is present).
-
-Description rows use italics in the first cell with empty remaining cells: `| _text_ | | |`
-
-## Child Reference Row
-
-When a needs-design issue spawns a child design (via `/explore`), a child reference row is inserted between the issue row and its description row. This links readers to the child design doc without importing its implementation details into the parent.
-
-**Format:**
-
-```markdown
-| [#N: <title>](<url>) | None | simple |
-| ^_Child: [DESIGN-<name>.md](<relative-path>)_ | | | |
-| _<description text>_ | | |
-```
-
-The `^` prefix distinguishes child reference rows from description rows. Only issues with a tracking label (`tracks-design` or `tracks-plan`) and correspondingly the `tracksDesign` or `tracksPlan` Mermaid class may have a child reference row. This invariant is bidirectional: tracking-class nodes must have a child reference row, and nodes without a tracking class must not have one. Projects may enforce this in CI.
-
-**Strikethrough:** When the issue completes, strike through all three rows -- the issue row, the child reference row, and the description row:
-
-```markdown
-| ~~[#N: <title>](<url>)~~ | ~~None~~ | ~~simple~~ |
-| ~~^_Child: [DESIGN-<name>.md](<relative-path>)_~~ | | | |
-| ~~_<description text>_~~ | | |
-```
-
-## Strikethrough Rules
-
-When an issue is completed (marked `done`), strike through all rows associated with it:
-
-1. **Issue row:** `| ~~[#N: title](url)~~ | ~~deps~~ | ~~complexity~~ |`
-2. **Child reference row** (if present): `| ~~^_Child: [DESIGN-name.md](path)_~~ | | | |`
-3. **Description row:** `| ~~_description text_~~ | | |`
-
-All row types (when present) must be struck through together. If the issue row is struck through, the child reference row and description row must also be struck through.
-
-## Dependency Graph
-
-### Mermaid Syntax Rules (Critical)
-
-These rules prevent common Mermaid rendering failures:
-
-**1. Use `graph`, not `flowchart`:**
-```
-graph TD    # Correct
-flowchart TD  # Wrong - less portable
-```
-
-**2. Direction:**
-- `LR` (left-right): Preferred for simple diagrams with few sequential levels
-- `TD` (top-down): Use when dependencies span 5+ sequential levels (horizontal becomes unreadable)
-
-**3. Subgraphs for phases (optional):**
-```
-subgraph Phase1["Phase 1: Name"]
-    I488["#488: Title"]
-    I489["#489: Title"]
-end
-```
-
-**4. Edges MUST be outside subgraphs:**
-```
-# Wrong - edges inside subgraph (will not render)
-subgraph Phase1
-    A --> B
-end
-
-# Correct - edges after all subgraphs
-subgraph Phase1
-    A["..."]
-    B["..."]
-end
-A --> B
-```
-
-**5. Class definitions at the end:**
-```
-graph TD
-    # ... nodes and edges ...
-
-    classDef done fill:#c8e6c9
-    classDef ready fill:#bbdefb
-    classDef blocked fill:#fff9c4
-    classDef needsDesign fill:#e1bee7
-    classDef needsPrd fill:#b3e5fc
-    classDef needsSpike fill:#ffcdd2
-    classDef needsDecision fill:#d1c4e9
-    classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
-    classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
-
-    class I488 ready
-    class I489,I490 blocked
-```
-
-### Status Classes (fixed, never change)
-
-| Status | Class | Fill Color | Meaning |
-|--------|-------|------------|---------|
-| done | `done` | `#c8e6c9` (light green) | Issue is closed |
-| ready | `ready` | `#bbdefb` (light blue) | Open, no blocking dependencies |
-| blocked | `blocked` | `#fff9c4` (light yellow) | Open, has open blockers |
-| needs-design | `needsDesign` | `#e1bee7` (light purple) | Future work, not yet designed |
-| needs-prd | `needsPrd` | `#b3e5fc` (light blue) | Future work, needs requirements definition |
-| needs-spike | `needsSpike` | `#ffcdd2` (light red) | Future work, needs feasibility investigation |
-| needs-decision | `needsDecision` | `#d1c4e9` (light indigo) | Future work, needs architectural choice |
-| tracks-design | `tracksDesign` | `#FFE0B2` (light orange), stroke `#F57C00` | Has spawned a child design in progress |
-| tracks-plan | `tracksPlan` | `#FFE0B2` (light orange), stroke `#F57C00` | PLAN created, implementation underway |
-
-### Node Format
-
-- Node ID: `I<issue-number>` (e.g., `I417`)
-- Node label: `#<N>: <short-title>` (max 40 characters)
-- Quotes around labels: Always use `["..."]`
-
-**Node Label Rules:**
-- Maximum 40 characters total
-- Truncate at last word boundary, add `...` if too long
-- Replace `[` `]` with `(` `)`, remove backticks
-- Example: `I417["#417: Add structured logging..."]`
-
-### Class Assignment
-
-Use `class` directive (not inline `:::`):
-```
-# Wrong - inline syntax less maintainable
-I488:::ready --> I489:::blocked
-
-# Correct - class directive at end
-I488 --> I489
-class I488 ready
-class I489 blocked
-```
-
-Group multiple nodes with same status:
-```
-class I489,I490,I491 blocked
-```
-
-### Initial Status (when /plan creates)
-
-- Issues with no dependencies: `ready`
-- Issues with dependencies: `blocked`
-- Future work issues needing upstream artifacts: `needsDesign`, `needsPrd`, `needsSpike`, or `needsDecision`
-- Issues with accepted child designs: `tracksDesign` or `tracksPlan`
-- No issues start as `done`
-
-### Status Updates (when /work-on completes an issue)
-
-- Completed issue changes to `done`
-- Downstream issues recalculated: if all blockers are done, change to `ready`
-
-### Table Row Updates (when issue completes)
-
-When an issue is marked as done:
-1. Strike through the issue row: `| ~~[#N: title](url)~~ | ~~deps~~ | ~~complexity~~ |`
-2. Strike through the child reference row (if present): `| ~~^_Child: [DESIGN-name.md](path)_~~ | | | |`
-3. Strike through the description row: `| ~~_description text_~~ | | |`
-
-The description remains readable (just with strikethrough styling) to preserve the build narrative. See "Strikethrough Rules" above for full details.
-
-### Legend
-
-Include a legend line after the diagram:
-
-```markdown
-**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan
-```
-
-### Child Reference Row Invariant
-
-`tracksDesign` and `tracksPlan` nodes must have a corresponding child reference row in the Implementation Issues table. Nodes without a tracking class must not have a child reference row.
-
 ## Section Placement (Legacy Context)
 
-In design docs that predate the PLAN artifact, the Implementation Issues section was inserted directly into the design doc body, immediately after Status. In the PLAN artifact, this content lives in its own document, so placement is governed by the Required Sections order above.
+In design docs that predate the PLAN artifact, the Implementation
+Issues section was inserted directly into the design doc body,
+immediately after Status. In the PLAN artifact, this content lives in
+its own document, so placement is governed by the Required Sections
+order above.
 
 ## Examples
 
-See `plan-doc-examples.md` for complete examples of multi-pr, completed issues,
-inline implementation, and roadmap modes.
+See `plan-doc-examples.md` for complete examples of multi-pr,
+completed issues, inline implementation, and roadmap modes.

--- a/skills/roadmap/references/roadmap-format.md
+++ b/skills/roadmap/references/roadmap-format.md
@@ -1,10 +1,14 @@
 # Roadmap Document Format Reference
 
-Structure, lifecycle, validation rules, and quality guidance for Roadmap
-documents.
+Structure, lifecycle, validation rules, and quality guidance for
+Roadmap documents. The roadmap profile of the shared issues-table
+framework owns the Implementation Issues shape; the shared
+dependency-diagram convention owns the mermaid graph. This file
+carries the roadmap-specific deltas, lifecycle, and quality guidance.
 
 ## Table of Contents
 
+- [Shared References](#shared-references)
 - [Frontmatter](#frontmatter)
 - [Required Sections](#required-sections)
 - [Reserved Sections](#reserved-sections)
@@ -13,12 +17,38 @@ documents.
 - [Validation Rules](#validation-rules)
 - [Quality Guidance](#quality-guidance)
 
+## Shared References
+
+Both the issues-table format (roadmap profile) and the
+dependency-diagram convention live at the plugin root and are
+consumed by both the roadmap and plan workflows:
+
+- `${CLAUDE_PLUGIN_ROOT}/references/issues-table.md` -- the shared
+  issues-table framework. The roadmap profile keys on features with
+  the `Feature | Issues | Dependencies | Status` shape, the `Issues`
+  fan-out column listing the issue links the feature decomposed into,
+  and the migration rules for the divergent committed shapes
+  (`Feature | Status | Downstream Artifact` and `Issue | Phase |
+  Dependencies | Label`). This reference owns table shape, description
+  rows, and strikethrough rules.
+
+- `${CLAUDE_PLUGIN_ROOT}/references/dependency-diagram.md` -- the
+  shared dependency-diagram convention. Owns the mermaid syntax
+  rules, the fixed status-class palette, node format, class
+  assignment, initial status, status updates, and legend.
+
+- `${CLAUDE_PLUGIN_ROOT}/references/workflow-principles.md` -- the
+  five principles both workflows derive from. A roadmap is multi-pr
+  because each feature delivers observable incremental value (P1),
+  not because "the input is a roadmap."
+
 ## Frontmatter
 
 Every roadmap begins with YAML frontmatter:
 
 ```yaml
 ---
+schema: roadmap/v1
 status: Draft
 theme: |
   1 paragraph describing the overarching theme or initiative this
@@ -31,36 +61,37 @@ upstream: docs/visions/VISION-<name>.md  # optional
 ---
 ```
 
-Required fields: `status`, `theme`, `scope`. Optional: `upstream` (path to the
-VISION document that this roadmap traces to, when one exists). Each field should
-be 1 paragraph using YAML literal block scalars (`|`).
+Required fields: `schema`, `status`, `theme`, `scope`. Optional:
+`upstream` (path to the VISION document that this roadmap traces to,
+when one exists). Each field other than `schema` should be 1
+paragraph using YAML literal block scalars (`|`).
 
-The `upstream` field links the roadmap to the strategic artifact that motivated
-it. When present, it points to a VISION document (the natural parent in the
-traceability chain). Roadmaps that emerge from exploration without a formal
-VISION omit this field. For cross-repo upstream references and the
-visibility-direction rules, see
+The `upstream` field links the roadmap to the strategic artifact that
+motivated it. When present, it points to a VISION document (the
+natural parent in the traceability chain). Roadmaps that emerge from
+exploration without a formal VISION omit this field. For cross-repo
+upstream references and the visibility-direction rules, see
 `${CLAUDE_PLUGIN_ROOT}/references/cross-repo-references.md`.
 
-Frontmatter status must match the Status section in the body -- agent workflows
-parse frontmatter to determine lifecycle state, so divergence causes silent
-errors.
+Frontmatter status must match the Status section in the body --
+agent workflows parse frontmatter to determine lifecycle state, so
+divergence causes silent errors.
 
 ## Required Sections
 
 Every roadmap has these sections in order:
 
 1. **Status** -- current lifecycle state
-2. **Theme** -- what initiative this roadmap coordinates and why sequencing
-   matters
+2. **Theme** -- what initiative this roadmap coordinates and why
+   sequencing matters
 3. **Features** -- ordered list of features with names, descriptions,
-   dependencies, and status. Each feature should reference its downstream
-   artifact (PRD, design doc, or plan) when one exists.
-4. **Sequencing Rationale** -- why features are ordered this way. What
-   constraints drive the ordering: technical dependencies, user value delivery,
-   risk reduction?
-5. **Progress** -- current state of the roadmap. Which features are done, in
-   progress, or not started. Updated as work progresses.
+   dependencies, and status. Each feature should reference its
+   downstream artifact (PRD, design doc, or plan) when one exists.
+4. **Sequencing Rationale** -- why features are ordered this way.
+   What constraints drive the ordering: technical dependencies, user
+   value delivery, risk reduction?
+5. **Progress** -- current state of the roadmap. Which features are
+   done, in progress, or not started. Updated as work progresses.
 
 ### Per-Feature Format
 
@@ -78,30 +109,37 @@ Each feature in the Features section follows this structure:
 **Status:** Not started
 ```
 
-The `Needs` annotation is optional. Features without it are treated as ready
-for direct implementation. When present, it determines which `needs-*` label
-gets applied during issue creation.
+The `Needs` annotation is optional. Features without it are treated
+as ready for direct implementation. When present, it determines which
+`needs-*` label gets applied during issue creation.
 
 ## Reserved Sections
 
-Two sections follow Progress. They're structurally part of the roadmap but
-are NOT populated by `/roadmap` -- they exist as empty placeholders at creation
-time and are filled later by `/plan` during decomposition.
+Two sections follow Progress. They're structurally part of the
+roadmap but are NOT populated by `/roadmap` -- they exist as empty
+placeholders at creation time and are filled later by `/plan` during
+decomposition.
 
-6. **Implementation Issues** -- table mapping features to GitHub issues.
-   Empty at creation.
+6. **Implementation Issues** -- table mapping features to GitHub
+   issues. Empty at creation. The canonical roadmap profile shape
+   (`Feature | Issues | Dependencies | Status`), description rows, and
+   strikethrough rules are defined in
+   `${CLAUDE_PLUGIN_ROOT}/references/issues-table.md`.
 
 ```markdown
 ## Implementation Issues
 
 <!-- Populated by /plan during decomposition. Do not fill manually. -->
 
-| Feature | Issues | Status |
-|---------|--------|--------|
+| Feature | Issues | Dependencies | Status |
+|---------|--------|--------------|--------|
 ```
 
-7. **Dependency Graph** -- Mermaid diagram showing feature dependencies and
-   issue relationships. Empty at creation.
+7. **Dependency Graph** -- Mermaid diagram showing feature
+   dependencies and issue relationships. Empty at creation. Mermaid
+   syntax rules, the fixed status-class palette, node format, and
+   legend are defined in
+   `${CLAUDE_PLUGIN_ROOT}/references/dependency-diagram.md`.
 
 ```markdown
 ## Dependency Graph
@@ -113,24 +151,26 @@ graph TD
 ```
 ```
 
-These sections must appear in every roadmap file, even when empty. Their
-presence signals that the roadmap is structurally complete and ready for
-downstream planning workflows.
+These sections must appear in every roadmap file, even when empty.
+Their presence signals that the roadmap is structurally complete and
+ready for downstream planning workflows.
 
 ## Content Boundaries
 
 A roadmap is NOT:
 
-- **A PRD**: PRDs define requirements for a single feature. Roadmaps sequence
-  multiple features. If you're writing detailed requirements, that's a PRD.
-- **A plan**: Plans break a single artifact into implementable issues. Roadmaps
-  operate one level above, coordinating across multiple PRDs or design docs.
-- **A project timeline**: Roadmaps don't include dates or time estimates. They
-  capture ordering and dependencies, not schedules.
+- **A PRD**: PRDs define requirements for a single feature. Roadmaps
+  sequence multiple features. If you're writing detailed
+  requirements, that's a PRD.
+- **A plan**: Plans break a single artifact into implementable
+  issues. Roadmaps operate one level above, coordinating across
+  multiple PRDs or design docs.
+- **A project timeline**: Roadmaps don't include dates or time
+  estimates. They capture ordering and dependencies, not schedules.
 
-If you're defining requirements for one feature, write a PRD. If you're breaking
-one design into issues, write a plan. If you're sequencing multiple features
-with dependencies, write a roadmap.
+If you're defining requirements for one feature, write a PRD. If
+you're breaking one design into issues, write a plan. If you're
+sequencing multiple features with dependencies, write a roadmap.
 
 ## Lifecycle
 
@@ -148,57 +188,69 @@ Draft --> Active --> Done
 
 ### Transition Rules
 
-- **Draft -> Active**: Feature list is complete and sequencing is justified.
-  Human must explicitly approve.
-- **Active -> Done**: Every feature has reached a terminal state (delivered or
-  explicitly dropped with rationale documented).
-- **Done -> any**: Forbidden. A completed roadmap is a historical record. Create
-  a new roadmap for follow-on work.
-- **Active -> Draft**: Forbidden. If the feature list needs significant revision,
-  create a new roadmap version.
+- **Draft -> Active**: Feature list is complete and sequencing is
+  justified. Human must explicitly approve.
+- **Active -> Done**: Every feature has reached a terminal state
+  (delivered or explicitly dropped with rationale documented).
+- **Done -> any**: Forbidden. A completed roadmap is a historical
+  record. Create a new roadmap for follow-on work.
+- **Active -> Draft**: Forbidden. If the feature list needs
+  significant revision, create a new roadmap version.
 
 ### Edit Rules
 
 Active roadmaps can update the Progress section and reserved sections
-(Implementation Issues, Dependency Graph) freely. Changes to the Features list
-or Sequencing Rationale require creating a new roadmap -- those sections are
-locked once the roadmap leaves Draft.
+(Implementation Issues, Dependency Graph) freely. Changes to the
+Features list or Sequencing Rationale require creating a new roadmap
+-- those sections are locked once the roadmap leaves Draft.
 
 ## File Location
 
-Roadmaps live at `docs/roadmaps/ROADMAP-<name>.md` (kebab-case). No directory
-movement based on status -- all roadmaps stay in `docs/roadmaps/` regardless
-of lifecycle state.
+Roadmaps live at `docs/roadmaps/ROADMAP-<name>.md` (kebab-case). No
+directory movement based on status -- all roadmaps stay in
+`docs/roadmaps/` regardless of lifecycle state.
 
 ## Validation Rules
 
 ### During drafting
 
-- Frontmatter has `status`, `theme`, `scope` fields
+- Frontmatter has `schema`, `status`, `theme`, `scope` fields
 - Frontmatter status matches Status section in body
 - All 5 required sections present and in order
 - Both reserved sections present (may be empty)
 - Status is "Draft"
-- At least 2 features listed (single-feature work doesn't need a roadmap)
+- At least 2 features listed (single-feature work doesn't need a
+  roadmap)
 
 ### When referenced by downstream workflows
 
 - Status must be "Active" to serve as upstream context
-- If status is "Draft": inform the referencing workflow that the roadmap
-  isn't yet approved
+- If status is "Draft": inform the referencing workflow that the
+  roadmap isn't yet approved
 
 ### Status consistency
 
 - Frontmatter `status` and body Status section must always match
-- Features marked as done in the Features section should be reflected in Progress
-- Reserved sections should only contain content if populated by `/plan`
+- Features marked as done in the Features section should be
+  reflected in Progress
+- Reserved sections should only contain content if populated by
+  `/plan`
+
+### Validation enforcement
+
+The Go validator runs FC05 (issues-table schema conformance) and FC06
+(cross-reference existence) on roadmap docs. See
+`${CLAUDE_PLUGIN_ROOT}/references/issues-table.md` for the canonical
+roadmap profile contract those checks enforce.
 
 ## Quality Guidance
 
 ### Theme
 
-- Identifies a coherent capability area, not a grab-bag of unrelated work
-- Explains why coordination matters (shared infrastructure, user-facing story)
+- Identifies a coherent capability area, not a grab-bag of unrelated
+  work
+- Explains why coordination matters (shared infrastructure,
+  user-facing story)
 - Scoped to one initiative -- don't combine unrelated streams
 
 ### Features
@@ -211,8 +263,8 @@ of lifecycle state.
 ### Sequencing Rationale
 
 - Explains ordering constraints, not just lists the order
-- Distinguishes hard dependencies (technical blockers) from soft preferences
-  (nice-to-have ordering)
+- Distinguishes hard dependencies (technical blockers) from soft
+  preferences (nice-to-have ordering)
 - Acknowledges where parallel execution is possible
 
 ### Progress
@@ -225,6 +277,8 @@ of lifecycle state.
 
 - Too granular: tracking individual issues instead of features
 - Too broad: mixing unrelated initiatives into one roadmap
-- Missing rationale: listing features without explaining why this order
+- Missing rationale: listing features without explaining why this
+  order
 - Stale progress: not updating the Progress section as work completes
-- Editing reserved sections manually instead of letting /plan populate them
+- Editing reserved sections manually instead of letting /plan
+  populate them


### PR DESCRIPTION
Standardizes shirabe's `/roadmap` and `/plan` workflows around shared, define-once conventions, and adds the first content-level validation for issues tables. Three pieces of work ship together so that error-level checks land at the same time as the migrated corpus that satisfies them.

**Shared references at the plugin root.** Three new references both skills consume via `${CLAUDE_PLUGIN_ROOT}`:

- `references/workflow-principles.md` -- the five principles (usable-value, lowest-ceremony, decisions-need-a-durable-home, one-canonical-format, strictness-tracks-blast-radius) that both workflows derive from, each one-line plus the rules it governs.
- `references/issues-table.md` -- the one issues-table framework with shared core (key + Dependencies + Status), shared rendering (italic description row, strikethrough-on-done), the plan profile (issue-keyed with Complexity and child reference row), the roadmap profile (feature-keyed with the Issues fan-out), and the migration rules for the legacy `Title` plan form and the divergent committed roadmap shapes.
- `references/dependency-diagram.md` -- the diagram convention moved verbatim out of `plan-doc-structure.md` (graph syntax rules, the fixed status-class palette, node format, class assignment, legend).

The two skill references (`skills/plan/references/quality/plan-doc-structure.md` and `skills/roadmap/references/roadmap-format.md`) are trimmed to cite the shared references and keep only their profile-specific deltas and lifecycle content.

**Markdown table parser + two error-level content checks.** A new `internal/validate/table.go` with `parseIssuesTable(doc Doc) (Table, bool)` parses the issues table under the Implementation Issues section. The parser strips `~~..~~` before classifying so done rows parse the same way as open ones, and is total over arbitrary input (no panics on ragged rows, missing separators, or unterminated sections). Two error-level checks consume it:

- `checkFC05` (R6 schema conformance) selects the profile from the doc's schema and compares the table header against the canonical column contract. The legacy `Issue | Title | Dependencies | Complexity` plan shape emits a migration-hint message pointing the author at the canonical three-column shape.
- `checkFC06` (R7 cross-reference existence) verifies every value in a Dependencies cell names an entity-row key that exists in the same table. Cross-repo references (`owner/repo#N`) are treated as non-local and skipped.

Both checks dispatch in the existing `Plan` arm of `ValidateFile` and a new `Roadmap` arm. The first content-validation pass adds no second binary and exactly one parser (R19).

**Committed corpus migrated to the canonical profiles.** The two committed roadmaps with divergent table shapes are migrated in the same PR so error-level FC05/FC06 never see an unmigrated corpus:

- `ROADMAP-strategic-pipeline.md`: divergent `Feature | Status | Downstream Artifact` table (under `## Progress`) is replaced by a canonical roadmap-profile table in a new `## Implementation Issues` section. The `Downstream Artifact` column is dropped (per-feature body sections already cite the artifacts). An empty `## Dependency Graph` section is added to satisfy the required-sections contract.
- `ROADMAP-koto-adoption.md`: divergent `Issue | Phase | Dependencies | Label` table is migrated to feature-keyed canonical shape; the Phase column is dropped (phase grouping already lives in Sequencing Rationale prose); the Label column folds into Status. The inline mermaid that lived under Implementation Issues is promoted into a new `## Dependency Graph` section. Cross-repo refs (`tsukumogami/koto#N`) are preserved verbatim.

Both roadmaps now declare `schema: roadmap/v1` so the SCHEMA gate engages and FC05/FC06 actually run.

After this PR: `shirabe validate --visibility=public` passes on every `docs/roadmaps/*.md` and `docs/plans/*.md`.

---

## What each issue contributed

- **#111** -- the three plugin-root shared references and the two trimmed skill references. Foundation issue; the validator code in #112 is the enforcement twin of these references.
- **#112** -- `internal/validate/table.go` with `parseIssuesTable` + `Table`, plus error-level `checkFC05` (schema) and `checkFC06` (cross-reference) wired into the Plan arm and a new Roadmap arm of `ValidateFile`. Table-driven tests cover the canonical plan and roadmap profiles, strikethrough classification, child reference rows, the legacy Title plan migration hint, both divergent committed roadmap shapes, a dangling cross-reference, cross-repo reference skip, and defensive parsing (no panics on ragged, unterminated, or empty input).
- **#113** -- the corpus migration. Both committed roadmaps now on the canonical profile; full repo corpus passes validation.

## PLAN doc tracking

The Implementation Issues table in `docs/plans/PLAN-roadmap-plan-standardization.md` is updated: the entity and description rows for **#111, #112, #113** are now struck through per the canonical strikethrough-on-done rule. The dependency-diagram class assignments are intentionally not updated in this PR (recalculating downstream readiness would touch the rows of issues outside this slice; that is a separate PM update).

## Local decisions recorded

`wip/slice-a_decisions.md` captures three decisions made while implementing the slice (each settle-able locally from PRD/design plus current code):

- **SA-1**: the corpus migration adds `schema: roadmap/v1` frontmatter to the two divergent roadmaps (they were skipping FC checks via the SCHEMA-notice gate, so FC05 could not fail their divergent shapes without this).
- **SA-2**: for `ROADMAP-koto-adoption.md`, the `Label = needs-*` column maps to Status (the canonical lifecycle marker); the `Downstream Artifact` column in `ROADMAP-strategic-pipeline.md` is dropped during migration.
- **SA-3**: `ROADMAP-strategic-pipeline.md` gets the two reserved sections it was missing (Implementation Issues, Dependency Graph) as part of the migration; without them, FC04 would fail before FC05 could run, defeating SA-1's purpose.

The `wip/` artifacts are cleaned up before merge per the workspace wip-hygiene rule.

## Verification

```
go build ./...                              # exit 0
go test ./...                               # exit 0
go vet ./...                                # exit 0
gofmt -l (new and edited files)             # clean

shirabe validate --visibility=public
  references                                # skipped (no doc prefix)
  docs/plans/PLAN-roadmap-plan-standardization.md   # exit 0
  docs/roadmaps/ROADMAP-koto-adoption.md            # exit 0
  docs/roadmaps/ROADMAP-strategic-pipeline.md       # exit 0
  (full corpus: every roadmap + plan)               # exit 0
```

Closes #111
Closes #112
Closes #113
