### PR TITLE
fix(ci): add cross-compile target to the pinned toolchain in release-binaries

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -36,10 +36,16 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install Rust toolchain
-        # Reads rust-toolchain.toml and adds the matrix target triple.
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
-        with:
-          targets: ${{ matrix.target }}
+
+      - name: Add cross-compile target
+        # dtolnay/rust-toolchain does not read rust-toolchain.toml, which pins
+        # the channel (1.95.0). Adding the target via the action would attach it
+        # to the wrong toolchain, so the toml-pinned build can't find it
+        # (error E0463: can't find crate for `core`). Run rustup target add in
+        # the repo, where the toml override is active, so the target lands on
+        # the toolchain that actually builds.
+        run: rustup target add ${{ matrix.target }}
 
       - name: Install cross linker (linux arm64)
         if: matrix.os == 'linux' && matrix.arch == 'arm64'


### PR DESCRIPTION
The release matrix in `release-binaries.yml` cross-compiles `shirabe` for linux/darwin x amd64/arm64. The toolchain step used `dtolnay/rust-toolchain@stable` with `targets:`, which installs the stable channel and adds the target triple to it. But `rust-toolchain.toml` pins `1.95.0`, so the build runs under 1.95.0 without the cross-target installed and fails with `error[E0463]: can't find crate for core`. Replace the action's `targets:` input with an explicit `rustup target add ${{ matrix.target }}` step that runs in the repo, where the rust-toolchain.toml override is active, so the target lands on the toolchain that actually builds.

---

## Root cause

`dtolnay/rust-toolchain` does not read `rust-toolchain.toml`; it installs whatever channel its ref names (stable). The `targets:` input therefore attached the cross-target to stable, not to the pinned 1.95.0 toolchain the build uses. This was invisible until now because release workflows only run on a `v*` tag push, so neither PR CI nor the parity suite ever exercised `release-binaries.yml`.

## Verification

This workflow only runs on a tag push, so it can't be exercised by this PR's CI. It will be validated by the re-cut of the `v0.8.0` release once this merges; the first failing run was https://github.com/tsukumogami/shirabe/actions/runs/26724915621 (darwin-amd64, E0463).

Fixes the binary build for the Rust release pipeline.