### PR TITLE
docs(plan): triage work-on-friction-fixes — drop two obsoleted issues

### DIFF
--- a/docs/plans/PLAN-work-on-friction-fixes.md
+++ b/docs/plans/PLAN-work-on-friction-fixes.md
@@ -3,7 +3,7 @@ schema: plan/v1
 status: Active
 execution_mode: multi-pr
 milestone: "Work-on Friction Fixes"
-issue_count: 8
+issue_count: 6
 ---
 
 # PLAN: Work-on Friction Fixes
@@ -14,18 +14,29 @@ Active
 
 Issues created and tracked under the
 [Work-on Friction Fixes](https://github.com/tsukumogami/shirabe/milestone/4)
-milestone (#79 through #86). The PLAN closes when each design (#79,
-#80, #81, #82, #83, #84, #85) reaches Accepted and its downstream
-implementation plan reaches Done, plus #86 (eval re-run) is closed.
+milestone. The PLAN closes when each remaining design (#79, #80, #81,
+#82, #84, #85) reaches Accepted and its downstream implementation
+plan reaches Done.
+
+**Triage update (2026-06)**: two of the original eight issues were
+closed during a triage pass after the standardization milestone
+landed. #83 (multi-issue bundling) was superseded by plan-backed
+mode (`SHARED_BRANCH` / `setup_plan_backed` / `pr_status: shared`)
+that arrived through the cascade-refactor work. #86 (re-run evals
+after `CLAUDE_PLUGIN_ROOT` change) was obsoleted by intervening CI
+runs across the standardization PRs; no assertion regressions
+surfaced and the verification window is past. The remaining six
+issues stay open; #81 and #85 carry status-update comments
+indicating partial address. The `issue_count` and the table /
+diagram below drop the two closed issues.
 
 ## Scope Summary
 
-Eight open items from a triage of `/work-on` friction observations
-that remain after the initial skill-hardening PR. Seven are design
-questions (#79, #80, #81, #82, #83, #84, #85) that each warrant a
+Six remaining items from a triage of `/work-on` friction observations
+that remain after the initial skill-hardening PR. All six are design
+questions (#79, #80, #81, #82, #84, #85) that each warrant a
 standalone DESIGN doc because the right shape of the fix is
-contested; one is a verification task (#86) that confirms a recent
-env-var change doesn't regress any work-on eval assertion.
+contested.
 
 The seven ready-to-implement items from the same triage landed
 directly in the PR that introduced this PLAN, along with two further
@@ -36,18 +47,15 @@ are not in the outline list.
 
 ## Decomposition Strategy
 
-**Horizontal, mixed issue kinds.** Each item maps 1:1 to a GitHub
-issue. The seven design issues (#79, #80, #81, #82, #83, #84, #85)
-are `docs(design): …` planning issues carrying `needs-design`; they
-produce a DESIGN doc and spawn their own downstream implementation
-plan via `/plan`. #86 is a verification task (complexity `simple`,
-no design step). All eight share the `Work-on Friction Fixes`
-milestone.
+**Horizontal, design-only.** Each item maps 1:1 to a GitHub
+issue. All six are `docs(design): …` planning issues carrying
+`needs-design`; they produce a DESIGN doc and spawn their own
+downstream implementation plan via `/plan`. All six share the
+`Work-on Friction Fixes` milestone.
 
 Dependencies are minimal. Only #84 (context findings cache) waits on
 #79 (remote DESIGN doc resolution): the cache key scheme can't be
-chosen without first deciding how the resolver finds documents. #86
-is independent and can run any time.
+chosen without first deciding how the resolver finds documents.
 
 ## Issue Outlines
 
@@ -69,14 +77,10 @@ below._
 | _Decide how the setup phase captures and routes baseline failures that predate the current change, so later gates don't misattribute them._ | | |
 | [#82: docs(design): pre-push confirmation gate with --auto mode](https://github.com/tsukumogami/shirabe/issues/82) | None | simple |
 | _Decide how phase-6 pauses for user confirmation before `git push` / `gh pr create` while remaining correct in `--auto` mode._ | | |
-| [#83: docs(design): multi-issue bundling as a first-class /work-on flow](https://github.com/tsukumogami/shirabe/issues/83) | None | simple |
-| _Decide how `/work-on` supports bundling multiple issues onto one branch and PR as a first-class flow. Highest-impact item; several viable approaches._ | | |
 | [#84: docs(design): per-branch context findings cache](https://github.com/tsukumogami/shirabe/issues/84) | [#79](https://github.com/tsukumogami/shirabe/issues/79) | simple |
 | _Decide the cache key scheme for `extract-context.sh` so sibling issues on one branch don't re-investigate the same design-doc dead ends._ | | |
 | [#85: docs(design): monorepo-aware baseline scoping](https://github.com/tsukumogami/shirabe/issues/85) | None | simple |
-| _Decide how setup detects monorepo structure and scopes baseline tests to touched packages. Also decides whether scoping belongs in work-on or a future language skill._ | | |
-| [#86: task(work-on): re-run work-on evals after CLAUDE_PLUGIN_ROOT change](https://github.com/tsukumogami/shirabe/issues/86) | None | simple |
-| _Re-run work-on evals after the `CLAUDE_PLUGIN_ROOT` standardization merges, to catch any assertion that still expects the old env-var string._ | | |
+| _Decide how setup detects monorepo structure and scopes baseline tests to touched packages. The routing decision (per-language-skill ownership) is settled; the remaining design work is the per-skill scoping logic._ | | |
 
 ## Dependency Graph
 
@@ -86,10 +90,8 @@ graph TD
   I80["#80: staleness_check portability"]
   I81["#81: pre-existing baseline failures"]
   I82["#82: pre-push confirmation"]
-  I83["#83: multi-issue bundling"]
   I84["#84: context findings cache"]
   I85["#85: monorepo baseline scoping"]
-  I86["#86: re-run evals after env-var change"]
 
   I79 --> I84
 
@@ -103,9 +105,8 @@ graph TD
   classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
   classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-  class I79,I80,I81,I82,I83,I85 needsDesign
+  class I79,I80,I81,I82,I85 needsDesign
   class I84 blocked
-  class I86 ready
 ```
 
 **Legend**: Purple = needs-design, Yellow = blocked on a prerequisite
@@ -113,19 +114,16 @@ design, Blue = ready to implement, Green = done.
 
 ## Implementation Sequence
 
-Seven of the eight can start in parallel once this PR merges: #79,
-#80, #81, #82, #83, #85 on the design track, plus #86 (eval re-run)
-on the implementation track. Only #84 waits — on #79 being Accepted,
-because its cache key scheme depends on the resolution strategy.
+Five of the six can start in parallel: #79, #80, #81, #82, #85 on
+the design track. Only #84 waits — on #79 being Accepted, because
+its cache key scheme depends on the resolution strategy.
 
-**Priority signal**: #83 (multi-issue bundling) was the highest-impact
-single item in the source triage. Starting its DESIGN doc first keeps
-the downstream implementation plan unblocked the earliest. #86 (eval
-re-run) is cheap to run and worth doing early since it verifies that
-no assertion regressed against the env-var change.
+**Priority signal**: #79 (extract-context remote resolution) is now
+the highest-impact starting point because it unblocks #84.
+Starting its DESIGN doc first keeps the downstream cache work
+(#84) unblocked at the earliest opportunity.
 
-**Per-design-doc follow-up**: each design issue (#79, #80, #81, #82,
-#83, #84, #85) spawns its own implementation plan via `/plan` once
-the design is Accepted. #86 closes directly via `/work-on`. This PLAN
-closes when all downstream plans have reached Done and #86 is closed
-(or an item is explicitly dropped).
+**Per-design-doc follow-up**: each design issue (#79, #80, #81,
+#82, #84, #85) spawns its own implementation plan via `/plan` once
+the design is Accepted. This PLAN closes when all downstream plans
+have reached Done (or an item is explicitly dropped).


### PR DESCRIPTION
Update `PLAN-work-on-friction-fixes.md` to reflect a triage pass against the current `/work-on` state. Drop #83 and #86 from the issue table and dependency graph; `issue_count` goes from 8 to 6. Add a triage paragraph to the Status section documenting the close-out. The two closed issues carry GitHub comments with the close-out rationale; #81 and #85 carry comments noting partial address.

The remaining six (#79, #80, #81, #82, #84, #85) stay open as the live friction items the standardization work didn't incidentally resolve.

---

## What this accomplishes

The PLAN was filed in late April 2026 and sat at Active for 6+ weeks while the cascade refactor (#176), the per-skill artifact-decision work (#179), the lifecycle/validator work that constituted milestone roadmap-plan-standardization (PRs #168-#190), and a workflow friction sweep (#166) landed in parallel. Two of the eight issues no longer name live friction:

- **#83 (multi-issue bundling as a first-class `/work-on` flow)** is superseded by plan-backed mode. `SHARED_BRANCH` plus `setup_plan_backed` plus `pr_status: shared` (see `koto-templates/work-on.md` line 631) is the first-class bundling flow the issue asked for. The plan-backed orchestrator is the per-issue iterator; bundled children share the orchestrator's PR rather than each creating their own. The design question is functionally answered.
- **#86 (re-run evals after `CLAUDE_PLUGIN_ROOT` change)** is obsoleted by intervening CI activity. The standardization landed in May; `grep -r CLAUDE_SKILL_DIR skills/work-on/` returns zero hits today; eval runs across the dozen-plus PRs that touched work-on since would have surfaced any keyed-on-the-old-literal regression. The verification window is past.

Two more sit in a middle state and get status comments rather than closure:

- **#81 (pre-existing baseline failure envelope)**: the capture surface now exists (`phase-1-setup.md` has a `## Pre-existing Issues` section in the baseline template), but the routing envelope — the formal evidence value plus the downstream-gate signal — is still open.
- **#85 (monorepo-aware baseline scoping)**: the routing decision (monorepo knowledge belongs in per-language skills, not `/work-on` itself) is settled in practice by `phase-1-setup.md`'s "use project-specific commands from the language skill" line, but the per-skill scoping logic is still to be designed.

The remaining four (#79, #80, #82, #84) are unchanged friction the standardization work didn't touch.

## Validation

- `shirabe validate docs/plans/PLAN-work-on-friction-fixes.md` exits 0 with only FC08 notices (pre-existing legend/classDef drift, not introduced by this PR).
- `shirabe validate --lifecycle . --strict` exits 0 — the chain stays at multi-pr in-flight passing-state with the updated table.