### PR TITLE
docs(plan): strikethrough fc09 row in parent plan

### DIFF
--- a/docs/plans/PLAN-roadmap-plan-standardization.md
+++ b/docs/plans/PLAN-roadmap-plan-standardization.md
@@ -83,8 +83,8 @@ with the spike-to-reconciliation merge gate as a second independent justificatio
 | ~~_Adds `mermaid.go` and `checkFC07` reconciling the parsed `Table` against the extracted diagram, shipped as a notice via `IsNotice` so an unreconciled committed diagram does not redden CI, with a one-line path to error-level promotion after corpus reconciliation. The final, spike-gated increment._~~ | | |
 | [#152: feat(validate): add fc08 legend-vs-classdef reconciliation as a notice](https://github.com/tsukumogami/shirabe/issues/152) | [#119](https://github.com/tsukumogami/shirabe/issues/119) | testable |
 | _Adds `checkFC08` reconciling the Dependency Graph Legend prose against the diagram's `classDef` declarations and the canonical class palette. Ships as a notice via `is_notice` so unupdated Legends do not redden CI, with a one-line path to error-level promotion after corpus reconciliation. Surfaces the drift surface FC07 explicitly does not cover._ | | |
-| [#153: feat(validate): add fc09 doc-vs-github state reconciliation as a notice](https://github.com/tsukumogami/shirabe/issues/153) | [#119](https://github.com/tsukumogami/shirabe/issues/119) | testable |
-| _Adds `checkFC09` reconciling the doc's claims about issue state (table strikethrough, diagram class assignments) against GitHub's actual issue state plus the current PR's `Closes #N` body lines. First network-dependent check; self-disables offline. Three sub-checks: doc-claims-done vs GH, doc-claims-open vs GH, and PR Closes consistency. The third pillar of consistency alongside FC07's intra-doc and R6's cross-doc checks._ | | |
+| ~~[#153: feat(validate): add fc09 doc-vs-github state reconciliation as a notice](https://github.com/tsukumogami/shirabe/issues/153)~~ | ~~[#119](https://github.com/tsukumogami/shirabe/issues/119)~~ | ~~testable~~ |
+| ~~_Adds `checkFC09` reconciling the doc's claims about issue state (table strikethrough, diagram class assignments) against GitHub's actual issue state plus the current PR's `Closes #N` body lines. First network-dependent check; self-disables offline. Three sub-checks: doc-claims-done vs GH, doc-claims-open vs GH, and PR Closes consistency. The third pillar of consistency alongside FC07's intra-doc and R6's cross-doc checks._~~ | | |
 | [#154: feat(validate): add fc10 single-pr plan validation (issue outlines + execution-mode-aware sections)](https://github.com/tsukumogami/shirabe/issues/154) | [#119](https://github.com/tsukumogami/shirabe/issues/119) | testable |
 | _Adds `checkFC10` and refactors `FormatSpec` to be `execution_mode`-aware so single-pr plans validate against their own structural contract: required sections branch on mode, Issue Outlines get structural enforcement, outline-to-outline deps resolve locally, issue_count matches outline count, and populated-wrong-section is flagged. Closes the gap where single-pr plans pass validation vacuously._ | | |
 
@@ -128,8 +128,8 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I111,I112,I113,I114,I115,I118,I119 done
-    class I116,I152,I153,I154 ready
+    class I111,I112,I113,I114,I115,I118,I119,I153 done
+    class I116,I152,I154 ready
     class I117 blocked
 ```
 


### PR DESCRIPTION
Bookkeeping after PR #167 merged. The parent PLAN at \`docs/plans/PLAN-roadmap-plan-standardization.md\` tracked #153 (the FC09 work) as a row in its Implementation Issues table and as the \`I153\` node in its Dependency Graph. With #167 merged, #153 is closed; the parent PLAN's view of that row was stale. This PR applies the strikethrough-on-done convention to the row and its italic description, and recomputes the diagram class assignment to move \`I153\` from the \`ready\` set to the \`done\` set.

The class-assignment update closes a self-meta-irony: with FC09 now live as a notice on every plan and roadmap doc the validator touches, leaving \`I153\` classed \`ready\` would fire FC09's Sub-check B notice against the parent PLAN itself the next time anything touched the file (\`row claims open with class ready; GitHub observes issue #153 closed (expected: change class from ready to done and apply strikethrough to the row)\`). The strikethrough on the table row is the matching transition on the table side.

---

## What changed

\`docs/plans/PLAN-roadmap-plan-standardization.md\`:

- The #153 entity row and its description row now carry strikethrough (\`~~...~~\` across the title link, the dependency cell, and the complexity cell; \`~~_..._~~\` on the italic description).
- The mermaid class assignment line moved \`I153\` from \`class I116,I152,I153,I154 ready\` to \`class I111,I112,I113,I114,I115,I118,I119,I153 done\`.

## Verification

\`\`\`
./target/release/shirabe validate --visibility=public docs/plans/PLAN-roadmap-plan-standardization.md
\`\`\`

Exits 0. The only output is the expected offline-context skip notice (\`[FC09] Sub-check C skipped: no PR context\`); no FC09 defect notices fire because \`I153\` now reflects GitHub state correctly.

## Milestone tracking

Milestone #6 remaining after this lands: four open issues (#116, #117 blocked-on-116, #152, #154). Three are unblocked. The two reconciliation-check follow-ups (#152 FC08, #154 FC10) are the natural next-up.