### PR TITLE
fix(ci): source tsuku env in install-latest so the installed binary resolves

### DIFF
--- a/.github/workflows/validate-tsuku-recipe.yml
+++ b/.github/workflows/validate-tsuku-recipe.yml
@@ -87,4 +87,11 @@ jobs:
         run: tsuku install tsukumogami/shirabe
 
       - name: Confirm shirabe runs
-        run: shirabe --version
+        run: |
+          # Activate tsuku's environment so an installed tool resolves. The env
+          # file puts both ~/.tsuku/bin and ~/.tsuku/tools/current on PATH and
+          # loads the shell init cache; the manual GITHUB_PATH entry above only
+          # covers bin, so the active-version binary under tools/current was not
+          # found in this non-interactive step (command not found, exit 127).
+          source "$HOME/.tsuku/env"
+          shirabe --version


### PR DESCRIPTION
The `install-latest` job installs `shirabe` via tsuku and then runs `shirabe --version`, relying on a manual `echo "$HOME/.tsuku/bin" >> "$GITHUB_PATH"` entry to find it. tsuku resolves an installed tool's active version through `~/.tsuku/tools/current` (and its shell init cache), not just `~/.tsuku/bin`, so that single PATH entry misses the binary and the step failed with `shirabe: command not found` (exit 127). Source `~/.tsuku/env` in the confirm step instead — it adds both `bin` and `tools/current` to `PATH` and loads the init cache, which is tsuku's documented activation.

---

## Context

This check has been red since it was introduced (#92), for two unrelated reasons in sequence:
1. At creation (Go era) the latest release predated the `--version` flag, so install verification failed with `unknown flag: --version`.
2. Now, with v0.8.0 published, `tsuku install tsukumogami/shirabe` succeeds (`shirabe@0.8.0`), but the confirm step couldn't find the binary on PATH.

This PR addresses (2). With it, the job installs the published release and resolves the binary the way tsuku intends. The job remains `continue-on-error` for now.

## Verification

This is a CI workflow change; the fix is exercised by the `install-latest` job itself once it runs against the published v0.8.0 release.