### PR TITLE
docs(plan): strikethrough fc08 row and reconcile legend in parent plan

### DIFF
--- a/docs/plans/PLAN-roadmap-plan-standardization.md
+++ b/docs/plans/PLAN-roadmap-plan-standardization.md
@@ -81,8 +81,8 @@ with the spike-to-reconciliation merge gate as a second independent justificatio
 | ~~_Writes the spike investigating the mermaid graph subset the corpus uses, a line-oriented extraction approach with no external dependency, and the reconciliation strictness. The explicit upstream that gates the reconciliation increment._~~ | | |
 | ~~[#119: feat(validate): add mermaid extractor and checkFC07 table-diagram reconciliation as a notice](https://github.com/tsukumogami/shirabe/issues/119)~~ | ~~[#112](https://github.com/tsukumogami/shirabe/issues/112), [#118](https://github.com/tsukumogami/shirabe/issues/118)~~ | ~~testable~~ |
 | ~~_Adds `mermaid.go` and `checkFC07` reconciling the parsed `Table` against the extracted diagram, shipped as a notice via `IsNotice` so an unreconciled committed diagram does not redden CI, with a one-line path to error-level promotion after corpus reconciliation. The final, spike-gated increment._~~ | | |
-| [#152: feat(validate): add fc08 legend-vs-classdef reconciliation as a notice](https://github.com/tsukumogami/shirabe/issues/152) | [#119](https://github.com/tsukumogami/shirabe/issues/119) | testable |
-| _Adds `checkFC08` reconciling the Dependency Graph Legend prose against the diagram's `classDef` declarations and the canonical class palette. Ships as a notice via `is_notice` so unupdated Legends do not redden CI, with a one-line path to error-level promotion after corpus reconciliation. Surfaces the drift surface FC07 explicitly does not cover._ | | |
+| ~~[#152: feat(validate): add fc08 legend-vs-classdef reconciliation as a notice](https://github.com/tsukumogami/shirabe/issues/152)~~ | ~~[#119](https://github.com/tsukumogami/shirabe/issues/119)~~ | ~~testable~~ |
+| ~~_Adds `checkFC08` reconciling the Dependency Graph Legend prose against the diagram's `classDef` declarations and the canonical class palette. Ships as a notice via `is_notice` so unupdated Legends do not redden CI, with a one-line path to error-level promotion after corpus reconciliation. Surfaces the drift surface FC07 explicitly does not cover._~~ | | |
 | ~~[#153: feat(validate): add fc09 doc-vs-github state reconciliation as a notice](https://github.com/tsukumogami/shirabe/issues/153)~~ | ~~[#119](https://github.com/tsukumogami/shirabe/issues/119)~~ | ~~testable~~ |
 | ~~_Adds `checkFC09` reconciling the doc's claims about issue state (table strikethrough, diagram class assignments) against GitHub's actual issue state plus the current PR's `Closes #N` body lines. First network-dependent check; self-disables offline. Three sub-checks: doc-claims-done vs GH, doc-claims-open vs GH, and PR Closes consistency. The third pillar of consistency alongside FC07's intra-doc and R6's cross-doc checks._~~ | | |
 | [#154: feat(validate): add fc10 single-pr plan validation (issue outlines + execution-mode-aware sections)](https://github.com/tsukumogami/shirabe/issues/154) | [#119](https://github.com/tsukumogami/shirabe/issues/119) | testable |
@@ -128,12 +128,12 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I111,I112,I113,I114,I115,I118,I119,I153 done
-    class I116,I152,I154 ready
+    class I111,I112,I113,I114,I115,I118,I119,I152,I153 done
+    class I116,I154 ready
     class I117 blocked
 ```
 
-**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan
+**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needsDesign, Light blue = needsPrd, Pink = needsSpike, Lilac = needsDecision, Orange = tracksDesign, Orange = tracksPlan
 
 ## Implementation Sequence
 


### PR DESCRIPTION
Bookkeeping after PR #169 merged. Two adjacent corpus updates folded into one PR because both flow from the just-landed FC08 check and both touch the same file.

First, the parent PLAN's Implementation Issues row for #152 (the FC08 work) carried no strikethrough. Applies the conventional strikethrough-on-done shape across the entity row, the italic description row, and the dependency cell; moves the \`I152\` node from the \`ready\` class to the \`done\` class in the diagram assignment line. Same pattern PR #168 used for #153 after PR #167 merged.

Second, the parent PLAN's Legend prose disagreed with the diagram's classDef declarations along the exact two axes FC08 was designed to surface: three pipeline-stage classes (\`needsDecision\`, \`needsPrd\`, \`needsSpike\`) were declared in the diagram but not named in the Legend, and three other names (\`needs-design\`, \`tracks-design\`, \`tracks-plan\`) appeared in the Legend in hyphenated form while the diagram used the camelCase form. Six FC08 notices fired on the parent PLAN against the very check that had just shipped. The Legend now enumerates every classDef name in the canonical camelCase form, with color hints preserved for readers. Validator runs clean on the updated PLAN: zero FC08 notices, and the only output is the unchanged offline-context FC09 Sub-check C skip notice.

The class-assignment update closes a second self-meta-irony alongside the Legend fix: with FC09 now live, leaving \`I152\` classed \`ready\` would have fired Sub-check B (\`claims open with class ready; GitHub observes issue #152 closed\`) on every subsequent PR that touched the file. The strikethrough on the table side is the matching transition on the row.

---

## What changed

\`docs/plans/PLAN-roadmap-plan-standardization.md\`:

- The #152 entity row and its description row carry strikethrough.
- The mermaid class assignment line moves \`I152\` from \`class I116,I152,I154 ready\` to \`class I111,I112,I113,I114,I115,I118,I119,I152,I153 done\`.
- The Legend line is rewritten to name every \`classDef\` declaration in canonical camelCase: \`Green = done, Blue = ready, Yellow = blocked, Purple = needsDesign, Light blue = needsPrd, Pink = needsSpike, Lilac = needsDecision, Orange = tracksDesign, Orange = tracksPlan\`.

## Verification

\`\`\`
./target/release/shirabe validate --visibility=public docs/plans/PLAN-roadmap-plan-standardization.md
\`\`\`

Exits 0. The only output is the expected offline-context skip notice (\`[FC09] Sub-check C skipped: no PR context\`); zero FC08 notices, zero FC09 defect notices.

\`cargo test\` clean: 28/28 parity tests pass. The parity test uses a frozen snapshot of the parent PLAN at \`crates/shirabe/tests/fixtures/golden/corpus/real/PLAN-roadmap-plan-standardization.md\`, so the live-file edits in this PR do not perturb the parity baseline. The snapshotted FC08 expectations remain accurate against the frozen snapshot's older Legend.

## Milestone tracking

After this lands, milestone #6 has three open issues: #116 (lifecycle mode), #117 (blocked on #116), and #154 (FC10 single-pr plan validation). 10/12 of milestone #6 complete.