### PR TITLE
docs(plan): sync dependency graph to issues-table status

### DIFF
--- a/docs/plans/PLAN-roadmap-plan-standardization.md
+++ b/docs/plans/PLAN-roadmap-plan-standardization.md
@@ -116,8 +116,9 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I111 ready
-    class I112,I113,I114,I115,I116,I117,I118,I119 blocked
+    class I111,I112,I113,I114,I115 done
+    class I116,I118 ready
+    class I117,I119 blocked
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan


### PR DESCRIPTION
The Implementation Issues table in `docs/plans/PLAN-roadmap-plan-standardization.md` has #111 through #115 struck through, but the Dependency Graph at the bottom of the same doc still carried the original Day-1 class assignments (only `I111` `ready`, every other node `blocked`). That meant the diagram and the table told different stories about the same plan. This PR recomputes the class partition from the edge list and the current done set, so a reader scrolling the doc sees `I111-I115` rendered as `done`, `I116` and `I118` newly `ready` (their last remaining dependency merged), and only `I117` and `I119` still `blocked`.

There's a small irony worth naming in passing: this very plan proposes `FC07` (table/diagram reconciliation), but the check's currently-scoped reconciliation rule covers node-set and edge agreement only, not class-vs-status synchronization, so today this kind of drift can land. That's a known scope decision in the design, not a regression -- this PR just removes the present-tense divergence.

---

### Reviewer context

- Done set was confirmed by `grep -nE '~~\[#11[0-9]:'` against the issues table (#111, #112, #113, #114, #115 struck through).
- Recomputed partition (from edges `I111 -> {I112, I114, I115, I118}`, `I112 -> {I113, I116, I119}`, `I116 -> I117`, `I118 -> I119`):
  - `done`: `I111, I112, I113, I114, I115`
  - `ready`: `I116` (waits on `I112`, done), `I118` (waits on `I111`, done)
  - `blocked`: `I117` (waits on `I116`), `I119` (waits on `I112` and `I118`; `I118` not done)
- `shirabe validate --visibility=public docs/plans/PLAN-roadmap-plan-standardization.md` exits 0.
- Diff touches only the three `class` lines inside the existing Dependency Graph mermaid block; node definitions, edges, `classDef` palette, and legend prose are unchanged.
- No `Closes #N` -- this is housekeeping (table/diagram sync), not an issue completion.
