### PR TITLE
chore(ci): update design doc validation

### DIFF
--- a/.github/scripts/absorption-capture-manifest.tsv
+++ b/.github/scripts/absorption-capture-manifest.tsv
@@ -1,0 +1,27 @@
+# Absorption capture manifest: which external check produces each shirabe
+# parity baseline, and over which corpus document.
+#
+# Consumed by capture-absorption-baseline.sh --manifest <this-file> <golden-dir>,
+# where <golden-dir> is the shirabe checkout's
+# crates/shirabe/tests/fixtures/absorption-golden. For each row the script runs
+# the named check (resolved under scripts/ci/checks/) over
+# <golden-dir>/corpus/<case_id>/<doc_relpath> and writes the captured fired-rule
+# set to <golden-dir>/expected/<case_id>/external_rules.
+#
+# Only the three current-model checks are captured here: frontmatter.sh,
+# sections.sh, and status-directory.sh validate something a design doc still
+# carries. The legacy design-doc-issues checks (implementation-issues.sh,
+# issue-status.sh, strikethrough-all-docs.sh) are NOT captured -- they validate
+# a retired pattern and are retired as legacy, their intent already covered by
+# the engine's FC05/FC06/FC09 on PLAN/ROADMAP.
+#
+# case_id	check	doc_relpath
+frontmatter-clean	frontmatter.sh	docs/designs/DESIGN-x.md
+frontmatter-missing-field	frontmatter.sh	docs/designs/DESIGN-x.md
+frontmatter-invalid-status	frontmatter.sh	docs/designs/DESIGN-x.md
+frontmatter-status-mismatch	frontmatter.sh	docs/designs/DESIGN-x.md
+sections-clean	sections.sh	docs/designs/DESIGN-x.md
+sections-missing	sections.sh	docs/designs/DESIGN-x.md
+sections-order	sections.sh	docs/designs/DESIGN-x.md
+sections-security-empty	sections.sh	docs/designs/DESIGN-x.md
+status-directory-misplaced	status-directory.sh	docs/designs/DESIGN-x.md

--- a/.github/scripts/capture-absorption-baseline.sh
+++ b/.github/scripts/capture-absorption-baseline.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# capture-absorption-baseline.sh - Capture an external check's real fired-rule
+# set for shirabe's absorption parity harness.
+#
+# The shirabe parity harness (crates/shirabe/tests/absorption_parity.rs) proves
+# that an absorbed engine check fires the same rules as the external bash check
+# it replaces, over a frozen corpus. The external side of that comparison is a
+# committed baseline at `expected/<case>/external_rules`. This script PRODUCES
+# that baseline from the real bash script, replacing the hand-authored stand-ins
+# the harness shipped with.
+#
+# It runs ONE check script over ONE document and writes, to stdout, the SORTED
+# UNIQUE set of rule codes the check fired (one per line) -- the exact payload
+# the harness reads. A check that fires nothing emits an empty set (the clean
+# baseline). This is the capture-ahead model: a developer runs this once in a
+# controlled environment and commits the output; `cargo test` and CI never run
+# the bash.
+#
+# Usage (single capture):
+#   capture-absorption-baseline.sh <check-script> <doc-path>
+#
+# Usage (regenerate a whole corpus from a capture manifest):
+#   capture-absorption-baseline.sh --manifest <manifest.tsv> <golden-dir>
+#
+#   The manifest is tab-separated `case_id <TAB> check-script <TAB> doc_relpath`
+#   (comments with '#' and blank lines ignored). For each row the script runs
+#   <check-script> over <golden-dir>/corpus/<case_id>/<doc_relpath> and writes
+#   the captured set to <golden-dir>/expected/<case_id>/external_rules, with a
+#   provenance header naming the check and the capture command.
+#
+# The normalization contract: each `[FAIL] ...` line an external check writes to
+# stderr leads with its rule code (FM01-03 from frontmatter.sh, SC01-03 from
+# sections.sh, SD01-02 from status-directory.sh). This script extracts those
+# leading codes verbatim -- they ARE the mapping.tsv keys the harness translates
+# into engine codes. The check's own exit 1 (findings present) is expected and
+# not an error; only an operational failure (exit 2) is surfaced.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Resolve a manifest's check reference: an absolute/relative path is used as-is;
+# a bare name resolves under this script's checks/ directory.
+resolve_check() {
+    local ref="$1"
+    if [[ "$ref" == */* ]]; then
+        printf '%s\n' "$ref"
+    else
+        printf '%s\n' "$SCRIPT_DIR/checks/$ref"
+    fi
+}
+
+# Extract the set of rule codes from a check's stderr. Each fired rule is the
+# leading two-letter/two-digit token of a `[FAIL] ...` line; the same code also
+# appears in that line's `See: .github/scripts/docs/<CODE>.md` reference, so
+# scanning [FAIL] lines and de-duplicating yields exactly the fired set.
+extract_codes() {
+    grep -E '^\[FAIL\]' | grep -oE '[A-Z]{2}[0-9]{2}' | sort -u
+}
+
+# Run one check over one doc; echo the captured code set (possibly empty).
+# Returns 2 (and prints to stderr) on an operational error from the check.
+capture_one() {
+    local check="$1" doc="$2"
+    if [[ ! -x "$check" ]]; then
+        echo "error: check script not executable: $check" >&2
+        return 2
+    fi
+    if [[ ! -f "$doc" ]]; then
+        echo "error: document not found: $doc" >&2
+        return 2
+    fi
+    local stderr rc
+    # Capture stderr, discard stdout (the [PASS] chatter); the check's exit 1
+    # on findings is expected, so do not let it abort the script.
+    stderr="$("$check" "$doc" 2>&1 1>/dev/null)"
+    rc=$?
+    if [[ $rc -eq 2 ]]; then
+        echo "error: operational failure (exit 2) from $check over $doc:" >&2
+        printf '%s\n' "$stderr" >&2
+        return 2
+    fi
+    # An empty fired-set (clean document) is a valid baseline, not an error, so
+    # the grep pipeline's empty-match exit 1 must not propagate.
+    local codes
+    codes="$(printf '%s\n' "$stderr" | extract_codes)"
+    [[ -n "$codes" ]] && printf '%s\n' "$codes"
+    return 0
+}
+
+main() {
+    if [[ "${1:-}" == "--manifest" ]]; then
+        local manifest="${2:-}" golden="${3:-}"
+        if [[ -z "$manifest" || -z "$golden" ]]; then
+            echo "usage: $0 --manifest <manifest.tsv> <golden-dir>" >&2
+            exit 2
+        fi
+        [[ -f "$manifest" ]] || { echo "no such manifest: $manifest" >&2; exit 2; }
+        [[ -d "$golden" ]] || { echo "no such golden dir: $golden" >&2; exit 2; }
+        local case_id check_ref check doc_relpath doc out codes
+        while IFS=$'\t' read -r case_id check_ref doc_relpath; do
+            [[ -z "$case_id" || "$case_id" == \#* ]] && continue
+            check="$(resolve_check "$check_ref")"
+            doc="$golden/corpus/$case_id/$doc_relpath"
+            out="$golden/expected/$case_id/external_rules"
+            codes="$(capture_one "$check" "$doc")" || exit 2
+            mkdir -p "$(dirname "$out")"
+            {
+                echo "# external fired-rule set for $case_id (captured ahead of time)."
+                echo "# source: $(basename "$check") over corpus/$case_id/$doc_relpath"
+                echo "# regenerate: capture-absorption-baseline.sh --manifest <manifest> <golden-dir>"
+                [[ -n "$codes" ]] && printf '%s\n' "$codes"
+            } > "$out"
+            echo "captured $case_id -> ${codes:-<empty>}" >&2
+        done < "$manifest"
+        return 0
+    fi
+
+    local check="${1:-}" doc="${2:-}"
+    if [[ -z "$check" || -z "$doc" ]]; then
+        echo "usage: $0 <check-script> <doc-path>" >&2
+        echo "       $0 --manifest <manifest.tsv> <golden-dir>" >&2
+        exit 2
+    fi
+    capture_one "$check" "$doc" || exit 2
+}
+
+main "$@"

--- a/.github/scripts/check-issue-status.sh
+++ b/.github/scripts/check-issue-status.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# check-issue-status.sh - Verify issue has expected status in design doc Mermaid diagram
+#
+# Usage:
+#   check-issue-status.sh <doc-path> <issue-num> <expected-status>
+#
+# Arguments:
+#   doc-path        Path to design document
+#   issue-num       Issue number (e.g., 384)
+#   expected-status Expected class: done, ready, blocked, needsDesign
+#
+# Exit codes:
+#   0 - Status matches expected
+#   1 - Status mismatch
+#   2 - Operational error (file not found, no diagram, invalid arguments)
+#
+# Example:
+#   check-issue-status.sh docs/designs/DESIGN-foo.md 350 done
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Valid status values
+VALID_STATUSES=("done" "ready" "blocked" "needsDesign")
+
+# Validate arguments
+if [[ $# -lt 3 ]]; then
+    echo "Error: missing required arguments" >&2
+    echo "Usage: check-issue-status.sh <doc-path> <issue-num> <expected-status>" >&2
+    exit 2
+fi
+
+DOC_PATH="$1"
+ISSUE_NUM="$2"
+EXPECTED_STATUS="$3"
+
+# Check file exists
+if [[ ! -f "$DOC_PATH" ]]; then
+    echo "Error: file not found: $DOC_PATH" >&2
+    exit 2
+fi
+
+# Validate issue number is numeric
+if ! [[ "$ISSUE_NUM" =~ ^[0-9]+$ ]]; then
+    echo "Error: invalid issue number: $ISSUE_NUM" >&2
+    exit 2
+fi
+
+# Validate expected status
+VALID=0
+for status in "${VALID_STATUSES[@]}"; do
+    if [[ "$EXPECTED_STATUS" == "$status" ]]; then
+        VALID=1
+        break
+    fi
+done
+if [[ $VALID -eq 0 ]]; then
+    echo "Error: invalid status '$EXPECTED_STATUS'. Valid: ${VALID_STATUSES[*]}" >&2
+    exit 2
+fi
+
+# Check for mermaid block
+if ! grep -q '```mermaid' "$DOC_PATH"; then
+    echo "Error: no Mermaid diagram found in $DOC_PATH" >&2
+    exit 2
+fi
+
+# Extract the mermaid block content
+MERMAID_CONTENT=$(awk '
+    /^```mermaid/ { in_mermaid = 1; next }
+    /^```/ && in_mermaid { in_mermaid = 0; next }
+    in_mermaid { print }
+' "$DOC_PATH")
+
+# Build a map of node -> class from class assignments
+# Handles both single and grouped: "class I100 done" and "class I100,I101,I102 blocked"
+declare -A NODE_CLASSES
+
+while IFS= read -r line; do
+    if echo "$line" | grep -qE '^\s*class\s+'; then
+        # Extract class name (last word on the line)
+        CLASS_NAME=$(echo "$line" | awk '{print $NF}')
+        # Extract nodes (everything between "class " and the class name)
+        NODES_STR=$(echo "$line" | sed 's/^\s*class\s*//' | sed "s/\s*${CLASS_NAME}$//" | tr -d ' ')
+        # Split by comma and assign
+        IFS=',' read -ra NODE_LIST <<< "$NODES_STR"
+        for node in "${NODE_LIST[@]}"; do
+            [[ -n "$node" ]] && NODE_CLASSES[$node]="$CLASS_NAME"
+        done
+    fi
+done <<< "$MERMAID_CONTENT"
+
+# Look up the status for our issue
+NODE_ID="I${ISSUE_NUM}"
+ACTUAL_STATUS="${NODE_CLASSES[$NODE_ID]:-}"
+
+if [[ -z "$ACTUAL_STATUS" ]]; then
+    echo "Error: issue #$ISSUE_NUM (node $NODE_ID) not found in diagram" >&2
+    exit 2
+fi
+
+# Compare
+if [[ "$ACTUAL_STATUS" == "$EXPECTED_STATUS" ]]; then
+    echo "Issue #$ISSUE_NUM: status '$ACTUAL_STATUS' matches expected '$EXPECTED_STATUS'"
+    exit 0
+else
+    echo "Issue #$ISSUE_NUM: expected '$EXPECTED_STATUS', found '$ACTUAL_STATUS'" >&2
+    exit 1
+fi

--- a/.github/scripts/checks/common.sh
+++ b/.github/scripts/checks/common.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# common.sh - Shared utilities for design document validation checks
+#
+# This file provides the interface contract that all check scripts must follow.
+#
+# Interface Contract:
+#   Input:  Single argument - path to design document
+#   Output: [PASS] message to stdout for passing checks
+#           [FAIL] message to stderr for failing checks
+#   Exit:   0 = all checks passed
+#           1 = one or more checks failed
+#           2 = operational error (file not found, invalid args)
+#
+# Required Exports:
+#   - extract_frontmatter <doc-path>  : Outputs frontmatter content (between --- delimiters)
+#   - emit_pass <message>             : Outputs [PASS] message to stdout
+#   - emit_fail <message>             : Outputs [FAIL] message to stderr
+#   - EXIT_PASS, EXIT_FAIL, EXIT_ERROR: Exit code constants
+#
+# Usage in check scripts:
+#   source "$(dirname "$0")/common.sh"
+#   # ... validation logic ...
+#   emit_pass "Frontmatter valid"
+#   exit $EXIT_PASS
+
+set -euo pipefail
+
+# Exit code constants
+readonly EXIT_PASS=0
+readonly EXIT_FAIL=1
+readonly EXIT_ERROR=2
+
+# Quiet mode - when set to 1, suppress [PASS] messages
+# Can be set via: export QUIET_MODE=1
+: "${QUIET_MODE:=0}"
+
+# emit_pass - Output a passing check message (suppressed in quiet mode)
+# Usage: emit_pass "Check passed"
+emit_pass() {
+    [[ "$QUIET_MODE" -eq 1 ]] && return 0
+    echo "[PASS] $1"
+}
+
+# emit_fail - Output a failing check message
+# Usage: emit_fail "Check failed: reason"
+# If VALIDATE_DOC_PATH is set (exported by the orchestrator), it is included.
+emit_fail() {
+    if [[ -n "${VALIDATE_DOC_PATH:-}" ]]; then
+        echo "[FAIL] $VALIDATE_DOC_PATH: $1" >&2
+    else
+        echo "[FAIL] $1" >&2
+    fi
+}
+
+# extract_frontmatter - Extract YAML frontmatter from a document
+# Usage: content=$(extract_frontmatter "/path/to/doc.md")
+# Returns: Frontmatter content (lines between --- delimiters, excluding delimiters)
+# Exit: 0 if frontmatter found, 1 if not found
+extract_frontmatter() {
+    local doc_path="$1"
+
+    # Check file exists
+    if [[ ! -f "$doc_path" ]]; then
+        return 1
+    fi
+
+    # Check first line is ---
+    local first_line
+    first_line=$(head -1 "$doc_path")
+    if [[ "$first_line" != "---" ]]; then
+        return 1
+    fi
+
+    # Extract content between first --- and second ---
+    # Use awk to get lines between first and second ---
+    awk '
+        NR == 1 && /^---$/ { in_frontmatter = 1; next }
+        in_frontmatter && /^---$/ { exit }
+        in_frontmatter { print }
+    ' "$doc_path"
+}
+
+# get_frontmatter_status - Extract and normalize status from frontmatter
+# Usage: status=$(get_frontmatter_status "/path/to/doc.md")
+# Returns: Normalized status (Proposed, Accepted, Planned, Current, Superseded)
+#          Empty string if no frontmatter or status field
+# Note: Normalizes case (e.g., "proposed" -> "Proposed", "PLANNED" -> "Planned")
+get_frontmatter_status() {
+    local doc_path="$1"
+
+    if ! has_frontmatter "$doc_path"; then
+        echo ""
+        return
+    fi
+
+    local frontmatter raw_status normalized
+    frontmatter=$(extract_frontmatter "$doc_path")
+    raw_status=$(echo "$frontmatter" | awk -F': ' '$1 == "status" { print $2 }')
+
+    # Normalize to title case
+    if [[ -n "$raw_status" ]]; then
+        # Convert to lowercase, then capitalize first letter
+        normalized=$(echo "$raw_status" | tr '[:upper:]' '[:lower:]')
+        normalized="${normalized^}"
+        echo "$normalized"
+    else
+        echo ""
+    fi
+}
+
+# has_frontmatter - Check if document has valid frontmatter structure
+# Usage: if has_frontmatter "/path/to/doc.md"; then ...
+# Returns: 0 if frontmatter exists, 1 if not
+has_frontmatter() {
+    local doc_path="$1"
+
+    # Check file exists
+    if [[ ! -f "$doc_path" ]]; then
+        return 1
+    fi
+
+    # Check first line is ---
+    local first_line
+    first_line=$(head -1 "$doc_path")
+    if [[ "$first_line" != "---" ]]; then
+        return 1
+    fi
+
+    # Check for closing ---
+    local has_closing
+    has_closing=$(awk 'NR > 1 && /^---$/ { found=1; exit } END { print found+0 }' "$doc_path")
+
+    [[ "$has_closing" -eq 1 ]]
+}

--- a/.github/scripts/checks/design-doc-template.md
+++ b/.github/scripts/checks/design-doc-template.md
@@ -1,0 +1,83 @@
+# Design Document Template
+
+Required sections in order:
+
+```markdown
+---
+status: Proposed
+problem: |
+  1 paragraph describing the problem being solved.
+  Cover what's broken or missing, who it affects,
+  and why it matters now.
+decision: |
+  1 paragraph stating the decision.
+  Cover the chosen approach and key design choices.
+rationale: |
+  1 paragraph explaining why this approach was chosen.
+  Cover trade-offs and why alternatives were rejected.
+---
+
+# DESIGN: Title
+
+## Status
+
+**Proposed**
+
+## Context and Problem Statement
+
+What problem are we solving and why does it matter now?
+
+## Decision Drivers
+
+- Driver 1
+- Driver 2
+
+## Considered Options
+
+### Option A
+Description, pros, cons.
+
+### Option B
+Description, pros, cons.
+
+## Decision Outcome
+
+Which option was chosen and why.
+
+## Solution Architecture
+
+Technical design and components.
+
+## Implementation Approach
+
+How to build it - phases, steps, order.
+
+## Security Considerations
+
+Address: download verification, execution isolation,
+supply chain risks, user data exposure.
+
+## Consequences
+
+### Positive
+- Benefit 1
+
+### Negative
+- Trade-off 1
+```
+
+Valid status values: Proposed, Accepted, Planned, Current, Superseded
+
+## Mermaid Diagram Reference
+
+When status is "Planned", include a dependency graph with standard class definitions:
+
+```
+classDef done fill:#c8e6c9
+classDef ready fill:#bbdefb
+classDef blocked fill:#fff9c4
+classDef needsDesign fill:#e1bee7
+classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
+```
+
+**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design, Orange = tracks-design

--- a/.github/scripts/checks/frontmatter.sh
+++ b/.github/scripts/checks/frontmatter.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# frontmatter.sh - Validate design document frontmatter
+#
+# Implements frontmatter validation rules:
+#   FM01: All 4 required fields present (status, problem, decision, rationale)
+#   FM02: Status is valid value (Proposed, Accepted, Planned, Current, Superseded)
+#   FM03: Frontmatter status matches body status section
+#
+# Usage:
+#   frontmatter.sh <doc-path>
+#
+# Exit codes:
+#   0 - All checks passed
+#   1 - One or more checks failed
+#   2 - Operational error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+# Constants
+readonly REQUIRED_FIELDS=(status problem decision rationale)
+readonly VALID_STATUSES=(Proposed Accepted Planned Current Superseded)
+
+# Validate arguments
+if [[ $# -lt 1 ]]; then
+    echo "Error: missing required argument <doc-path>" >&2
+    exit $EXIT_ERROR
+fi
+
+DOC_PATH="$1"
+
+# Check file exists
+if [[ ! -f "$DOC_PATH" ]]; then
+    echo "Error: file not found: $DOC_PATH" >&2
+    exit $EXIT_ERROR
+fi
+
+# Run checks
+FAILED=0
+
+# Check: Frontmatter exists (prerequisite for other checks)
+if ! has_frontmatter "$DOC_PATH"; then
+    emit_fail "FM01: Frontmatter missing or malformed. See: .github/scripts/docs/FM01.md"
+    exit $EXIT_FAIL
+fi
+
+# Extract frontmatter content
+FRONTMATTER=$(extract_frontmatter "$DOC_PATH")
+
+# Helper: get field value from frontmatter
+get_field() {
+    local field="$1"
+    echo "$FRONTMATTER" | awk -F': ' -v field="$field" '$1 == field { print substr($0, index($0, ": ") + 2) }'
+}
+
+# FM01: Check all required fields are present
+for field in "${REQUIRED_FIELDS[@]}"; do
+    value=$(get_field "$field")
+    if [[ -z "$value" ]]; then
+        emit_fail "FM01: Missing frontmatter field: $field. See: .github/scripts/docs/FM01.md"
+        FAILED=1
+    fi
+done
+
+# FM02: Validate status value
+FM_STATUS=$(get_field "status")
+if [[ -n "$FM_STATUS" ]]; then
+    valid=0
+    for status in "${VALID_STATUSES[@]}"; do
+        if [[ "$FM_STATUS" == "$status" ]]; then
+            valid=1
+            break
+        fi
+    done
+    if [[ "$valid" -eq 0 ]]; then
+        emit_fail "FM02: Invalid frontmatter status: $FM_STATUS. See: .github/scripts/docs/FM02.md"
+        FAILED=1
+    fi
+fi
+
+# FM03: Check frontmatter status matches body status
+# Skip for Superseded docs (per design: "validation is relaxed to not block archival of legacy formats")
+if [[ "$FM_STATUS" != "Superseded" ]]; then
+    # Body status is in "## Status" section, formatted as **Status** (preferred) or just Status
+    # Also handles inline **Status: Value** format
+    extract_body_status() {
+        local doc="$1"
+        # Method 1: Look for ## Status section, then find status value
+        local status
+        status=$(awk '
+            /^## Status/ { in_status = 1; next }
+            in_status && /^\*\*[A-Za-z]+\*\*/ {
+                # Bold format: **Proposed**
+                gsub(/^\*\*/, "")
+                gsub(/\*\*.*$/, "")
+                print
+                exit
+            }
+            in_status && /^[A-Za-z]+$/ {
+                # Plain format: Proposed (on its own line)
+                print
+                exit
+            }
+            in_status && /^Superseded by/ {
+                # Superseded with link format
+                print "Superseded"
+                exit
+            }
+            in_status && /^## / { exit }  # Hit next section
+        ' "$doc")
+
+        if [[ -n "$status" ]]; then
+            echo "$status"
+            return
+        fi
+
+        # Method 2: Look for inline status formats
+        # Handles: **Status: Value** (all bold) or **Status:** Value (label bold only)
+        awk '
+            /^\*\*Status:\*\* [A-Za-z]+/ {
+                # **Status:** Value format (label bold, value plain)
+                gsub(/^\*\*Status:\*\* /, "")
+                gsub(/ .*$/, "")
+                print
+                exit
+            }
+            /^\*\*Status: [A-Za-z]+\*\*/ {
+                # **Status: Value** format (all bold)
+                gsub(/^\*\*Status: /, "")
+                gsub(/\*\*.*$/, "")
+                print
+                exit
+            }
+        ' "$doc"
+    }
+
+    BODY_STATUS=$(extract_body_status "$DOC_PATH")
+    if [[ -z "$BODY_STATUS" ]]; then
+        emit_fail "FM03: Could not extract body status from ## Status section. See: .github/scripts/docs/FM03.md"
+        FAILED=1
+    elif [[ -n "$FM_STATUS" && "$FM_STATUS" != "$BODY_STATUS" ]]; then
+        emit_fail "FM03: Frontmatter status '$FM_STATUS' doesn't match body status '$BODY_STATUS'. See: .github/scripts/docs/FM03.md"
+        FAILED=1
+    fi
+fi
+
+# Return appropriate exit code
+if [[ "$FAILED" -eq 0 ]]; then
+    exit $EXIT_PASS
+else
+    exit $EXIT_FAIL
+fi

--- a/.github/scripts/checks/implementation-issues.sh
+++ b/.github/scripts/checks/implementation-issues.sh
@@ -1,0 +1,407 @@
+#!/usr/bin/env bash
+#
+# implementation-issues.sh - Validate design document Implementation Issues section
+#
+# Implements implementation issues validation rules:
+#   II00: Section must NOT exist for Proposed/Accepted status
+#   II01: Section exists for Planned status (optional for Current)
+#   II02: Table has correct columns (Issue, Dependencies, Tier) or legacy (Issue, Title, Dependencies, Tier)
+#   II03: Issue/milestone links use valid format [#N](url) or [Name](milestone-url)
+#   II04: Dependencies use link format, not plain text
+#   II05: Tier values are valid (simple, testable, critical, milestone)
+#   II06: Child design reference links must point to existing files
+#   II07: Every issue row must be followed by a description row (grandfathered before cutoff)
+#   II08: Strikethrough consistency between issue, child reference, and description rows
+#
+# Usage:
+#   implementation-issues.sh <doc-path>
+#
+# Exit codes:
+#   0 - All checks passed
+#   1 - One or more checks failed
+#   2 - Operational error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+# Validate arguments
+if [[ $# -lt 1 ]]; then
+    echo "Error: missing required argument <doc-path>" >&2
+    exit $EXIT_ERROR
+fi
+
+DOC_PATH="$1"
+
+# Check file exists
+if [[ ! -f "$DOC_PATH" ]]; then
+    echo "Error: file not found: $DOC_PATH" >&2
+    exit $EXIT_ERROR
+fi
+
+# Get normalized status from frontmatter (uses shared function from common.sh)
+FM_STATUS=$(get_frontmatter_status "$DOC_PATH")
+
+# II00: Implementation Issues section must NOT exist for Proposed/Accepted status
+# These statuses indicate issues haven't been created yet via /plan
+if [[ "$FM_STATUS" == "Proposed" || "$FM_STATUS" == "Accepted" ]]; then
+    if grep -q "^## Implementation Issues" "$DOC_PATH"; then
+        emit_fail "II00: Implementation Issues section not allowed in '$FM_STATUS' status. See: .github/scripts/docs/II00.md"
+        exit $EXIT_FAIL
+    fi
+    exit $EXIT_PASS
+fi
+
+# Only validate table format for Planned and Current status
+if [[ "$FM_STATUS" != "Planned" && "$FM_STATUS" != "Current" ]]; then
+    exit $EXIT_PASS
+fi
+
+FAILED=0
+
+# II01: Check for Implementation Issues section
+# - Planned status: MUST have this section (created by /plan)
+# - Current status: MAY have this section (Accepted→Current direct path doesn't create it)
+if ! grep -q "^## Implementation Issues" "$DOC_PATH"; then
+    if [[ "$FM_STATUS" == "Planned" ]]; then
+        emit_fail "II01: Planned status requires '## Implementation Issues' section. See: .github/scripts/docs/II01.md"
+        FAILED=1
+        exit $EXIT_FAIL
+    else
+        # Current status without section - valid (direct Accepted→Current path)
+        exit $EXIT_PASS
+    fi
+fi
+
+# Extract the Implementation Issues section content
+# Get content from "## Implementation Issues" until next "## " heading or end of file
+ISSUES_SECTION=$(awk '
+    /^## Implementation Issues/ { in_section = 1; next }
+    in_section && /^## / { exit }
+    in_section { print }
+' "$DOC_PATH")
+
+# Find the issues table (first table after section heading)
+# Table starts with | Issue | and has separator row |---|
+TABLE_HEADER=$(echo "$ISSUES_SECTION" | grep -E "^\| *Issue" | head -1 || true)
+
+if [[ -z "$TABLE_HEADER" ]]; then
+    emit_fail "II02: Implementation Issues section missing issues table. See: .github/scripts/docs/II02.md"
+    FAILED=1
+    exit $EXIT_FAIL
+fi
+
+# II02: Validate required columns exist
+# Accept both formats:
+#   New (3-col): | Issue | Dependencies | Tier |
+#   Legacy (4-col): | Issue | Title | Dependencies | Tier |
+REQUIRED_COLUMNS=("Issue" "Dependencies" "Tier")
+for col in "${REQUIRED_COLUMNS[@]}"; do
+    if ! echo "$TABLE_HEADER" | grep -qiE "\| *$col *\|"; then
+        # Check if it's the last column (no trailing |)
+        if ! echo "$TABLE_HEADER" | grep -qiE "\| *$col *$"; then
+            emit_fail "II02: Issues table missing required column: $col. See: .github/scripts/docs/II02.md"
+            FAILED=1
+        fi
+    fi
+done
+
+# Extract table data rows (skip header, separator, description rows, and child reference rows)
+# Description rows: | _text_ | | | | or struck-through: | ~~_text_~~ | | | |
+# Child reference rows: | ^_Child: ..._ | | | | or struck-through: | ~~^_Child: ..._~~ | | | |
+TABLE_ROWS=$(echo "$ISSUES_SECTION" | awk '
+    /^\|/ && !/^\| *-/ && !/^\| *Issue/ && !/^\| *_/ && !/^\| *~~_/ && !/^\| *\^_/ && !/^\| *~~\^_/ { print }
+')
+
+# Parse column positions from header
+get_column_position() {
+    local header="$1"
+    local col_name="$2"
+    echo "$header" | awk -v col="$col_name" '
+    BEGIN { FS = "|"; pos = 0 }
+    {
+        for (i = 1; i <= NF; i++) {
+            gsub(/^[ \t]+|[ \t]+$/, "", $i)
+            if (tolower($i) == tolower(col)) {
+                print i
+                exit
+            }
+        }
+    }
+    '
+}
+
+ISSUE_COL=$(get_column_position "$TABLE_HEADER" "Issue")
+DEP_COL=$(get_column_position "$TABLE_HEADER" "Dependencies")
+TIER_COL=$(get_column_position "$TABLE_HEADER" "Tier")
+
+# Helper: Strip strikethrough formatting ~~text~~ -> text
+# Completed issues/milestones are shown with strikethrough
+strip_strikethrough() {
+    echo "$1" | sed 's/^~~//;s/~~$//'
+}
+
+# Helper: Check if a value is a valid markdown link [text](url)
+is_markdown_link() {
+    local val
+    val=$(strip_strikethrough "$1")
+    [[ "$val" =~ ^\[.+\]\(.+\)$ ]]
+}
+
+# Helper: Check if a value is a milestone link (contains /milestone/ in URL)
+is_milestone_link() {
+    local val
+    val=$(strip_strikethrough "$1")
+    [[ "$val" =~ ^\[.+\]\(.*milestone.*\)$ ]]
+}
+
+# Helper: Check if a value is an issue link [#N](url) or [#N: title](url)
+is_issue_link() {
+    local val
+    val=$(strip_strikethrough "$1")
+    [[ "$val" =~ ^\[#[0-9]+(\]|:\ .*\])\(.+\)$ ]]
+}
+
+# Process each row
+while IFS= read -r row; do
+    [[ -z "$row" ]] && continue
+
+    # Extract column values
+    ISSUE_VAL=$(echo "$row" | awk -F'|' -v col="$ISSUE_COL" '{ gsub(/^[ \t]+|[ \t]+$/, "", $col); print $col }')
+    DEP_VAL=$(echo "$row" | awk -F'|' -v col="$DEP_COL" '{ gsub(/^[ \t]+|[ \t]+$/, "", $col); print $col }')
+    TIER_VAL=$(echo "$row" | awk -F'|' -v col="$TIER_COL" '{ gsub(/^[ \t]+|[ \t]+$/, "", $col); print $col }')
+
+    # Strip strikethrough for comparison (completed items use ~~text~~)
+    TIER_VAL_CLEAN=$(strip_strikethrough "$TIER_VAL")
+
+    # Determine if this is a milestone row or issue row
+    IS_MILESTONE_ROW=false
+    if [[ "$TIER_VAL_CLEAN" == "milestone" ]] || is_milestone_link "$ISSUE_VAL"; then
+        IS_MILESTONE_ROW=true
+    fi
+
+    # II03: Validate first column format
+    if [[ -n "$ISSUE_VAL" ]]; then
+        if [[ "$IS_MILESTONE_ROW" == true ]]; then
+            # Milestone row: must be a valid markdown link
+            if ! is_markdown_link "$ISSUE_VAL"; then
+                emit_fail "II03: Invalid milestone link format: '$ISSUE_VAL'. See: .github/scripts/docs/II03.md"
+                FAILED=1
+            fi
+        else
+            # Issue row: must be [#N](url) format
+            if ! is_issue_link "$ISSUE_VAL"; then
+                emit_fail "II03: Invalid issue link format: '$ISSUE_VAL'. See: .github/scripts/docs/II03.md"
+                FAILED=1
+            fi
+        fi
+    fi
+
+    # II04: Validate dependencies format
+    if [[ -n "$DEP_VAL" ]]; then
+        # Strip strikethrough and check for "None"
+        DEP_VAL_CLEAN=$(strip_strikethrough "$DEP_VAL")
+        if [[ "$DEP_VAL_CLEAN" != "None" ]]; then
+            # Split on comma and validate each
+            IFS=',' read -ra DEPS <<< "$DEP_VAL"
+            for dep in "${DEPS[@]}"; do
+                # Trim whitespace
+                dep=$(echo "$dep" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+                # Strip strikethrough for validation
+                dep_clean=$(strip_strikethrough "$dep")
+                # Check for plain text issue reference (e.g., #123)
+                if [[ "$dep_clean" =~ ^#[0-9]+$ ]]; then
+                    emit_fail "II04: Dependencies must use link format, not plain text: '$dep'. See: .github/scripts/docs/II04.md"
+                    FAILED=1
+                # Check for plain text milestone reference (e.g., M38)
+                elif [[ "$dep_clean" =~ ^M[0-9]+$ ]]; then
+                    emit_fail "II04: Dependencies must use link format, not plain text: '$dep'. See: .github/scripts/docs/II04.md"
+                    FAILED=1
+                # Must be a valid markdown link (issue or milestone)
+                elif ! is_markdown_link "$dep"; then
+                    emit_fail "II04: Invalid dependency format: '$dep'. See: .github/scripts/docs/II04.md"
+                    FAILED=1
+                fi
+            done
+        fi
+    fi
+
+    # II05: Validate tier value (use cleaned value, strikethrough is valid)
+    if [[ -n "$TIER_VAL" ]]; then
+        case "$TIER_VAL_CLEAN" in
+            simple|testable|critical|milestone)
+                # Valid
+                ;;
+            *)
+                emit_fail "II05: Invalid tier value: '$TIER_VAL'. See: .github/scripts/docs/II05.md"
+                FAILED=1
+                ;;
+        esac
+    fi
+done <<< "$TABLE_ROWS"
+
+# II07 and II08: Row sequence validation
+# These checks operate on the full sequence of table rows (including description and child reference rows)
+# to validate that issue rows are followed by description rows and that strikethrough is consistent.
+
+# II07 grandfathering: only enforce for docs created on or after this date
+II07_CUTOFF="2026-02-16"
+
+# Helper: check if the doc predates the II07 cutoff
+ii07_grandfathered() {
+    local file="$1"
+    local creation_info
+    creation_info=$("$SCRIPT_DIR/../get-file-creation-commit.sh" "$file" 2>/dev/null) || return 1
+    local file_date
+    file_date=$(echo "$creation_info" | sed 's/.*"date": "\([0-9-]*\)T.*/\1/')
+    [[ "$file_date" < "$II07_CUTOFF" ]]
+}
+
+# Helper: check if a row has strikethrough on its first cell content
+row_has_strikethrough() {
+    local row="$1"
+    local first_cell
+    first_cell=$(echo "$row" | awk -F'|' '{ gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2 }')
+    [[ "$first_cell" =~ ^~~ ]]
+}
+
+# Helper: check if a row is a description row (| _text_ | | | or | ~~_text_~~ | | |)
+is_description_row() {
+    local row="$1"
+    [[ "$row" =~ ^\|\ *_ ]] || [[ "$row" =~ ^\|\ *~~_ ]]
+}
+
+# Helper: check if a row is a child reference row (| ^_text_ | | | or | ~~^_text_~~ | | |)
+is_child_ref_row() {
+    local row="$1"
+    [[ "$row" =~ ^\|\ *\^_ ]] || [[ "$row" =~ ^\|\ *~~\^_ ]]
+}
+
+# Helper: check if a row is an issue/milestone data row (not header, separator, description, or child ref)
+is_data_row() {
+    local row="$1"
+    [[ "$row" =~ ^\| ]] && ! [[ "$row" =~ ^\|\ *- ]] && ! [[ "$row" =~ ^\|\ *Issue ]] && \
+        ! is_description_row "$row" && ! is_child_ref_row "$row"
+}
+
+# Determine if II07 applies to this doc
+ENFORCE_II07=true
+if ii07_grandfathered "$DOC_PATH"; then
+    ENFORCE_II07=false
+fi
+
+# Extract ALL table rows (including description and child reference rows, but not header/separator)
+# We need the full sequence to check row ordering
+ALL_TABLE_ROWS=$(echo "$ISSUES_SECTION" | awk '
+    /^\|/ && !/^\| *-/ && !/^\| *Issue/ { print }
+')
+
+# Build an array of all rows for sequential analysis
+declare -a ROW_ARRAY
+ROW_INDEX=0
+while IFS= read -r row; do
+    [[ -z "$row" ]] && continue
+    ROW_ARRAY[$ROW_INDEX]="$row"
+    ROW_INDEX=$((ROW_INDEX + 1))
+done <<< "$ALL_TABLE_ROWS"
+
+TOTAL_ROWS=${#ROW_ARRAY[@]}
+
+# Walk through rows and validate II07/II08
+i=0
+while [[ $i -lt $TOTAL_ROWS ]]; do
+    row="${ROW_ARRAY[$i]}"
+
+    if is_data_row "$row"; then
+        # This is an issue or milestone row
+        ISSUE_STRIKETHROUGH=false
+        if row_has_strikethrough "$row"; then
+            ISSUE_STRIKETHROUGH=true
+        fi
+
+        # Extract the issue identifier for error messages
+        ISSUE_ID=$(echo "$row" | awk -F'|' '{ gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2 }')
+
+        # Look at the next row(s)
+        NEXT_IDX=$((i + 1))
+        HAS_CHILD_REF=false
+        HAS_DESCRIPTION=false
+
+        # Check for optional child reference row
+        if [[ $NEXT_IDX -lt $TOTAL_ROWS ]] && is_child_ref_row "${ROW_ARRAY[$NEXT_IDX]}"; then
+            HAS_CHILD_REF=true
+            CHILD_REF_ROW="${ROW_ARRAY[$NEXT_IDX]}"
+
+            # II08: child reference row strikethrough must match issue row
+            if [[ "$ISSUE_STRIKETHROUGH" == true ]] && ! row_has_strikethrough "$CHILD_REF_ROW"; then
+                emit_fail "II08: Struck-through issue row has non-struck child reference row: '$ISSUE_ID'. See: .github/scripts/docs/II08.md"
+                FAILED=1
+            fi
+
+            # II06: Validate child design reference link points to existing file
+            CHILD_CELL=$(echo "$CHILD_REF_ROW" | awk -F'|' '{ gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2 }')
+            # Strip strikethrough if present
+            CHILD_CELL_CLEAN=$(echo "$CHILD_CELL" | sed 's/^~~//;s/~~$//')
+            # Extract path from ^_Child: [DESIGN-name.md](path)_
+            II06_REF_PATH=$(echo "$CHILD_CELL_CLEAN" | grep -oE '\]\([^)]+\)' | sed 's/^\](\(.*\))$/\1/' || true)
+
+            if [[ -n "$II06_REF_PATH" ]]; then
+                # Check for cross-repo references (absolute URLs)
+                if [[ "$II06_REF_PATH" =~ ^https?:// ]]; then
+                    emit_pass "II06: Child reference in '$ISSUE_ID' is a cross-repo URL, skipping validation"
+                else
+                    # Resolve relative to the design doc's directory
+                    II06_DOC_DIR=$(dirname "$DOC_PATH")
+                    II06_CHILD_PATH="$II06_DOC_DIR/$II06_REF_PATH"
+
+                    # Check if path resolves outside repo root
+                    II06_REPO_ROOT=$(cd "$II06_DOC_DIR" && git rev-parse --show-toplevel 2>/dev/null || echo "")
+                    II06_IS_CROSS_REPO=false
+                    if [[ -n "$II06_REPO_ROOT" ]]; then
+                        II06_REAL_PATH=$(cd "$II06_DOC_DIR" && realpath -m "$II06_REF_PATH" 2>/dev/null || echo "$II06_CHILD_PATH")
+                        if [[ ! "$II06_REAL_PATH" =~ ^"$II06_REPO_ROOT" ]]; then
+                            II06_IS_CROSS_REPO=true
+                        fi
+                    fi
+
+                    if [[ "$II06_IS_CROSS_REPO" == true ]]; then
+                        emit_pass "II06: Child reference in '$ISSUE_ID' points outside repo, skipping validation"
+                    elif [[ ! -f "$II06_CHILD_PATH" ]]; then
+                        emit_fail "II06: Child reference in '$ISSUE_ID' points to nonexistent file: '$II06_REF_PATH'. See: .github/scripts/docs/II06.md"
+                        FAILED=1
+                    fi
+                fi
+            fi
+
+            NEXT_IDX=$((NEXT_IDX + 1))
+        fi
+
+        # Check for description row
+        if [[ $NEXT_IDX -lt $TOTAL_ROWS ]] && is_description_row "${ROW_ARRAY[$NEXT_IDX]}"; then
+            HAS_DESCRIPTION=true
+            DESC_ROW="${ROW_ARRAY[$NEXT_IDX]}"
+
+            # II08: description row strikethrough must match issue row
+            if [[ "$ISSUE_STRIKETHROUGH" == true ]] && ! row_has_strikethrough "$DESC_ROW"; then
+                emit_fail "II08: Struck-through issue row has non-struck description row: '$ISSUE_ID'. See: .github/scripts/docs/II08.md"
+                FAILED=1
+            fi
+        fi
+
+        # II07: issue row must be followed by a description row
+        if [[ "$ENFORCE_II07" == true ]] && [[ "$HAS_DESCRIPTION" == false ]]; then
+            emit_fail "II07: Issue row missing required description row: '$ISSUE_ID'. See: .github/scripts/docs/II07.md"
+            FAILED=1
+        fi
+    fi
+
+    i=$((i + 1))
+done
+
+# Return appropriate exit code
+if [[ "$FAILED" -eq 0 ]]; then
+    exit $EXIT_PASS
+else
+    exit $EXIT_FAIL
+fi

--- a/.github/scripts/checks/issue-status.sh
+++ b/.github/scripts/checks/issue-status.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# issue-status.sh - Validate strikethrough formatting matches GitHub issue status
+#
+# Validates that issues/milestones marked with strikethrough in the Implementation
+# Issues table are actually closed in GitHub, and vice versa.
+#
+# Usage:
+#   issue-status.sh <doc-path> [--pr <number>]
+#
+# Options:
+#   --pr <number>   Consider issues that will be closed by this PR as "closed"
+#
+# Exit codes:
+#   0 - All checks passed
+#   1 - One or more checks failed
+#   2 - Operational error
+#
+# Environment:
+#   GH_TOKEN - GitHub token for API access (optional but recommended)
+#
+# Notes:
+#   - Requires gh CLI and jq
+#   - Graceful degradation: warns but doesn't fail if GitHub API unavailable
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+# Validate arguments
+if [[ $# -lt 1 ]]; then
+    echo "Error: missing required argument <doc-path>" >&2
+    exit $EXIT_ERROR
+fi
+
+DOC_PATH="$1"
+shift
+
+PR_NUMBER=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --pr requires a PR number" >&2
+                exit $EXIT_ERROR
+            fi
+            PR_NUMBER="$2"
+            shift 2
+            ;;
+        *)
+            echo "Error: unknown option: $1" >&2
+            exit $EXIT_ERROR
+            ;;
+    esac
+done
+
+# Check file exists
+if [[ ! -f "$DOC_PATH" ]]; then
+    echo "Error: file not found: $DOC_PATH" >&2
+    exit $EXIT_ERROR
+fi
+
+# Export for emit_fail to include in error messages (when called standalone)
+export VALIDATE_DOC_PATH="${VALIDATE_DOC_PATH:-$DOC_PATH}"
+
+# Check for required tools
+if ! command -v gh &> /dev/null; then
+    echo "Warning: gh CLI not found, skipping issue status validation" >&2
+    exit $EXIT_PASS
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq required but not found" >&2
+    exit $EXIT_ERROR
+fi
+
+# Get sibling scripts directory
+CI_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Extract issues from design doc
+DESIGN_ISSUES=$("$CI_DIR/extract-design-issues.sh" "$DOC_PATH" 2>/dev/null) || {
+    # No Implementation Issues section - nothing to validate
+    exit $EXIT_PASS
+}
+
+# Get list of issues that will be closed by the PR
+CLOSING_ISSUES="[]"
+if [[ -n "$PR_NUMBER" ]]; then
+    CLOSING_ISSUES=$("$CI_DIR/extract-closing-issues.sh" --pr "$PR_NUMBER" 2>/dev/null) || CLOSING_ISSUES="[]"
+fi
+
+# Get GitHub status for all issues/milestones (batch query)
+# Exit code 1 = partial failure (some issues not found); still usable
+# Exit code 2 = operational error (missing tools, bad input)
+GH_STATUS_EXIT=0
+GITHUB_STATUS=$("$CI_DIR/get-github-status.sh" --from-doc "$DOC_PATH") || GH_STATUS_EXIT=$?
+if [[ $GH_STATUS_EXIT -eq 2 ]]; then
+    echo "Error: could not query GitHub API" >&2
+    exit $EXIT_FAIL
+fi
+
+FAILED=0
+
+# Process each entry in the design doc (flatten all milestones)
+ENTRIES=$(echo "$DESIGN_ISSUES" | jq -c '.milestones[].entries[]')
+
+while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+
+    TYPE=$(echo "$entry" | jq -r '.type')
+    NUMBER=$(echo "$entry" | jq -r '.number')
+    TITLE=$(echo "$entry" | jq -r '.title')
+    COMPLETED=$(echo "$entry" | jq -r '.completed')
+
+    # Skip entries without a number (named milestones without ID)
+    if [[ "$NUMBER" == "null" || -z "$NUMBER" ]]; then
+        continue
+    fi
+
+    # Get actual status from cached GitHub data
+    if [[ "$TYPE" == "issue" ]]; then
+        ACTUAL_STATUS=$(echo "$GITHUB_STATUS" | jq -r ".issues[\"$NUMBER\"] // \"unknown\"")
+    else
+        ACTUAL_STATUS=$(echo "$GITHUB_STATUS" | jq -r ".milestones[\"$NUMBER\"] // \"unknown\"")
+    fi
+
+    # Skip if we couldn't get status
+    if [[ "$ACTUAL_STATUS" == "unknown" ]]; then
+        continue
+    fi
+
+    # Check if issue will be closed by this PR
+    WILL_BE_CLOSED="false"
+    if [[ "$TYPE" == "issue" && "$CLOSING_ISSUES" != "[]" ]]; then
+        if echo "$CLOSING_ISSUES" | jq -e "index($NUMBER)" > /dev/null 2>&1; then
+            WILL_BE_CLOSED="true"
+        fi
+    fi
+
+    # Determine effective status (considering PR closures)
+    EFFECTIVE_STATUS="$ACTUAL_STATUS"
+    if [[ "$WILL_BE_CLOSED" == "true" ]]; then
+        EFFECTIVE_STATUS="closed"
+    fi
+
+    # Validate: strikethrough should match closed status
+    if [[ "$COMPLETED" == "true" ]]; then
+        # Marked complete - should be closed
+        if [[ "$EFFECTIVE_STATUS" != "closed" ]]; then
+            emit_fail "IS01: #$NUMBER marked complete but is $ACTUAL_STATUS in GitHub. See: .github/scripts/docs/IS01.md"
+            FAILED=1
+        fi
+    else
+        # Not marked complete - should be open
+        if [[ "$EFFECTIVE_STATUS" == "closed" ]]; then
+            if [[ "$WILL_BE_CLOSED" == "true" ]]; then
+                emit_fail "IS02: #$NUMBER will be closed by this PR but is not marked complete. See: .github/scripts/docs/IS02.md"
+            else
+                emit_fail "IS02: #$NUMBER is closed in GitHub but not marked complete. See: .github/scripts/docs/IS02.md"
+            fi
+            FAILED=1
+        fi
+    fi
+done <<< "$ENTRIES"
+
+# Return appropriate exit code
+if [[ "$FAILED" -eq 0 ]]; then
+    exit $EXIT_PASS
+else
+    exit $EXIT_FAIL
+fi

--- a/.github/scripts/checks/mermaid.sh
+++ b/.github/scripts/checks/mermaid.sh
@@ -1,0 +1,1024 @@
+#!/usr/bin/env bash
+#
+# mermaid.sh - Validate Mermaid dependency diagrams in design documents
+#
+# Implements mermaid diagram validation rules:
+#   MM01: Use 'graph', not 'flowchart'
+#   MM02: Direction (LR or TD) required
+#   MM03: No edges inside subgraph blocks
+#   MM04: Class definitions must come after edges
+#   MM05: Valid class names (done, ready, blocked, needsDesign, needsPrd, needsSpike, needsDecision, tracksDesign, tracksPlan)
+#   MM06: Issue in table must appear in diagram
+#   MM07: Diagram only allowed in "Planned" status
+#   MM08: Only one mermaid diagram per document
+#   MM09: Issue in diagram must appear in table (no orphans)
+#   MM10: Node naming convention: I<number> or M<number>
+#   MM11: Every node must have a class assigned
+#   MM12: If classDef present, colors must be standardized
+#   MM13: If subgraph styling present, colors must be standardized
+#   MM14: Legend line required after diagram
+#   MM15: Class must match actual issue status (requires gh CLI)
+#   MM16a: needs-design label must use needsDesign class
+#   MM16b: needsDesign class must have needs-design label
+#   MM16c: tracks-design label must use tracksDesign class
+#   MM16d: tracksDesign class must have tracks-design label
+#   MM16e: needs-prd label must use needsPrd class
+#   MM16f: needsPrd class must have needs-prd label
+#   MM16g: needs-spike label must use needsSpike class
+#   MM16h: needsSpike class must have needs-spike label
+#   MM16i: needs-decision label must use needsDecision class
+#   MM16j: needsDecision class must have needs-decision label
+#   MM16k: tracks-plan label must use tracksPlan class
+#   MM16l: tracksPlan class must have tracks-plan label
+#   MM17: Node with no open blockers cannot have class 'blocked'
+#   MM18: Node with open blocker cannot have class 'ready'
+#   MM19: Node with open blocker cannot have class 'needsDesign', 'needsPrd', 'needsSpike', 'needsDecision', 'tracksDesign', or 'tracksPlan'
+#   MM20: Parent-child Mermaid consistency (class matches child design status)
+#   MM21: tracksDesign/tracksPlan nodes must have child reference rows (and vice versa)
+#
+# Usage:
+#   mermaid.sh [-q|--quiet] [--skip-status-check] [--github-state <file>] [--pr <number>] <doc-path>
+#
+# Options:
+#   -q, --quiet              Suppress [PASS] messages, only show failures
+#   --skip-status-check      Skip MM15-MM18 (GitHub status validation)
+#   --github-state <file>    Read node state from JSON file instead of GitHub API
+#   --pr <number>            PR number; issues closed by this PR expect 'done' class
+#
+# Exit codes:
+#   0 - All checks passed
+#   1 - One or more checks failed
+#   2 - Operational error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+CI_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Valid class names and their standard colors
+declare -A VALID_CLASS_COLORS=(
+    ["done"]="#c8e6c9"
+    ["ready"]="#bbdefb"
+    ["blocked"]="#fff9c4"
+    ["needsDesign"]="#e1bee7"
+    ["needsPrd"]="#b3e5fc"
+    ["needsSpike"]="#ffcdd2"
+    ["needsDecision"]="#d1c4e9"
+    ["tracksDesign"]="#FFE0B2"
+    ["tracksPlan"]="#FFE0B2"
+)
+
+# Parse arguments
+SKIP_STATUS_CHECK=0
+PR_NUMBER=""
+GITHUB_STATE_FILE=""
+DOC_PATH=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -q|--quiet)
+            export QUIET_MODE=1
+            shift
+            ;;
+        --skip-status-check)
+            SKIP_STATUS_CHECK=1
+            shift
+            ;;
+        --github-state)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --github-state requires a file path" >&2
+                exit $EXIT_ERROR
+            fi
+            GITHUB_STATE_FILE="$2"
+            shift 2
+            ;;
+        --pr)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --pr requires a number" >&2
+                exit $EXIT_ERROR
+            fi
+            PR_NUMBER="$2"
+            shift 2
+            ;;
+        -*)
+            echo "Error: unknown option: $1" >&2
+            exit $EXIT_ERROR
+            ;;
+        *)
+            DOC_PATH="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$DOC_PATH" ]]; then
+    echo "Error: missing required argument <doc-path>" >&2
+    exit $EXIT_ERROR
+fi
+
+# Check file exists
+if [[ ! -f "$DOC_PATH" ]]; then
+    echo "Error: file not found: $DOC_PATH" >&2
+    exit $EXIT_ERROR
+fi
+
+# Export for emit_fail to include in error messages (when called standalone)
+export VALIDATE_DOC_PATH="${VALIDATE_DOC_PATH:-$DOC_PATH}"
+
+# Get normalized status from frontmatter (uses shared function from common.sh)
+FM_STATUS=$(get_frontmatter_status "$DOC_PATH")
+
+# Count mermaid code blocks
+# Note: grep -c returns 0 count with exit 1, so fallback must be outside subshell
+MERMAID_COUNT=$(grep -c '```mermaid' "$DOC_PATH" 2>/dev/null) || MERMAID_COUNT=0
+
+# If no mermaid diagram, check if Planned status requires one
+if [[ "$MERMAID_COUNT" -eq 0 ]]; then
+    if [[ "$FM_STATUS" == "Planned" ]]; then
+        emit_fail "MM07: 'Planned' status requires an issue dependency diagram. See: .github/scripts/docs/MM07.md"
+        exit $EXIT_FAIL
+    fi
+    exit $EXIT_PASS
+fi
+
+# Extract each mermaid block separately and find the one with I<number> or M<number> nodes
+# This is the issue dependency diagram - other diagrams are ignored for validation
+DEPENDENCY_DIAGRAM_CONTENT=""
+ALL_DEPENDENCY_NODES=""
+ISSUE_NODES=""
+MILESTONE_NODES=""
+
+# Use a unique separator that won't appear in mermaid diagrams
+BLOCK_SEP="__MERMAID_BLOCK_SEP_$$__"
+
+# Extract all blocks separated by the unique separator
+ALL_BLOCKS=$(awk -v sep="$BLOCK_SEP" '
+    /^```mermaid/ { in_mermaid = 1; block = ""; next }
+    /^```/ && in_mermaid {
+        in_mermaid = 0
+        print block
+        print sep
+        next
+    }
+    in_mermaid { block = block (block ? "\n" : "") $0 }
+' "$DOC_PATH")
+
+# Process each block
+current_block=""
+while IFS= read -r line; do
+    if [[ "$line" == "$BLOCK_SEP" ]]; then
+        # End of block, process it
+        if [[ -n "$current_block" ]]; then
+            # Check if this block contains I<number> nodes
+            block_issue_nodes=$(echo "$current_block" | grep -oE '\bI[0-9]+\b' | sort -u || true)
+
+            # Check for M<number> nodes (excluding subgraph names)
+            block_subgraph_ids=$(echo "$current_block" | grep -E '^\s*subgraph\s+' | \
+                sed 's/^\s*subgraph\s*//' | sed 's/\[.*$//' | tr -d ' ' || true)
+            block_milestone_nodes_raw=$(echo "$current_block" | grep -oE '\bM[0-9]+\b' | sort -u || true)
+            block_milestone_nodes=""
+            if [[ -n "$block_milestone_nodes_raw" ]]; then
+                while IFS= read -r mnode; do
+                    [[ -z "$mnode" ]] && continue
+                    if [[ -z "$block_subgraph_ids" ]] || ! echo "$block_subgraph_ids" | grep -qE "^${mnode}$"; then
+                        block_milestone_nodes=$(printf '%s\n%s' "$block_milestone_nodes" "$mnode")
+                    fi
+                done <<< "$block_milestone_nodes_raw"
+                block_milestone_nodes=$(echo "$block_milestone_nodes" | grep -v '^$' | sort -u || true)
+            fi
+
+            # If this block has I<number> or M<number> nodes, it's the dependency diagram
+            if [[ -n "$block_issue_nodes" || -n "$block_milestone_nodes" ]]; then
+                DEPENDENCY_DIAGRAM_CONTENT="$current_block"
+                ISSUE_NODES="$block_issue_nodes"
+                MILESTONE_NODES="$block_milestone_nodes"
+                break  # Only validate the first dependency diagram found
+            fi
+        fi
+        current_block=""
+    else
+        # Accumulate lines into current block
+        if [[ -z "$current_block" ]]; then
+            current_block="$line"
+        else
+            current_block="$current_block"$'\n'"$line"
+        fi
+    fi
+done <<< "$ALL_BLOCKS"
+
+ALL_DEPENDENCY_NODES=$(printf '%s\n%s' "$ISSUE_NODES" "$MILESTONE_NODES" | grep -v '^$' | sort -u || true)
+HAS_ISSUE_DIAGRAM=0
+if [[ -n "$ALL_DEPENDENCY_NODES" ]]; then
+    HAS_ISSUE_DIAGRAM=1
+fi
+
+# MM07: Issue dependency diagram rules
+# - Issue dependency diagrams (with I<number> nodes) ONLY allowed in Planned status
+# - Non-issue diagrams (documentation, examples) allowed in any status
+# - Planned status MUST have exactly one issue dependency diagram
+if [[ "$HAS_ISSUE_DIAGRAM" -eq 1 ]]; then
+    if [[ "$FM_STATUS" != "Planned" ]]; then
+        emit_fail "MM07: Issue dependency diagram (with I<number> or M<number> nodes) only allowed in 'Planned' status, found in '$FM_STATUS'. See: .github/scripts/docs/MM07.md"
+        exit $EXIT_FAIL
+    fi
+else
+    # No issue dependency diagram - check if Planned status requires one
+    if [[ "$FM_STATUS" == "Planned" ]]; then
+        emit_fail "MM07: 'Planned' status requires an issue dependency diagram (with I<number> or M<number> nodes). See: .github/scripts/docs/MM07.md"
+        exit $EXIT_FAIL
+    fi
+    # Non-issue diagrams in non-Planned status - skip all further validation
+    exit $EXIT_PASS
+fi
+
+# At this point: we have an issue dependency diagram in Planned status
+# Continue with detailed validation
+
+# MM08: Only one issue dependency diagram per doc
+# Count mermaid blocks that contain I<number> or M<number> nodes (not just any diagram)
+ISSUE_DIAGRAM_COUNT=$(awk '
+    /^```mermaid/ { in_mermaid = 1; block = ""; next }
+    /^```/ && in_mermaid {
+        in_mermaid = 0
+        # Check if block contains I<number> or M<number> nodes (not as subgraph names)
+        if (match(block, /\bI[0-9]+\b/) || match(block, /\bM[0-9]+\[/)) {
+            count++
+        }
+        next
+    }
+    in_mermaid { block = block "\n" $0 }
+    END { print count+0 }
+' "$DOC_PATH")
+
+if [[ "$ISSUE_DIAGRAM_COUNT" -gt 1 ]]; then
+    emit_fail "MM08: Only one issue dependency diagram allowed per document, found $ISSUE_DIAGRAM_COUNT. See: .github/scripts/docs/MM08.md"
+    exit $EXIT_FAIL
+fi
+
+# Use only the dependency diagram content for validation
+MERMAID_CONTENT="$DEPENDENCY_DIAGRAM_CONTENT"
+
+FAILED=0
+
+# MM01: Check for flowchart keyword
+if echo "$MERMAID_CONTENT" | grep -qE '^flowchart\b'; then
+    emit_fail "MM01: Mermaid diagram should use 'graph', not 'flowchart'. See: .github/scripts/docs/MM01.md"
+    FAILED=1
+fi
+
+# MM02: Check for direction (LR or TD)
+GRAPH_LINE=$(echo "$MERMAID_CONTENT" | grep -E '^graph\b' | head -1 || true)
+if [[ -n "$GRAPH_LINE" ]]; then
+    if ! echo "$GRAPH_LINE" | grep -qE '^graph\s+(LR|TD)\b'; then
+        emit_fail "MM02: Mermaid diagram missing direction (LR or TD). See: .github/scripts/docs/MM02.md"
+        FAILED=1
+    fi
+fi
+
+# MM03: Check for edges inside subgraph blocks
+# Track subgraph depth and detect edges (-->, ---)
+IN_SUBGRAPH=0
+LINE_NUM=0
+while IFS= read -r line; do
+    LINE_NUM=$((LINE_NUM + 1))
+    # Skip empty lines and comments
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*%% ]] && continue
+
+    # Track subgraph entry/exit
+    if echo "$line" | grep -qE '^\s*subgraph\b'; then
+        IN_SUBGRAPH=$((IN_SUBGRAPH + 1))
+    elif echo "$line" | grep -qE '^\s*end\b'; then
+        IN_SUBGRAPH=$((IN_SUBGRAPH - 1))
+        [[ $IN_SUBGRAPH -lt 0 ]] && IN_SUBGRAPH=0
+    fi
+
+    # Check for edge while inside subgraph
+    if [[ $IN_SUBGRAPH -gt 0 ]]; then
+        if echo "$line" | grep -qE -- '-->|---'; then
+            # Extract the edge for error message
+            EDGE=$(echo "$line" | grep -oE -- '[A-Za-z0-9_]+\s*(-->|---)\s*[A-Za-z0-9_]+' | head -1)
+            emit_fail "MM03: Mermaid edge inside subgraph will not render: '$EDGE'. See: .github/scripts/docs/MM03.md"
+            FAILED=1
+        fi
+    fi
+done <<< "$MERMAID_CONTENT"
+
+# MM04: Check class definitions come after all edges
+# Find line numbers of last edge and first class/classDef
+LAST_EDGE_LINE=0
+FIRST_CLASS_LINE=0
+LINE_NUM=0
+while IFS= read -r line; do
+    LINE_NUM=$((LINE_NUM + 1))
+    if echo "$line" | grep -qE -- '-->|---'; then
+        LAST_EDGE_LINE=$LINE_NUM
+    fi
+    if echo "$line" | grep -qE '^\s*(class|classDef)\b'; then
+        if [[ $FIRST_CLASS_LINE -eq 0 ]]; then
+            FIRST_CLASS_LINE=$LINE_NUM
+        fi
+    fi
+done <<< "$MERMAID_CONTENT"
+
+if [[ $FIRST_CLASS_LINE -gt 0 && $LAST_EDGE_LINE -gt $FIRST_CLASS_LINE ]]; then
+    emit_fail "MM04: Class definition before diagram edges. See: .github/scripts/docs/MM04.md"
+    FAILED=1
+fi
+
+# MM05: Validate class names are valid
+# Extract class assignments: class NodeA,NodeB classname
+while IFS= read -r line; do
+    if echo "$line" | grep -qE '^\s*class\s+'; then
+        # Extract class name (last word on the line)
+        CLASS_NAME=$(echo "$line" | awk '{print $NF}')
+        if [[ ! "${VALID_CLASS_COLORS[$CLASS_NAME]+isset}" ]]; then
+            emit_fail "MM05: Invalid class '$CLASS_NAME'. Valid: done, ready, blocked, needsDesign, needsPrd, needsSpike, needsDecision, tracksDesign, tracksPlan. See: .github/scripts/docs/MM05.md"
+            FAILED=1
+        fi
+    fi
+done <<< "$MERMAID_CONTENT"
+
+# MM12: If classDef present, validate colors are standardized
+while IFS= read -r line; do
+    if echo "$line" | grep -qE '^\s*classDef\s+'; then
+        # Extract class name and color
+        CLASS_NAME=$(echo "$line" | awk '{print $2}')
+        COLOR=$(echo "$line" | grep -oE 'fill:#[a-fA-F0-9]{6}' | sed 's/fill://' || true)
+
+        if [[ -n "$COLOR" && "${VALID_CLASS_COLORS[$CLASS_NAME]+isset}" ]]; then
+            EXPECTED_COLOR="${VALID_CLASS_COLORS[$CLASS_NAME]}"
+            if [[ "${COLOR,,}" != "${EXPECTED_COLOR,,}" ]]; then
+                emit_fail "MM12: classDef '$CLASS_NAME' has wrong color '$COLOR', expected '$EXPECTED_COLOR'. See: .github/scripts/docs/MM12.md"
+                FAILED=1
+            fi
+        fi
+    fi
+done <<< "$MERMAID_CONTENT"
+
+# Extract all node definitions (I<number>["..."] or M<number>["..."])
+# Use the already extracted dependency nodes (issues + milestones)
+DIAGRAM_NODES="$ALL_DEPENDENCY_NODES"
+
+# MM10: Validate node naming convention
+# Find any node definitions that don't follow I<number> or M<number> pattern
+# First, extract subgraph names to exclude them (subgraphs are not issue/milestone nodes)
+SUBGRAPH_NAMES=$(echo "$MERMAID_CONTENT" | grep -E '^\s*subgraph\s+' | \
+    sed 's/^\s*subgraph\s*//' | sed 's/\[.*$//' | tr -d ' ' || true)
+
+# Look for node definitions like: NodeName["label"]
+OTHER_NODES=$(echo "$MERMAID_CONTENT" | grep -oE '\b[A-Za-z][A-Za-z0-9_]*\[' | sed 's/\[$//' | grep -vE '^[IM][0-9]+$' || true)
+if [[ -n "$OTHER_NODES" ]]; then
+    while IFS= read -r node; do
+        [[ -z "$node" ]] && continue
+        # Skip known keywords
+        [[ "$node" == "subgraph" || "$node" == "graph" || "$node" == "end" ]] && continue
+        # Skip subgraph names (they're allowed to be non-I/M<number>)
+        if [[ -n "$SUBGRAPH_NAMES" ]] && echo "$SUBGRAPH_NAMES" | grep -qE "^${node}$"; then
+            continue
+        fi
+        emit_fail "MM10: Node '$node' doesn't follow naming convention I<number> or M<number>. See: .github/scripts/docs/MM10.md"
+        FAILED=1
+    done <<< "$OTHER_NODES"
+fi
+
+# Extract issue numbers from Implementation Issues table
+TABLE_ISSUES=""
+if grep -q "^## Implementation Issues" "$DOC_PATH"; then
+    TABLE_ISSUES=$("$CI_DIR/extract-design-issues.sh" "$DOC_PATH" 2>/dev/null | \
+        jq -r '.milestones[].entries[] | select(.type == "issue") | .number' 2>/dev/null | sort -n || true)
+fi
+
+# MM06: Issue in table must appear in diagram
+if [[ -n "$TABLE_ISSUES" ]]; then
+    while IFS= read -r issue_num; do
+        [[ -z "$issue_num" ]] && continue
+        NODE_ID="I${issue_num}"
+        if ! echo "$DIAGRAM_NODES" | grep -qE "^${NODE_ID}$"; then
+            emit_fail "MM06: Issue #$issue_num in table but not in diagram. See: .github/scripts/docs/MM06.md"
+            FAILED=1
+        fi
+    done <<< "$TABLE_ISSUES"
+fi
+
+# MM09: Issue in diagram must appear in table (no orphans)
+# Only check I-prefix nodes; M-prefix milestone nodes don't require table entries
+if [[ -n "$ISSUE_NODES" ]]; then
+    while IFS= read -r node; do
+        [[ -z "$node" ]] && continue
+        # Extract issue number from node ID (I123 -> 123)
+        ISSUE_NUM=$(echo "$node" | sed 's/^I//')
+        if [[ -n "$TABLE_ISSUES" ]]; then
+            if ! echo "$TABLE_ISSUES" | grep -qE "^${ISSUE_NUM}$"; then
+                emit_fail "MM09: Node $node in diagram but issue #$ISSUE_NUM not in table. See: .github/scripts/docs/MM09.md"
+                FAILED=1
+            fi
+        fi
+    done <<< "$ISSUE_NODES"
+fi
+
+# MM11: Every node must have a class assigned
+# Extract all nodes that have class assignments
+CLASSED_NODES=$(echo "$MERMAID_CONTENT" | grep -E '^\s*class\s+' | \
+    sed 's/^\s*class\s*//' | sed 's/\s*[a-zA-Z]*$//' | tr ',' '\n' | tr -d ' ' | sort -u)
+
+if [[ -n "$DIAGRAM_NODES" ]]; then
+    while IFS= read -r node; do
+        [[ -z "$node" ]] && continue
+        if ! echo "$CLASSED_NODES" | grep -qE "^${node}$"; then
+            emit_fail "MM11: Node '$node' has no class assigned. See: .github/scripts/docs/MM11.md"
+            FAILED=1
+        fi
+    done <<< "$DIAGRAM_NODES"
+fi
+
+# MM13: If subgraph styling present, validate colors are standardized
+# Standard: fill:#f5f5f5,stroke:#e0e0e0
+while IFS= read -r line; do
+    if echo "$line" | grep -qE '^\s*style\s+[A-Za-z]'; then
+        # Extract fill color if present
+        FILL_COLOR=$(echo "$line" | grep -oE 'fill:#[a-fA-F0-9]{6}' | sed 's/fill://' || true)
+        STROKE_COLOR=$(echo "$line" | grep -oE 'stroke:#[a-fA-F0-9]{6}' | sed 's/stroke://' || true)
+
+        if [[ -n "$FILL_COLOR" && "${FILL_COLOR,,}" != "#f5f5f5" ]]; then
+            emit_fail "MM13: Subgraph fill color '$FILL_COLOR' should be '#f5f5f5'. See: .github/scripts/docs/MM13.md"
+            FAILED=1
+        fi
+        if [[ -n "$STROKE_COLOR" && "${STROKE_COLOR,,}" != "#e0e0e0" ]]; then
+            emit_fail "MM13: Subgraph stroke color '$STROKE_COLOR' should be '#e0e0e0'. See: .github/scripts/docs/MM13.md"
+            FAILED=1
+        fi
+    fi
+done <<< "$MERMAID_CONTENT"
+
+# MM14: Legend line required after diagram
+# Look for "**Legend**:" pattern after the mermaid block
+LEGEND_LINE=$(awk '
+    /^```mermaid/ { in_mermaid = 1; next }
+    /^```/ && in_mermaid { in_mermaid = 0; after_mermaid = 1; next }
+    after_mermaid && /^\*\*Legend\*\*:/ { found = 1; exit }
+    after_mermaid && /^##/ { exit }  # Hit next section
+    END { print found ? "found" : "" }
+' "$DOC_PATH")
+
+if [[ -z "$LEGEND_LINE" ]]; then
+    emit_fail "MM14: Legend line required after diagram. Add: **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design. See: .github/scripts/docs/MM14.md"
+    FAILED=1
+fi
+
+# MM15: Validate class matches actual issue status
+# Only run if gh CLI is available, we have diagram nodes, and --skip-status-check not set
+if [[ "$SKIP_STATUS_CHECK" -eq 0 ]] && { [[ -n "$GITHUB_STATE_FILE" ]] || command -v gh &>/dev/null; } && [[ -n "$DIAGRAM_NODES" ]]; then
+    # Extract issues being closed by this PR (if --pr was provided)
+    CLOSING_ISSUES=""
+    if [[ -n "$PR_NUMBER" ]]; then
+        CLOSING_ISSUES=$("$CI_DIR/extract-closing-issues.sh" --pr "$PR_NUMBER" 2>/dev/null | jq -r '.[]' || true)
+    fi
+
+    # Build dependency map: for each node, list its blockers (nodes it depends on)
+    # Edge A --> B means A blocks B (B depends on A)
+    declare -A BLOCKERS
+    while IFS= read -r line; do
+        # Match edges: I/M nodes connected by --> or ---
+        if echo "$line" | grep -qE -- '[IM][0-9]+\s*(-->|---)\s*[IM][0-9]+'; then
+            # Extract source and target
+            SOURCE=$(echo "$line" | grep -oE '[IM][0-9]+' | head -1)
+            TARGET=$(echo "$line" | grep -oE '[IM][0-9]+' | tail -1)
+            if [[ -n "$SOURCE" && -n "$TARGET" && "$SOURCE" != "$TARGET" ]]; then
+                # Add source as a blocker of target
+                BLOCKERS[$TARGET]="${BLOCKERS[$TARGET]:-} $SOURCE"
+            fi
+        fi
+    done <<< "$MERMAID_CONTENT"
+
+    # Get actual class assignments from diagram
+    declare -A ACTUAL_CLASS
+    while IFS= read -r line; do
+        if echo "$line" | grep -qE '^\s*class\s+'; then
+            # Format: class I123,I456 done
+            CLASS_NAME=$(echo "$line" | awk '{print $NF}')
+            NODES_STR=$(echo "$line" | sed 's/^\s*class\s*//' | sed "s/\s*${CLASS_NAME}$//" | tr -d ' ')
+            IFS=',' read -ra NODE_LIST <<< "$NODES_STR"
+            for node in "${NODE_LIST[@]}"; do
+                [[ -n "$node" ]] && ACTUAL_CLASS[$node]="$CLASS_NAME"
+            done
+        fi
+    done <<< "$MERMAID_CONTENT"
+
+    # First pass: get state for all nodes
+    declare -A NODE_GITHUB_STATE   # OPEN or CLOSED
+    declare -A NODE_NEEDS_DESIGN   # true or false
+    declare -A NODE_NEEDS_PRD      # true or false
+    declare -A NODE_NEEDS_SPIKE    # true or false
+    declare -A NODE_NEEDS_DECISION # true or false
+    declare -A NODE_TRACKS_DESIGN  # true or false
+    declare -A NODE_TRACKS_PLAN    # true or false
+    declare -A NODE_LABELS         # human-readable label
+    declare -A NODE_IS_CLOSING     # true if PR closes it
+
+    if [[ -n "$GITHUB_STATE_FILE" ]]; then
+        # Load state from JSON file (for testing)
+        while IFS= read -r node; do
+            [[ -z "$node" ]] && continue
+            NODE_DATA=$(jq -r --arg n "$node" '.[$n] // empty' "$GITHUB_STATE_FILE")
+            if [[ -z "$NODE_DATA" ]]; then
+                continue
+            fi
+            NODE_GITHUB_STATE[$node]=$(echo "$NODE_DATA" | jq -r '.state')
+            HAS_ND=$(echo "$NODE_DATA" | jq -r '.labels // [] | map(select(. == "needs-design")) | length > 0')
+            NODE_NEEDS_DESIGN[$node]="$HAS_ND"
+            HAS_NP=$(echo "$NODE_DATA" | jq -r '.labels // [] | map(select(. == "needs-prd")) | length > 0')
+            NODE_NEEDS_PRD[$node]="$HAS_NP"
+            HAS_NS=$(echo "$NODE_DATA" | jq -r '.labels // [] | map(select(. == "needs-spike")) | length > 0')
+            NODE_NEEDS_SPIKE[$node]="$HAS_NS"
+            HAS_NDC=$(echo "$NODE_DATA" | jq -r '.labels // [] | map(select(. == "needs-decision")) | length > 0')
+            NODE_NEEDS_DECISION[$node]="$HAS_NDC"
+            HAS_TD=$(echo "$NODE_DATA" | jq -r '.labels // [] | map(select(. == "tracks-design")) | length > 0')
+            NODE_TRACKS_DESIGN[$node]="$HAS_TD"
+            HAS_TP=$(echo "$NODE_DATA" | jq -r '.labels // [] | map(select(. == "tracks-plan")) | length > 0')
+            NODE_TRACKS_PLAN[$node]="$HAS_TP"
+            if [[ "$node" =~ ^M ]]; then
+                NODE_LABELS[$node]="milestone #${node#M}"
+            else
+                NODE_LABELS[$node]="issue #${node#I}"
+            fi
+            NODE_IS_CLOSING[$node]="false"
+            if [[ "$node" =~ ^I[0-9]+$ && -n "$CLOSING_ISSUES" ]]; then
+                ISSUE_NUM="${node#I}"
+                if echo "$CLOSING_ISSUES" | grep -qE "^${ISSUE_NUM}$"; then
+                    NODE_IS_CLOSING[$node]="true"
+                fi
+            fi
+        done <<< "$DIAGRAM_NODES"
+    else
+        # Query GitHub API
+        REPO_NWO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
+
+        while IFS= read -r node; do
+            [[ -z "$node" ]] && continue
+
+            if [[ "$node" =~ ^M[0-9]+$ ]]; then
+                MILESTONE_NUM="${node#M}"
+                if [[ -z "$REPO_NWO" ]]; then
+                    continue
+                fi
+                MILESTONE_DATA=$(gh api "repos/${REPO_NWO}/milestones/${MILESTONE_NUM}" 2>/dev/null || true)
+                if [[ -z "$MILESTONE_DATA" ]]; then
+                    continue
+                fi
+                MS_STATE=$(echo "$MILESTONE_DATA" | jq -r '.state')
+                if [[ "$MS_STATE" == "closed" ]]; then
+                    NODE_GITHUB_STATE[$node]="CLOSED"
+                else
+                    NODE_GITHUB_STATE[$node]="OPEN"
+                fi
+                NODE_NEEDS_DESIGN[$node]="false"
+                NODE_NEEDS_PRD[$node]="false"
+                NODE_NEEDS_SPIKE[$node]="false"
+                NODE_NEEDS_DECISION[$node]="false"
+                NODE_TRACKS_DESIGN[$node]="false"
+                NODE_TRACKS_PLAN[$node]="false"
+                NODE_LABELS[$node]="milestone #$MILESTONE_NUM"
+            else
+                ISSUE_NUM="${node#I}"
+                ISSUE_DATA=$(gh issue view "$ISSUE_NUM" --json state,labels 2>/dev/null || true)
+                if [[ -z "$ISSUE_DATA" ]]; then
+                    continue
+                fi
+                NODE_GITHUB_STATE[$node]=$(echo "$ISSUE_DATA" | jq -r '.state')
+                NODE_NEEDS_DESIGN[$node]=$(echo "$ISSUE_DATA" | jq -r '.labels[]?.name' 2>/dev/null | grep -qE '^needs-design$' && echo "true" || echo "false")
+                NODE_NEEDS_PRD[$node]=$(echo "$ISSUE_DATA" | jq -r '.labels[]?.name' 2>/dev/null | grep -qE '^needs-prd$' && echo "true" || echo "false")
+                NODE_NEEDS_SPIKE[$node]=$(echo "$ISSUE_DATA" | jq -r '.labels[]?.name' 2>/dev/null | grep -qE '^needs-spike$' && echo "true" || echo "false")
+                NODE_NEEDS_DECISION[$node]=$(echo "$ISSUE_DATA" | jq -r '.labels[]?.name' 2>/dev/null | grep -qE '^needs-decision$' && echo "true" || echo "false")
+                NODE_TRACKS_DESIGN[$node]=$(echo "$ISSUE_DATA" | jq -r '.labels[]?.name' 2>/dev/null | grep -qE '^tracks-design$' && echo "true" || echo "false")
+                NODE_TRACKS_PLAN[$node]=$(echo "$ISSUE_DATA" | jq -r '.labels[]?.name' 2>/dev/null | grep -qE '^tracks-plan$' && echo "true" || echo "false")
+                NODE_LABELS[$node]="issue #$ISSUE_NUM"
+            fi
+
+            NODE_IS_CLOSING[$node]="false"
+            if [[ "$node" =~ ^I[0-9]+$ && -n "$CLOSING_ISSUES" ]]; then
+                ISSUE_NUM="${node#I}"
+                if echo "$CLOSING_ISSUES" | grep -qE "^${ISSUE_NUM}$"; then
+                    NODE_IS_CLOSING[$node]="true"
+                fi
+            fi
+        done <<< "$DIAGRAM_NODES"
+    fi
+
+    # Helper: check if a node has any open blockers (using GitHub state)
+    node_has_open_blocker() {
+        local node="$1"
+        local blocker_list="${BLOCKERS[$node]:-}"
+        for blocker in $blocker_list; do
+            local b_state="${NODE_GITHUB_STATE[$blocker]:-}"
+            local b_closing="${NODE_IS_CLOSING[$blocker]:-false}"
+            if [[ "$b_state" != "CLOSED" && "$b_closing" != "true" ]]; then
+                return 0
+            fi
+        done
+        return 1
+    }
+
+    # Second pass: validate class assignments against GitHub state
+    while IFS= read -r node; do
+        [[ -z "$node" ]] && continue
+
+        NODE_STATE="${NODE_GITHUB_STATE[$node]:-}"
+        [[ -z "$NODE_STATE" ]] && continue
+
+        HAS_NEEDS_DESIGN="${NODE_NEEDS_DESIGN[$node]:-false}"
+        HAS_NEEDS_PRD="${NODE_NEEDS_PRD[$node]:-false}"
+        HAS_NEEDS_SPIKE="${NODE_NEEDS_SPIKE[$node]:-false}"
+        HAS_NEEDS_DECISION="${NODE_NEEDS_DECISION[$node]:-false}"
+        HAS_TRACKS_DESIGN="${NODE_TRACKS_DESIGN[$node]:-false}"
+        HAS_TRACKS_PLAN="${NODE_TRACKS_PLAN[$node]:-false}"
+        NODE_LABEL="${NODE_LABELS[$node]:-$node}"
+        IS_CLOSING="${NODE_IS_CLOSING[$node]:-false}"
+        ACTUAL="${ACTUAL_CLASS[$node]:-}"
+        [[ -z "$ACTUAL" ]] && continue
+
+        # MM15: Closed/closing issues must be 'done', open issues must not be 'done'
+        if [[ "$IS_CLOSING" == "true" || "$NODE_STATE" == "CLOSED" ]]; then
+            if [[ "$ACTUAL" != "done" ]]; then
+                if [[ "$IS_CLOSING" == "true" ]]; then
+                    REASON="(PR closes this issue)"
+                else
+                    REASON="($NODE_LABEL is closed)"
+                fi
+                emit_fail "MM15: Node $node has class '$ACTUAL' but $NODE_LABEL requires 'done' $REASON. See: .github/scripts/docs/MM15.md"
+                FAILED=1
+            fi
+            continue
+        fi
+        if [[ "$ACTUAL" == "done" && "$NODE_STATE" == "OPEN" ]]; then
+            emit_fail "MM15: Node $node has class 'done' but $NODE_LABEL is open. See: .github/scripts/docs/MM15.md"
+            FAILED=1
+            continue
+        fi
+
+        # MM16a: needs-design label must use needsDesign class
+        # Exempt: 'blocked' is allowed when node has open blockers (blocked takes precedence)
+        if [[ "$HAS_NEEDS_DESIGN" == "true" && "$ACTUAL" != "needsDesign" ]]; then
+            if ! { [[ "$ACTUAL" == "blocked" ]] && node_has_open_blocker "$node"; }; then
+                emit_fail "MM16a: Node $node has class '$ACTUAL' but $NODE_LABEL has 'needs-design' label, expected 'needsDesign'. See: .github/scripts/docs/MM16.md"
+                FAILED=1
+            fi
+        fi
+
+        # MM16b: needsDesign class must have needs-design label
+        if [[ "$ACTUAL" == "needsDesign" && "$HAS_NEEDS_DESIGN" != "true" ]]; then
+            emit_fail "MM16b: Node $node has class 'needsDesign' but $NODE_LABEL lacks 'needs-design' label. See: .github/scripts/docs/MM16b.md"
+            FAILED=1
+        fi
+
+        # MM16c: tracks-design label must use tracksDesign class
+        # Exempt: 'blocked' is allowed when node has open blockers (blocked takes precedence)
+        if [[ "$HAS_TRACKS_DESIGN" == "true" && "$ACTUAL" != "tracksDesign" ]]; then
+            if ! { [[ "$ACTUAL" == "blocked" ]] && node_has_open_blocker "$node"; }; then
+                emit_fail "MM16c: Node $node has class '$ACTUAL' but $NODE_LABEL has 'tracks-design' label, expected 'tracksDesign'. See: .github/scripts/docs/MM16c.md"
+                FAILED=1
+            fi
+        fi
+
+        # MM16d: tracksDesign class must have tracks-design label
+        if [[ "$ACTUAL" == "tracksDesign" && "$HAS_TRACKS_DESIGN" != "true" ]]; then
+            emit_fail "MM16d: Node $node has class 'tracksDesign' but $NODE_LABEL lacks 'tracks-design' label. See: .github/scripts/docs/MM16d.md"
+            FAILED=1
+        fi
+
+        # MM16e: needs-prd label must use needsPrd class
+        # Exempt: 'blocked' is allowed when node has open blockers (blocked takes precedence)
+        if [[ "$HAS_NEEDS_PRD" == "true" && "$ACTUAL" != "needsPrd" ]]; then
+            if ! { [[ "$ACTUAL" == "blocked" ]] && node_has_open_blocker "$node"; }; then
+                emit_fail "MM16e: Node $node has class '$ACTUAL' but $NODE_LABEL has 'needs-prd' label, expected 'needsPrd'. See: .github/scripts/docs/MM16.md"
+                FAILED=1
+            fi
+        fi
+
+        # MM16f: needsPrd class must have needs-prd label
+        if [[ "$ACTUAL" == "needsPrd" && "$HAS_NEEDS_PRD" != "true" ]]; then
+            emit_fail "MM16f: Node $node has class 'needsPrd' but $NODE_LABEL lacks 'needs-prd' label. See: .github/scripts/docs/MM16.md"
+            FAILED=1
+        fi
+
+        # MM16g: needs-spike label must use needsSpike class
+        # Exempt: 'blocked' is allowed when node has open blockers (blocked takes precedence)
+        if [[ "$HAS_NEEDS_SPIKE" == "true" && "$ACTUAL" != "needsSpike" ]]; then
+            if ! { [[ "$ACTUAL" == "blocked" ]] && node_has_open_blocker "$node"; }; then
+                emit_fail "MM16g: Node $node has class '$ACTUAL' but $NODE_LABEL has 'needs-spike' label, expected 'needsSpike'. See: .github/scripts/docs/MM16.md"
+                FAILED=1
+            fi
+        fi
+
+        # MM16h: needsSpike class must have needs-spike label
+        if [[ "$ACTUAL" == "needsSpike" && "$HAS_NEEDS_SPIKE" != "true" ]]; then
+            emit_fail "MM16h: Node $node has class 'needsSpike' but $NODE_LABEL lacks 'needs-spike' label. See: .github/scripts/docs/MM16.md"
+            FAILED=1
+        fi
+
+        # MM16i: needs-decision label must use needsDecision class
+        # Exempt: 'blocked' is allowed when node has open blockers (blocked takes precedence)
+        if [[ "$HAS_NEEDS_DECISION" == "true" && "$ACTUAL" != "needsDecision" ]]; then
+            if ! { [[ "$ACTUAL" == "blocked" ]] && node_has_open_blocker "$node"; }; then
+                emit_fail "MM16i: Node $node has class '$ACTUAL' but $NODE_LABEL has 'needs-decision' label, expected 'needsDecision'. See: .github/scripts/docs/MM16.md"
+                FAILED=1
+            fi
+        fi
+
+        # MM16j: needsDecision class must have needs-decision label
+        if [[ "$ACTUAL" == "needsDecision" && "$HAS_NEEDS_DECISION" != "true" ]]; then
+            emit_fail "MM16j: Node $node has class 'needsDecision' but $NODE_LABEL lacks 'needs-decision' label. See: .github/scripts/docs/MM16.md"
+            FAILED=1
+        fi
+
+        # MM16k: tracks-plan label must use tracksPlan class
+        # Exempt: 'blocked' is allowed when node has open blockers (blocked takes precedence)
+        if [[ "$HAS_TRACKS_PLAN" == "true" && "$ACTUAL" != "tracksPlan" ]]; then
+            if ! { [[ "$ACTUAL" == "blocked" ]] && node_has_open_blocker "$node"; }; then
+                emit_fail "MM16k: Node $node has class '$ACTUAL' but $NODE_LABEL has 'tracks-plan' label, expected 'tracksPlan'. See: .github/scripts/docs/MM16.md"
+                FAILED=1
+            fi
+        fi
+
+        # MM16l: tracksPlan class must have tracks-plan label
+        if [[ "$ACTUAL" == "tracksPlan" && "$HAS_TRACKS_PLAN" != "true" ]]; then
+            emit_fail "MM16l: Node $node has class 'tracksPlan' but $NODE_LABEL lacks 'tracks-plan' label. See: .github/scripts/docs/MM16.md"
+            FAILED=1
+        fi
+
+        # MM17: No open blockers cannot show as 'blocked'
+        if [[ "$ACTUAL" == "blocked" ]] && ! node_has_open_blocker "$node"; then
+            emit_fail "MM17: Node $node has class 'blocked' but has no open blocking dependencies. See: .github/scripts/docs/MM17.md"
+            FAILED=1
+        fi
+
+        # MM18: Has open blocker cannot show as 'ready'
+        if [[ "$ACTUAL" == "ready" ]] && node_has_open_blocker "$node"; then
+            BLOCKER_LIST="${BLOCKERS[$node]:-}"
+            emit_fail "MM18: Node $node has class 'ready' but is blocked by open dependencies ($(echo "$BLOCKER_LIST" | sed 's/^ //; s/ /, /g')). See: .github/scripts/docs/MM18.md"
+            FAILED=1
+        fi
+
+        # MM19: Status classes (needsDesign, needsPrd, needsSpike, needsDecision, tracksDesign, tracksPlan)
+        # cannot have open blockers -- should be 'blocked' instead
+        if [[ "$ACTUAL" == "needsDesign" || "$ACTUAL" == "needsPrd" || "$ACTUAL" == "needsSpike" || \
+              "$ACTUAL" == "needsDecision" || "$ACTUAL" == "tracksDesign" || "$ACTUAL" == "tracksPlan" ]] && \
+           node_has_open_blocker "$node"; then
+            BLOCKER_LIST="${BLOCKERS[$node]:-}"
+            emit_fail "MM19: Node $node has class '$ACTUAL' but is blocked by open dependencies ($(echo "$BLOCKER_LIST" | sed 's/^ //; s/ /, /g')), expected 'blocked'. See: .github/scripts/docs/MM19.md"
+            FAILED=1
+        fi
+    done <<< "$DIAGRAM_NODES"
+fi
+
+# --- MM20 and MM21: Parent-child consistency checks ---
+# These checks cross-reference Mermaid node classes with child reference rows
+# in the Implementation Issues table, and validate against child design doc status.
+
+# Extract child reference rows from the Implementation Issues section.
+# Each child ref row has format: | ^_Child: [DESIGN-name.md](path)_ | | | |
+# or: | ^_Child: [PLAN-name.md](path)_ | | | |
+# or struck-through: | ~~^_Child: [DESIGN-name.md](path)_~~ | | | |
+# We need to associate each child ref row with the issue row immediately above it.
+
+if [[ -n "$DIAGRAM_NODES" ]] && grep -q "^## Implementation Issues" "$DOC_PATH"; then
+    ISSUES_SECTION=$(awk '
+        /^## Implementation Issues/ { in_section = 1; next }
+        in_section && /^## / { exit }
+        in_section { print }
+    ' "$DOC_PATH")
+
+    # Extract ALL table rows (excluding header and separator) in order
+    ALL_II_ROWS=$(echo "$ISSUES_SECTION" | awk '
+        /^\|/ && !/^\| *-/ && !/^\| *Issue/ { print }
+    ')
+
+    # Build maps: issue_number -> child_ref_path, issue_number -> child_ref_struck
+    declare -A CHILD_REF_PATHS         # issue_num -> relative path from child ref row
+    declare -A CHILD_REF_STRUCK        # issue_num -> true/false (struck through)
+    declare -A CHILD_REF_DISPLAY       # issue_num -> display name for errors
+
+    # Helper: check if a row is a child reference row
+    mm_is_child_ref_row() {
+        local row="$1"
+        [[ "$row" =~ ^\|\ *\^_ ]] || [[ "$row" =~ ^\|\ *~~\^_ ]]
+    }
+
+    # Helper: check if a row is a description row
+    mm_is_description_row() {
+        local row="$1"
+        [[ "$row" =~ ^\|\ *_ ]] || [[ "$row" =~ ^\|\ *~~_ ]]
+    }
+
+    # Helper: check if a row is a data row (issue or milestone)
+    mm_is_data_row() {
+        local row="$1"
+        [[ "$row" =~ ^\| ]] && ! [[ "$row" =~ ^\|\ *- ]] && ! [[ "$row" =~ ^\|\ *Issue ]] && \
+            ! mm_is_description_row "$row" && ! mm_is_child_ref_row "$row"
+    }
+
+    # Walk through rows to associate child ref rows with their parent issue
+    LAST_ISSUE_NUM=""
+    while IFS= read -r row; do
+        [[ -z "$row" ]] && continue
+
+        if mm_is_data_row "$row"; then
+            # Extract issue number from the first cell
+            FIRST_CELL=$(echo "$row" | awk -F'|' '{ gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2 }')
+            # Strip strikethrough
+            FIRST_CELL_CLEAN=$(echo "$FIRST_CELL" | sed 's/^~~//;s/~~$//')
+            # Extract issue number from [#N: ...](url) or [#N](url)
+            if [[ "$FIRST_CELL_CLEAN" =~ ^\[#([0-9]+) ]]; then
+                LAST_ISSUE_NUM="${BASH_REMATCH[1]}"
+            else
+                LAST_ISSUE_NUM=""
+            fi
+        elif mm_is_child_ref_row "$row" && [[ -n "$LAST_ISSUE_NUM" ]]; then
+            # Parse the child reference path from the row
+            # Format: | ^_Child: [DESIGN-name.md](path)_ | | | |
+            # Or:     | ~~^_Child: [DESIGN-name.md](path)_~~ | | | |
+            CELL_CONTENT=$(echo "$row" | awk -F'|' '{ gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2 }')
+
+            # Check if struck through
+            IS_STRUCK=false
+            if [[ "$CELL_CONTENT" =~ ^~~ ]]; then
+                IS_STRUCK=true
+                CELL_CONTENT=$(echo "$CELL_CONTENT" | sed 's/^~~//;s/~~$//')
+            fi
+
+            # Extract path from: ^_Child: [DESIGN-name.md](path)_
+            # The path is inside the parentheses of the markdown link
+            REF_PATH=$(echo "$CELL_CONTENT" | grep -oE '\]\([^)]+\)' | sed 's/^\](\(.*\))$/\1/' || true)
+            DISPLAY_NAME=$(echo "$CELL_CONTENT" | grep -oE '\[[^\]]+\]' | sed 's/^\[\(.*\)\]$/\1/' || true)
+
+            if [[ -n "$REF_PATH" ]]; then
+                CHILD_REF_PATHS[$LAST_ISSUE_NUM]="$REF_PATH"
+                CHILD_REF_STRUCK[$LAST_ISSUE_NUM]="$IS_STRUCK"
+                CHILD_REF_DISPLAY[$LAST_ISSUE_NUM]="${DISPLAY_NAME:-$REF_PATH}"
+            fi
+        fi
+    done <<< "$ALL_II_ROWS"
+
+    # Get actual class assignments (reuse ACTUAL_CLASS if already set, otherwise build it)
+    if [[ -z "${ACTUAL_CLASS+x}" ]]; then
+        declare -A ACTUAL_CLASS
+        while IFS= read -r line; do
+            if echo "$line" | grep -qE '^\s*class\s+'; then
+                CLASS_NAME=$(echo "$line" | awk '{print $NF}')
+                NODES_STR=$(echo "$line" | sed 's/^\s*class\s*//' | sed "s/\s*${CLASS_NAME}$//" | tr -d ' ')
+                IFS=',' read -ra NODE_LIST <<< "$NODES_STR"
+                for node in "${NODE_LIST[@]}"; do
+                    [[ -n "$node" ]] && ACTUAL_CLASS[$node]="$CLASS_NAME"
+                done
+            fi
+        done <<< "$MERMAID_CONTENT"
+    fi
+
+    # MM20: Parent-child Mermaid consistency
+    # For each issue with a child reference, check that the class matches the child status
+    DOC_DIR=$(dirname "$DOC_PATH")
+    REPO_ROOT=$(cd "$DOC_DIR" && git rev-parse --show-toplevel 2>/dev/null || echo "")
+
+    for issue_num in "${!CHILD_REF_PATHS[@]}"; do
+        REF_PATH="${CHILD_REF_PATHS[$issue_num]}"
+        IS_STRUCK="${CHILD_REF_STRUCK[$issue_num]}"
+        NODE_ID="I${issue_num}"
+        ACTUAL="${ACTUAL_CLASS[$NODE_ID]:-}"
+
+        # Skip if node not in diagram
+        [[ -z "$ACTUAL" ]] && continue
+
+        # Check if cross-repo reference (absolute URL or path outside repo)
+        if [[ "$REF_PATH" =~ ^https?:// ]]; then
+            emit_pass "MM20: Node $NODE_ID child reference is cross-repo URL, skipping validation"
+            continue
+        fi
+
+        # Resolve the path relative to the design doc's location
+        CHILD_DOC_PATH="$DOC_DIR/$REF_PATH"
+
+        # Normalize the path
+        if [[ -n "$REPO_ROOT" ]]; then
+            CHILD_DOC_REAL=$(cd "$DOC_DIR" && realpath -m "$REF_PATH" 2>/dev/null || echo "$CHILD_DOC_PATH")
+            # Check if outside repo root
+            if [[ ! "$CHILD_DOC_REAL" =~ ^"$REPO_ROOT" ]]; then
+                emit_pass "MM20: Node $NODE_ID child reference points outside repo, skipping validation"
+                continue
+            fi
+        fi
+
+        # Check if child doc exists
+        if [[ ! -f "$CHILD_DOC_PATH" ]]; then
+            # MM20 skips if file doesn't exist; II06 handles that
+            continue
+        fi
+
+        # Read child design status
+        CHILD_STATUS=$(get_frontmatter_status "$CHILD_DOC_PATH")
+
+        if [[ -z "$CHILD_STATUS" ]]; then
+            # Can't determine child status, skip
+            continue
+        fi
+
+        # Determine child doc type from filename: PLAN-*.md or DESIGN-*.md
+        CHILD_BASENAME=$(basename "$CHILD_DOC_PATH")
+        IS_PLAN_DOC=false
+        if [[ "$CHILD_BASENAME" =~ ^PLAN- ]]; then
+            IS_PLAN_DOC=true
+        fi
+
+        # Validate class matches child lifecycle status
+        if [[ "$IS_PLAN_DOC" == "true" ]]; then
+            # PLAN doc statuses: Draft, Active -> tracksPlan; Done -> done
+            case "$CHILD_STATUS" in
+                Draft|Active)
+                    if [[ "$ACTUAL" != "tracksPlan" ]]; then
+                        emit_fail "MM20: Node $NODE_ID has class '$ACTUAL' but child PLAN status is '$CHILD_STATUS', expected 'tracksPlan'. See: .github/scripts/docs/MM20.md"
+                        FAILED=1
+                    fi
+                    ;;
+                Done)
+                    if [[ "$ACTUAL" != "done" ]]; then
+                        emit_fail "MM20: Node $NODE_ID has class '$ACTUAL' but child PLAN status is 'Done', expected 'done'. See: .github/scripts/docs/MM20.md"
+                        FAILED=1
+                    fi
+                    ;;
+            esac
+        else
+            # Design doc statuses: Proposed, Accepted, Planned -> tracksDesign; Current -> done; Superseded -> needsDesign
+            case "$CHILD_STATUS" in
+                Proposed|Accepted|Planned)
+                    # Parent node should be tracksDesign
+                    if [[ "$ACTUAL" != "tracksDesign" ]]; then
+                        emit_fail "MM20: Node $NODE_ID has class '$ACTUAL' but child design status is '$CHILD_STATUS', expected 'tracksDesign'. See: .github/scripts/docs/MM20.md"
+                        FAILED=1
+                    fi
+                    ;;
+                Current)
+                    # Parent node should be done and row should be struck through
+                    if [[ "$ACTUAL" != "done" ]]; then
+                        emit_fail "MM20: Node $NODE_ID has class '$ACTUAL' but child design status is 'Current', expected 'done'. See: .github/scripts/docs/MM20.md"
+                        FAILED=1
+                    fi
+                    ;;
+                Superseded)
+                    # Parent node should revert to needsDesign
+                    if [[ "$ACTUAL" != "needsDesign" ]]; then
+                        emit_fail "MM20: Node $NODE_ID has class '$ACTUAL' but child design status is 'Superseded', expected 'needsDesign'. See: .github/scripts/docs/MM20.md"
+                        FAILED=1
+                    fi
+                    ;;
+            esac
+        fi
+    done
+
+    # MM21: tracksDesign/tracksPlan validation
+    # 1. Every tracksDesign or tracksPlan node must have a child reference row
+    # 2. Every child reference row must belong to a tracksDesign, tracksPlan, or done (struck) node
+
+    # Check all tracking nodes have child ref rows
+    if [[ -n "$ISSUE_NODES" ]]; then
+        while IFS= read -r node; do
+            [[ -z "$node" ]] && continue
+            ACTUAL="${ACTUAL_CLASS[$node]:-}"
+            ISSUE_NUM="${node#I}"
+
+            if [[ "$ACTUAL" == "tracksDesign" || "$ACTUAL" == "tracksPlan" ]]; then
+                if [[ -z "${CHILD_REF_PATHS[$ISSUE_NUM]:-}" ]]; then
+                    emit_fail "MM21: Node $node has class '$ACTUAL' but no child reference row in Implementation Issues table. See: .github/scripts/docs/MM21.md"
+                    FAILED=1
+                fi
+            fi
+        done <<< "$ISSUE_NODES"
+    fi
+
+    # Check all child ref rows belong to tracksDesign, tracksPlan, or done (struck) nodes
+    for issue_num in "${!CHILD_REF_PATHS[@]}"; do
+        NODE_ID="I${issue_num}"
+        ACTUAL="${ACTUAL_CLASS[$NODE_ID]:-}"
+        IS_STRUCK="${CHILD_REF_STRUCK[$issue_num]}"
+
+        # Skip if node not in diagram
+        [[ -z "$ACTUAL" ]] && continue
+
+        if [[ "$ACTUAL" == "tracksDesign" || "$ACTUAL" == "tracksPlan" ]]; then
+            # Valid: tracking node with child ref
+            continue
+        elif [[ "$ACTUAL" == "done" && "$IS_STRUCK" == "true" ]]; then
+            # Valid: done node with struck-through child ref (completed state)
+            continue
+        else
+            emit_fail "MM21: Node $NODE_ID has class '$ACTUAL' but has a child reference row. Only 'tracksDesign', 'tracksPlan', or 'done' (struck-through) nodes may have child reference rows. See: .github/scripts/docs/MM21.md"
+            FAILED=1
+        fi
+    done
+fi
+
+# Return appropriate exit code
+if [[ "$FAILED" -eq 0 ]]; then
+    exit $EXIT_PASS
+else
+    exit $EXIT_FAIL
+fi

--- a/.github/scripts/checks/sections.sh
+++ b/.github/scripts/checks/sections.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#
+# sections.sh - Validate design document required sections
+#
+# Implements section validation rules:
+#   SC01: All 9 required sections exist
+#   SC02: Sections appear in correct order
+#   SC03: Security Considerations section has meaningful content
+#
+# Usage:
+#   sections.sh <doc-path>
+#
+# Exit codes:
+#   0 - All checks passed
+#   1 - One or more checks failed
+#   2 - Operational error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+# Constants - required sections in order
+REQUIRED_SECTIONS=(
+    "Status"
+    "Context and Problem Statement"
+    "Decision Drivers"
+    "Considered Options"
+    "Decision Outcome"
+    "Solution Architecture"
+    "Implementation Approach"
+    "Security Considerations"
+    "Consequences"
+)
+readonly REQUIRED_SECTIONS
+
+# Validate arguments
+if [[ $# -lt 1 ]]; then
+    echo "Error: missing required argument <doc-path>" >&2
+    exit $EXIT_ERROR
+fi
+
+DOC_PATH="$1"
+
+# Check file exists
+if [[ ! -f "$DOC_PATH" ]]; then
+    echo "Error: file not found: $DOC_PATH" >&2
+    exit $EXIT_ERROR
+fi
+
+# Get normalized status from frontmatter (uses shared function from common.sh)
+# Skip sections check for Superseded status (legacy format allowed)
+FM_STATUS=$(get_frontmatter_status "$DOC_PATH")
+
+# Skip validation for Superseded documents (legacy format allowed per design)
+if [[ "$FM_STATUS" == "Superseded" ]]; then
+    exit $EXIT_PASS
+fi
+
+# Extract all ## level headings from the document (after frontmatter)
+# Returns: heading name and line number, tab-separated
+# Skips headings inside fenced code blocks (``` ... ```)
+extract_headings() {
+    local doc="$1"
+    awk '
+        # Skip frontmatter
+        NR == 1 && /^---$/ { in_frontmatter = 1; next }
+        in_frontmatter && /^---$/ { in_frontmatter = 0; next }
+        in_frontmatter { next }
+
+        # Track fenced code blocks (``` or ~~~)
+        /^```/ || /^~~~/ { in_code_block = !in_code_block; next }
+        in_code_block { next }
+
+        # Match ## headings (not ### or deeper)
+        /^## / {
+            # Remove the ## prefix and any trailing whitespace
+            heading = $0
+            sub(/^## /, "", heading)
+            sub(/[[:space:]]*$/, "", heading)
+            print NR "\t" heading
+        }
+    ' "$doc"
+}
+
+# Run checks
+FAILED=0
+
+# Extract headings with line numbers
+HEADINGS=$(extract_headings "$DOC_PATH")
+
+# SC01: Check all 9 required sections exist
+# Build a set of found sections for O(1) lookup
+declare -A FOUND_SECTIONS
+declare -A SECTION_LINES
+while IFS=$'\t' read -r line_num heading; do
+    FOUND_SECTIONS["$heading"]=1
+    SECTION_LINES["$heading"]=$line_num
+done <<< "$HEADINGS"
+
+MISSING_COUNT=0
+MISSING_SECTIONS=()
+for section in "${REQUIRED_SECTIONS[@]}"; do
+    if [[ -z "${FOUND_SECTIONS[$section]:-}" ]]; then
+        MISSING_SECTIONS+=("$section")
+        MISSING_COUNT=$((MISSING_COUNT + 1))
+    fi
+done
+
+if [[ "$MISSING_COUNT" -gt 0 ]]; then
+    emit_fail "SC01: Missing $MISSING_COUNT of ${#REQUIRED_SECTIONS[@]} required sections. See: .github/scripts/docs/SC01.md"
+    for section in "${MISSING_SECTIONS[@]}"; do
+        echo "       - ## $section" >&2
+    done
+    FAILED=1
+fi
+
+# SC02: Validate sections appear in correct order
+# Only check if all sections are present (otherwise SC01 already failed)
+if [[ "$MISSING_COUNT" -eq 0 ]]; then
+    ORDER_FAILED=0
+    PREV_LINE=0
+    PREV_SECTION=""
+
+    for section in "${REQUIRED_SECTIONS[@]}"; do
+        CURRENT_LINE=${SECTION_LINES[$section]}
+        if [[ "$PREV_LINE" -gt 0 ]] && [[ "$CURRENT_LINE" -lt "$PREV_LINE" ]]; then
+            emit_fail "SC02: Wrong section order - '## $section' (line $CURRENT_LINE) appears before '## $PREV_SECTION' (line $PREV_LINE). See: .github/scripts/docs/SC02.md"
+            FAILED=1
+            ORDER_FAILED=1
+        fi
+        PREV_LINE=$CURRENT_LINE
+        PREV_SECTION=$section
+    done
+
+fi
+
+# SC03: Security Considerations section has meaningful content
+# Extract content between "Security Considerations" and next ## heading
+if [[ -n "${FOUND_SECTIONS["Security Considerations"]:-}" ]]; then
+    SECURITY_CONTENT=$(awk '
+        # Skip frontmatter
+        NR == 1 && /^---$/ { in_frontmatter = 1; next }
+        in_frontmatter && /^---$/ { in_frontmatter = 0; next }
+        in_frontmatter { next }
+
+        # Find Security Considerations section
+        /^## Security Considerations/ { in_security = 1; next }
+
+        # Stop at next ## heading
+        in_security && /^## / { exit }
+
+        # Collect content
+        in_security { print }
+    ' "$DOC_PATH")
+
+    # Strip whitespace and check for meaningful content
+    STRIPPED_CONTENT=$(echo "$SECURITY_CONTENT" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr -d '\n')
+
+    # Check if empty or only N/A (case insensitive)
+    if [[ -z "$STRIPPED_CONTENT" ]]; then
+        emit_fail "SC03: Security Considerations section is empty. See: .github/scripts/docs/SC03.md"
+        FAILED=1
+    elif [[ "${STRIPPED_CONTENT,,}" =~ ^n/?a\.?$ ]]; then
+        emit_fail "SC03: Security Considerations section contains only 'N/A'. See: .github/scripts/docs/SC03.md"
+        FAILED=1
+    fi
+fi
+
+# Return appropriate exit code
+if [[ "$FAILED" -eq 0 ]]; then
+    exit $EXIT_PASS
+else
+    # Print concise help with full template inline
+    cat >&2 <<'TEMPLATE'
+
+Fix: Add/reorder sections to match this structure:
+
+    ## Status
+    ## Context and Problem Statement
+    ## Decision Drivers
+    ## Considered Options
+    ## Decision Outcome
+    ## Solution Architecture
+    ## Implementation Approach
+    ## Security Considerations
+    ## Consequences
+
+Each section must be an H2 heading (## ) in the document body.
+TEMPLATE
+    exit $EXIT_FAIL
+fi

--- a/.github/scripts/checks/status-directory.sh
+++ b/.github/scripts/checks/status-directory.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# status-directory.sh - Validate design document status-directory alignment
+#
+# Implements status-directory validation rules:
+#   SD01: File is in correct directory for its status
+#   SD02: Superseded documents have "Superseded by" link
+#
+# Usage:
+#   status-directory.sh <doc-path>
+#
+# Exit codes:
+#   0 - All checks passed
+#   1 - One or more checks failed
+#   2 - Operational error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+# Validate arguments
+if [[ $# -lt 1 ]]; then
+    echo "Error: missing required argument <doc-path>" >&2
+    exit $EXIT_ERROR
+fi
+
+DOC_PATH="$1"
+
+# Check file exists
+if [[ ! -f "$DOC_PATH" ]]; then
+    echo "Error: file not found: $DOC_PATH" >&2
+    exit $EXIT_ERROR
+fi
+
+# Note: get_frontmatter_status is now in common.sh with case normalization
+
+# Get expected directory for a given status
+# Returns the directory suffix after docs/designs
+get_expected_directory() {
+    local status="$1"
+    case "$status" in
+        Proposed|Accepted|Planned)
+            echo "docs/designs"
+            ;;
+        Current)
+            echo "docs/designs/current"
+            ;;
+        Superseded)
+            echo "docs/designs/archive"
+            ;;
+        *)
+            echo ""
+            ;;
+    esac
+}
+
+# Extract actual directory from file path
+# Normalizes to match expected directory format
+get_actual_directory() {
+    local path="$1"
+    local dir
+    dir=$(dirname "$path")
+
+    # Remove leading ./ if present
+    dir="${dir#./}"
+
+    # Return the normalized directory
+    echo "$dir"
+}
+
+FM_STATUS=$(get_frontmatter_status "$DOC_PATH")
+
+# If no status found, can't validate - other checks will catch this
+if [[ -z "$FM_STATUS" ]]; then
+    exit $EXIT_PASS
+fi
+
+FAILED=0
+
+# SD01: Validate file is in correct directory for its status
+EXPECTED_DIR=$(get_expected_directory "$FM_STATUS")
+ACTUAL_DIR=$(get_actual_directory "$DOC_PATH")
+
+if [[ -n "$EXPECTED_DIR" ]]; then
+    # Check if actual directory ends with expected pattern
+    # This handles both relative (docs/designs/) and absolute (/path/to/docs/designs/) paths
+    if [[ "$ACTUAL_DIR" != "$EXPECTED_DIR" && "$ACTUAL_DIR" != */"$EXPECTED_DIR" ]]; then
+        emit_fail "SD01: Status '$FM_STATUS' requires directory '$EXPECTED_DIR', found in '$ACTUAL_DIR'. See: .github/scripts/docs/SD01.md"
+        FAILED=1
+    fi
+fi
+
+# SD02: Superseded documents must have "Superseded by" link
+if [[ "$FM_STATUS" == "Superseded" ]]; then
+    # Search for "Superseded by" followed by markdown link pattern
+    # Pattern: Superseded by [anything](anything)
+    if ! grep -qE "Superseded by \[.+\]\(.+\)" "$DOC_PATH"; then
+        emit_fail "SD02: Superseded status requires 'Superseded by [DESIGN-...](path)' link in body. See: .github/scripts/docs/SD02.md"
+        FAILED=1
+    fi
+fi
+
+# Return appropriate exit code
+if [[ "$FAILED" -eq 0 ]]; then
+    exit $EXIT_PASS
+else
+    exit $EXIT_FAIL
+fi

--- a/.github/scripts/checks/strikethrough-all-docs.sh
+++ b/.github/scripts/checks/strikethrough-all-docs.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# strikethrough-all-docs.sh - Validate closing issues are marked complete in all design docs
+#
+# When a PR closes an issue, this check ensures that issue is marked as
+# strikethrough (completed) in ALL design documents that reference it.
+#
+# Usage:
+#   strikethrough-all-docs.sh --pr <number>
+#
+# Exit codes:
+#   0 - All checks passed (or no issues to validate)
+#   1 - One or more issues not marked complete in design docs
+#   2 - Operational error
+#
+# Example:
+#   # PR #408 has "Fixes #404" in body
+#   ./strikethrough-all-docs.sh --pr 408
+#   # Checks that #404 is strikethrough in all DESIGN-*.md files that reference it
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+CI_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Validate arguments
+if [[ $# -lt 2 ]] || [[ "$1" != "--pr" ]]; then
+    echo "Usage: strikethrough-all-docs.sh --pr <number>" >&2
+    exit $EXIT_ERROR
+fi
+
+PR_NUMBER="$2"
+
+# Check for required tools
+if ! command -v gh &> /dev/null; then
+    echo "Warning: gh CLI not found, skipping cross-doc strikethrough validation" >&2
+    exit $EXIT_PASS
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq required but not found" >&2
+    exit $EXIT_ERROR
+fi
+
+# Get issues being closed by this PR
+CLOSING_ISSUES=$("$CI_DIR/extract-closing-issues.sh" --pr "$PR_NUMBER" 2>/dev/null) || {
+    echo "Warning: could not extract closing issues from PR #$PR_NUMBER" >&2
+    exit $EXIT_PASS
+}
+
+# If no issues being closed, nothing to validate
+if [[ "$CLOSING_ISSUES" == "[]" ]] || [[ -z "$CLOSING_ISSUES" ]]; then
+    exit $EXIT_PASS
+fi
+
+# Find all design docs (exclude archive - superseded docs don't need updates)
+DESIGN_DOCS=$(find docs/designs -name 'DESIGN-*.md' -type f ! -path '*/archive/*' 2>/dev/null || true)
+
+if [[ -z "$DESIGN_DOCS" ]]; then
+    # No design docs found
+    exit $EXIT_PASS
+fi
+
+FAILED=0
+FAILURES=()
+
+# For each issue being closed
+while IFS= read -r issue_num; do
+    [[ -z "$issue_num" ]] && continue
+
+    # Check each design doc
+    while IFS= read -r doc_path; do
+        [[ -z "$doc_path" ]] && continue
+
+        # Extract issues from this doc
+        DOC_ISSUES=$("$CI_DIR/extract-design-issues.sh" "$doc_path" 2>/dev/null) || continue
+
+        # Check if this issue is referenced in the doc
+        # Look for entry with matching number that is NOT completed
+        INCOMPLETE_MATCH=$(echo "$DOC_ISSUES" | jq -r --argjson num "$issue_num" '
+            .milestones[].entries[]
+            | select(.type == "issue" and .number == $num and .completed == false)
+            | .number
+        ' 2>/dev/null || true)
+
+        if [[ -n "$INCOMPLETE_MATCH" ]]; then
+            FAILURES+=("Issue #$issue_num will be closed but not marked complete in $doc_path")
+            FAILED=1
+        fi
+    done <<< "$DESIGN_DOCS"
+done <<< "$(echo "$CLOSING_ISSUES" | jq -r '.[]')"
+
+# Report results
+if [[ "$FAILED" -eq 1 ]]; then
+    emit_fail "Closing issues not marked complete in all design docs:"
+    for failure in "${FAILURES[@]}"; do
+        echo "       - $failure" >&2
+    done
+    echo "" >&2
+    echo "Fix: Add strikethrough to mark issues complete: ~~[#N](url)~~" >&2
+    exit $EXIT_FAIL
+fi
+
+exit $EXIT_PASS

--- a/.github/scripts/docs/FM01.md
+++ b/.github/scripts/docs/FM01.md
@@ -1,0 +1,42 @@
+# FM01: Missing frontmatter field
+
+A required field is missing from the YAML frontmatter at the top of the design document.
+
+## Required Fields
+
+All design documents must have these 4 fields in their frontmatter:
+
+```yaml
+---
+status: Proposed
+problem: |
+  1 paragraph describing the problem being solved.
+decision: |
+  1 paragraph stating what was decided.
+rationale: |
+  1 paragraph explaining why this approach was chosen.
+---
+```
+
+## How to Fix
+
+Add the missing field to the frontmatter block at the very top of the file.
+
+**Example - Before (missing `rationale`):**
+```yaml
+---
+status: Proposed
+problem: Users can't track installation progress.
+decision: Add progress bar to CLI output.
+---
+```
+
+**Example - After:**
+```yaml
+---
+status: Proposed
+problem: Users can't track installation progress.
+decision: Add progress bar to CLI output.
+rationale: Visual feedback reduces perceived wait time and helps debug stuck installs.
+---
+```

--- a/.github/scripts/docs/FM02.md
+++ b/.github/scripts/docs/FM02.md
@@ -1,0 +1,35 @@
+# FM02: Invalid frontmatter status
+
+The `status` field in the frontmatter contains an invalid value.
+
+## Valid Status Values
+
+- `Proposed` - Initial draft awaiting review
+- `Accepted` - Approved, ready for implementation planning
+- `Planned` - Has Implementation Issues section with tracked issues
+- `Current` - All implementation complete
+- `Superseded` - Replaced by a newer design
+
+## How to Fix
+
+Update the `status` field to one of the valid values.
+
+**Example - Before (invalid status):**
+```yaml
+---
+status: Draft
+problem: ...
+---
+```
+
+**Example - After:**
+```yaml
+---
+status: Proposed
+problem: ...
+---
+```
+
+## Note
+
+Status values are case-sensitive. Use exactly `Proposed`, not `proposed` or `PROPOSED`.

--- a/.github/scripts/docs/FM03.md
+++ b/.github/scripts/docs/FM03.md
@@ -1,0 +1,54 @@
+# FM03: Status mismatch
+
+The `status` field in the frontmatter doesn't match the status shown in the document body's `## Status` section.
+
+## Expected Behavior
+
+Both locations must show the same status value:
+
+```yaml
+---
+status: Accepted
+...
+---
+```
+
+```markdown
+## Status
+
+**Accepted**
+```
+
+## How to Fix
+
+Update either the frontmatter or body status so they match.
+
+**Common causes:**
+1. Updated one location but forgot the other
+2. Copy-paste from a template with different status
+
+## Body Status Formats
+
+The validation accepts these formats in the `## Status` section:
+
+```markdown
+## Status
+
+**Accepted**
+```
+
+or
+
+```markdown
+## Status
+
+Accepted
+```
+
+or (for Superseded):
+
+```markdown
+## Status
+
+Superseded by [DESIGN-new-feature.md](path)
+```

--- a/.github/scripts/docs/II00.md
+++ b/.github/scripts/docs/II00.md
@@ -1,0 +1,57 @@
+# II00: Implementation Issues section not allowed in Proposed/Accepted status
+
+An Implementation Issues section was found in a design document with Proposed or Accepted status.
+
+## Why This Matters
+
+The Implementation Issues section is created by the `/plan` command when transitioning a design from Accepted to Planned status. Its presence indicates:
+
+- Issues have been created in GitHub
+- A milestone has been assigned
+- The design is ready for implementation
+
+Documents in Proposed or Accepted status haven't gone through `/plan` yet, so they shouldn't have this section.
+
+## Status Lifecycle
+
+| Status | Implementation Issues Section |
+|--------|------------------------------|
+| Proposed | NOT allowed (design under review) |
+| Accepted | NOT allowed (approved but not planned) |
+| Planned | REQUIRED (issues created via /plan) |
+| Current | OPTIONAL (may exist from Planned phase) |
+| Superseded | OPTIONAL (historical record) |
+
+## How to Fix
+
+**If the document should be Planned:**
+- Change the status to Planned (both frontmatter and Status section)
+- Ensure the Implementation Issues section has valid content
+
+**If the document is still Proposed/Accepted:**
+- Remove the Implementation Issues section
+- The section will be added when you run `/plan` after the design is accepted
+
+## Example
+
+**Invalid - Accepted status with Implementation Issues:**
+```yaml
+---
+status: Accepted
+---
+```
+```markdown
+## Implementation Issues
+
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#123: Task](url) | None | simple |
+```
+
+**Valid - Accepted status without Implementation Issues:**
+```yaml
+---
+status: Accepted
+---
+```
+(no Implementation Issues section)

--- a/.github/scripts/docs/II01.md
+++ b/.github/scripts/docs/II01.md
@@ -1,0 +1,33 @@
+# II01: Missing Implementation Issues section
+
+A design document with status "Planned" must have an `## Implementation Issues` section.
+
+## Why This Matters
+
+The "Planned" status indicates that implementation has been broken into tracked GitHub issues. The Implementation Issues section documents these issues and their dependencies.
+
+## How to Fix
+
+Add an Implementation Issues section with a milestone and issues table:
+
+```markdown
+## Implementation Issues
+
+### Milestone: [Feature Name](https://github.com/org/repo/milestone/N)
+
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#123: First task](https://github.com/org/repo/issues/123) | None | testable |
+| [#124: Second task](https://github.com/org/repo/issues/124) | [#123](https://github.com/org/repo/issues/123) | testable |
+```
+
+## Alternative
+
+If the design isn't ready for implementation planning yet, change the status to "Accepted" instead:
+
+```yaml
+---
+status: Accepted
+...
+---
+```

--- a/.github/scripts/docs/II02.md
+++ b/.github/scripts/docs/II02.md
@@ -1,0 +1,34 @@
+# II02: Issues table missing column
+
+The Implementation Issues table is missing a required column.
+
+## Required Columns
+
+| Column | Description |
+|--------|-------------|
+| Issue | Link with title: `[#N: <title>](url)` |
+| Dependencies | `None` or comma-separated issue links |
+| Tier | Validation tier: `simple`, `testable`, or `critical` |
+
+## How to Fix
+
+Add the missing column to the table header and all rows.
+
+**Example - Current format (3-col):**
+```markdown
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#123: Add feature X](https://github.com/org/repo/issues/123) | None | testable |
+| [#124: Update tests](https://github.com/org/repo/issues/124) | [#123](https://github.com/org/repo/issues/123) | testable |
+```
+
+**Legacy format (4-col, still accepted):**
+```markdown
+| Issue | Title | Dependencies | Tier |
+|-------|-------|--------------|------|
+| [#123](https://github.com/org/repo/issues/123) | Add feature X | None | testable |
+```
+
+## Note
+
+Required columns: Issue, Dependencies, Tier. The legacy Title column is optional.

--- a/.github/scripts/docs/II03.md
+++ b/.github/scripts/docs/II03.md
@@ -1,0 +1,42 @@
+# II03: Invalid issue link format
+
+An entry in the Issue column has an invalid format.
+
+## Expected Format
+
+Issue links must use markdown link format with the issue number as text:
+
+```markdown
+[#123](https://github.com/org/repo/issues/123)
+```
+
+Milestone links use the milestone name:
+
+```markdown
+[Milestone Name](https://github.com/org/repo/milestone/N)
+```
+
+## Common Mistakes
+
+**Plain text (invalid):**
+```markdown
+| #123 | Title | None | testable |
+```
+
+**URL only (invalid):**
+```markdown
+| https://github.com/org/repo/issues/123 | Title | None | testable |
+```
+
+**Wrong link text (invalid):**
+```markdown
+| [Issue 123](https://github.com/org/repo/issues/123) | Title | None | testable |
+```
+
+## How to Fix
+
+Use the correct link format:
+
+```markdown
+| [#123](https://github.com/org/repo/issues/123) | Title | None | testable |
+```

--- a/.github/scripts/docs/II04.md
+++ b/.github/scripts/docs/II04.md
@@ -1,0 +1,43 @@
+# II04: Dependencies not using link format
+
+The Dependencies column contains plain text instead of proper links.
+
+## Expected Format
+
+Dependencies must use markdown link format:
+
+```markdown
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#124: Task B](url) | [#123](url) | testable |
+| [#125: Task C](url) | [#123](url), [#124](url) | testable |
+| [#126: Task D](url) | None | testable |
+```
+
+## Common Mistakes
+
+**Plain text (invalid):**
+```markdown
+| [#124: Task B](url) | #123 | testable |
+```
+
+**Mixed format (invalid):**
+```markdown
+| [#124: Task B](url) | #123, [#122](url) | testable |
+```
+
+## How to Fix
+
+Convert all dependencies to link format:
+
+**Before:**
+```markdown
+| [#124: Task B](https://github.com/org/repo/issues/124) | #123 | testable |
+```
+
+**After:**
+```markdown
+| [#124: Task B](https://github.com/org/repo/issues/124) | [#123](https://github.com/org/repo/issues/123) | testable |
+```
+
+Use `None` (not `N/A` or empty) when there are no dependencies.

--- a/.github/scripts/docs/II05.md
+++ b/.github/scripts/docs/II05.md
@@ -1,0 +1,34 @@
+# II05: Invalid tier value
+
+The Tier column contains an invalid value.
+
+## Valid Tier Values
+
+| Tier | When to Use |
+|------|-------------|
+| `simple` | Docs, typos, comments, trivial fixes |
+| `testable` | New features, refactoring, behavior changes (default) |
+| `critical` | Auth, security, payments, crypto, permissions |
+| `milestone` | Milestone rows (not regular issues) |
+
+## How to Fix
+
+Update the tier to a valid value.
+
+**Before (invalid):**
+```markdown
+| [#123](url) | Add feature | None | high |
+```
+
+**After:**
+```markdown
+| [#123](url) | Add feature | None | testable |
+```
+
+## Choosing the Right Tier
+
+- **simple**: Low-risk documentation or trivial fixes. No tests required.
+- **testable**: Default for most implementation work. Requires tests.
+- **critical**: Security-sensitive changes. Requires additional security review.
+
+When in doubt, choose `testable` - it's the safe default.

--- a/.github/scripts/docs/II06.md
+++ b/.github/scripts/docs/II06.md
@@ -1,0 +1,34 @@
+# II06: Child design reference link validation
+
+A child reference row links to a design document that does not exist.
+
+## Rules
+
+For each child reference row in the Implementation Issues table:
+- `| ^_Child: [DESIGN-name.md](relative/path)_ | | | |`
+- `| ~~^_Child: [DESIGN-name.md](relative/path)_~~ | | | |`
+
+The referenced file path is resolved relative to the design doc's directory and must point to an existing file.
+
+## Why This Matters
+
+Child design references provide navigation from parent design docs to their spawned child designs. Broken links make the parent doc harder to navigate and indicate the child design may have been moved or deleted without updating the parent.
+
+## How to Fix
+
+Update the child reference row to point to the correct file:
+
+```markdown
+| ^_Child: [DESIGN-feature-x.md](docs/designs/DESIGN-feature-x.md)_ | | | |
+```
+
+If the child design was moved (e.g., from `planned/` to `current/`), update the path accordingly.
+
+## Cross-repo References
+
+References that are absolute URLs (starting with `http://` or `https://`) or that resolve to paths outside the repository root emit a warning but do not fail this check. Cross-repo validation requires access to the other repository which CI cannot guarantee.
+
+## Related Rules
+
+- MM20: Parent-child Mermaid consistency
+- MM21: tracksDesign nodes must have child reference rows

--- a/.github/scripts/docs/II07.md
+++ b/.github/scripts/docs/II07.md
@@ -1,0 +1,42 @@
+# II07: Issue row missing required description row
+
+Every issue row in the Implementation Issues table must be followed by a description row.
+
+## Expected Format
+
+Each issue row should be immediately followed by a description row (italic text in the first cell, remaining cells empty):
+
+```markdown
+| [#509: fix description row parsing](url) | None | testable |
+| _Fix the awk skip filter so struck-through description rows work._ | | |
+```
+
+If the issue has a child reference row, it goes between the issue row and the description row:
+
+```markdown
+| [#1701: design dashboard observability](url) | None | simple |
+| ^_Child: [DESIGN-dashboard-observability.md](path)_ | | | |
+| _Designs the observability layer for the pipeline dashboard._ | | |
+```
+
+## How to Fix
+
+Add a description row after the issue row. The description should briefly summarize what the issue does.
+
+**Before (invalid):**
+```markdown
+| [#123](url) | None | testable |
+| [#124](url) | [#123](url) | testable |
+```
+
+**After:**
+```markdown
+| [#123](url) | None | testable |
+| _Implement the first feature._ | | |
+| [#124](url) | [#123](url) | testable |
+| _Build on feature one to add feature two._ | | |
+```
+
+## Grandfathering
+
+This check only applies to design docs created on or after 2026-02-16. Older docs are exempt.

--- a/.github/scripts/docs/II08.md
+++ b/.github/scripts/docs/II08.md
@@ -1,0 +1,42 @@
+# II08: Strikethrough consistency between issue and associated rows
+
+When an issue row is struck through (completed), its description row and child reference row (if present) must also be struck through.
+
+## Expected Format
+
+**Struck-through issue with description:**
+```markdown
+| ~~[#123: some feature](url)~~ | ~~None~~ | ~~testable~~ |
+| ~~_Implement the feature._~~ | | |
+```
+
+**Struck-through issue with child reference and description:**
+```markdown
+| ~~[#1701: design dashboard observability](url)~~ | ~~None~~ | ~~simple~~ |
+| ~~^_Child: [DESIGN-dashboard-observability.md](path)_~~ | | | |
+| ~~_Designs the observability layer._~~ | | |
+```
+
+## Common Mistakes
+
+**Description row not struck through (invalid):**
+```markdown
+| ~~[#123: some feature](url)~~ | ~~None~~ | ~~testable~~ |
+| _Implement the feature._ | | |
+```
+
+**Child reference row not struck through (invalid):**
+```markdown
+| ~~[#1701: design dashboard](url)~~ | ~~None~~ | ~~simple~~ |
+| ^_Child: [DESIGN-dashboard-observability.md](path)_ | | | |
+| ~~_Designs the observability layer._~~ | | |
+```
+
+## How to Fix
+
+Apply strikethrough (`~~`) to all rows associated with the completed issue:
+
+```markdown
+| ~~[#123: some feature](url)~~ | ~~None~~ | ~~testable~~ |
+| ~~_Implement the feature._~~ | | |
+```

--- a/.github/scripts/docs/IS01.md
+++ b/.github/scripts/docs/IS01.md
@@ -1,0 +1,25 @@
+# IS01: Strikethrough item is not closed
+
+An issue or milestone in the Implementation Issues table is marked as completed (with strikethrough formatting) but is still open in GitHub.
+
+## Expected Format
+
+Strikethrough uses double tildes `~~` around the entire cell content:
+
+```markdown
+| ~~[#123](https://github.com/org/repo/issues/123)~~ | ~~Issue title~~ | ~~None~~ | ~~testable~~ |
+```
+
+## How to Fix
+
+Either:
+1. **Remove strikethrough** if the issue is not actually complete:
+   ```markdown
+   | [#123](https://github.com/org/repo/issues/123) | Issue title | None | testable |
+   ```
+
+2. **Close the issue in GitHub** if the work is complete
+
+## Note on PRs
+
+If your PR will close the issue (via `Fixes #123` in PR body or commit message), the strikethrough is correct and validation will pass.

--- a/.github/scripts/docs/IS02.md
+++ b/.github/scripts/docs/IS02.md
@@ -1,0 +1,34 @@
+# IS02: Closed item missing strikethrough
+
+An issue or milestone in the Implementation Issues table is closed in GitHub (or will be closed by this PR) but is not marked as completed with strikethrough formatting.
+
+## Expected Format
+
+Strikethrough uses double tildes `~~` around the entire cell content:
+
+**Before (incorrect):**
+```markdown
+| [#123](https://github.com/org/repo/issues/123) | Issue title | None | testable |
+```
+
+**After (correct):**
+```markdown
+| ~~[#123](https://github.com/org/repo/issues/123)~~ | ~~Issue title~~ | ~~None~~ | ~~testable~~ |
+```
+
+## How to Fix
+
+Add `~~` around each cell in the row for the closed issue:
+
+1. Issue column: `~~[#123](url)~~`
+2. Title column: `~~Issue title~~`
+3. Dependencies column: `~~None~~` or `~~[#456](url)~~`
+4. Tier column: `~~testable~~`
+
+## Mermaid Diagram
+
+Also update the diagram's class assignment to mark the issue as done:
+
+```mermaid
+class I123 done
+```

--- a/.github/scripts/docs/MM01.md
+++ b/.github/scripts/docs/MM01.md
@@ -1,0 +1,32 @@
+# MM01: Using flowchart instead of graph
+
+The Mermaid dependency diagram uses `flowchart` instead of `graph`.
+
+## Expected Format
+
+Use `graph` for better portability:
+
+```mermaid
+graph TD
+    A --> B
+```
+
+## How to Fix
+
+Change `flowchart` to `graph`:
+
+**Before (invalid):**
+```
+flowchart TD
+    A --> B
+```
+
+**After:**
+```
+graph TD
+    A --> B
+```
+
+## Why This Matters
+
+While `flowchart` works in many renderers, `graph` is more portable and renders consistently across different Mermaid implementations.

--- a/.github/scripts/docs/MM02.md
+++ b/.github/scripts/docs/MM02.md
@@ -1,0 +1,40 @@
+# MM02: Missing diagram direction
+
+The Mermaid diagram is missing a direction specifier.
+
+## Expected Format
+
+Include `TD` (top-down) or `LR` (left-right) after `graph`:
+
+```mermaid
+graph TD
+    A --> B
+```
+
+or
+
+```mermaid
+graph LR
+    A --> B
+```
+
+## How to Fix
+
+Add the direction to the graph declaration:
+
+**Before (invalid):**
+```
+graph
+    A --> B
+```
+
+**After:**
+```
+graph TD
+    A --> B
+```
+
+## Choosing Direction
+
+- **TD** (top-down): Use when dependencies span 5+ sequential levels (vertical is more readable)
+- **LR** (left-right): Use for simple diagrams with few sequential levels

--- a/.github/scripts/docs/MM03.md
+++ b/.github/scripts/docs/MM03.md
@@ -1,0 +1,43 @@
+# MM03: Edge inside subgraph
+
+An edge (arrow) is defined inside a subgraph block, which may not render correctly.
+
+## The Problem
+
+Edges defined inside subgraphs can cause rendering issues:
+
+```mermaid
+graph TD
+    subgraph Phase1
+        A --> B    <-- This edge is inside the subgraph
+    end
+```
+
+## How to Fix
+
+Move all edges outside of subgraph blocks:
+
+**Before (may not render):**
+```
+graph TD
+    subgraph Phase1
+        A["Task A"]
+        B["Task B"]
+        A --> B
+    end
+```
+
+**After (correct):**
+```
+graph TD
+    subgraph Phase1
+        A["Task A"]
+        B["Task B"]
+    end
+
+    A --> B
+```
+
+## Why This Matters
+
+Mermaid processes subgraphs and edges separately. Edges inside subgraphs may be ignored or cause rendering failures in some viewers.

--- a/.github/scripts/docs/MM04.md
+++ b/.github/scripts/docs/MM04.md
@@ -1,0 +1,46 @@
+# MM04: Class definition before edges
+
+A `classDef` or `class` statement appears before the diagram edges.
+
+## Expected Structure
+
+Class definitions should come at the end of the diagram:
+
+```mermaid
+graph TD
+    %% 1. Subgraphs with nodes
+    subgraph Phase1
+        A["Task A"]
+    end
+
+    %% 2. Edges
+    A --> B
+
+    %% 3. Class definitions (at the end)
+    classDef done fill:#c8e6c9
+    classDef ready fill:#bbdefb
+
+    class A done
+    class B ready
+```
+
+## How to Fix
+
+Move all `classDef` and `class` statements to the end of the diagram.
+
+**Before (wrong order):**
+```
+graph TD
+    classDef done fill:#c8e6c9
+    A --> B
+    class A done
+```
+
+**After:**
+```
+graph TD
+    A --> B
+
+    classDef done fill:#c8e6c9
+    class A done
+```

--- a/.github/scripts/docs/MM05.md
+++ b/.github/scripts/docs/MM05.md
@@ -1,0 +1,39 @@
+# MM05: Invalid status class
+
+A node is assigned an invalid class name.
+
+## Valid Classes
+
+| Class | Color | Meaning |
+|-------|-------|---------|
+| `done` | Green (#c8e6c9) | Issue is closed |
+| `ready` | Blue (#bbdefb) | Open, no blocking dependencies |
+| `blocked` | Yellow (#fff9c4) | Open, has open blockers |
+| `needsDesign` | Purple (#e1bee7) | Future work, not yet designed |
+| `tracksDesign` | Orange (#FFE0B2) | Child design in progress |
+
+## How to Fix
+
+Use one of the valid class names:
+
+**Before (invalid):**
+```
+class I123 complete
+```
+
+**After:**
+```
+class I123 done
+```
+
+## Class Definitions
+
+Include the standard class definitions in your diagram:
+
+```
+classDef done fill:#c8e6c9
+classDef ready fill:#bbdefb
+classDef blocked fill:#fff9c4
+classDef needsDesign fill:#e1bee7
+classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
+```

--- a/.github/scripts/docs/MM06.md
+++ b/.github/scripts/docs/MM06.md
@@ -1,0 +1,46 @@
+# MM06: Issue in table but not in diagram
+
+An issue appears in the Implementation Issues table but is missing from the Mermaid dependency diagram.
+
+## Expected Behavior
+
+Every issue in the table should have a corresponding node in the diagram:
+
+**Table:**
+```markdown
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#123: Task A](url) | None | testable |
+| [#124: Task B](url) | [#123](url) | testable |
+```
+
+**Diagram:**
+```mermaid
+graph TD
+    I123["#123: Task A"]
+    I124["#124: Task B"]
+
+    I123 --> I124
+```
+
+## How to Fix
+
+Add the missing issue to the diagram:
+
+1. Create a node: `I<number>["#<number>: <short-title>"]`
+2. Add edges for dependencies
+3. Assign appropriate status class
+
+**Example:**
+```
+I123["#123: Add feature"]
+
+I122 --> I123
+
+class I123 ready
+```
+
+## Node Naming Convention
+
+- Node ID: `I<issue-number>` (e.g., `I123`)
+- Node label: `"#<N>: <title>"` (max 40 characters)

--- a/.github/scripts/docs/MM07.md
+++ b/.github/scripts/docs/MM07.md
@@ -1,0 +1,85 @@
+# MM07: Issue dependency diagram and status relationship
+
+This rule distinguishes between two types of Mermaid diagrams:
+
+1. **Issue dependency diagrams** - Contain `I<number>` nodes (e.g., `I123`, `I456`) representing GitHub issues
+2. **Documentation diagrams** - Architecture diagrams, flowcharts, examples without issue nodes
+
+## Rules
+
+| Diagram Type | Allowed Statuses |
+|--------------|------------------|
+| Issue dependency (has `I<number>` nodes) | **Planned only** |
+| Documentation (no `I<number>` nodes) | Any status |
+
+### Issue Dependency Diagrams
+
+- **Planned** status MUST have exactly one issue dependency diagram
+- Only **Planned** status may have issue dependency diagrams
+- Other statuses (Proposed, Accepted, Current, Superseded) must NOT have issue dependency diagrams
+
+### Documentation Diagrams
+
+- Allowed in any status
+- No validation of content (MM01-MM15 checks are skipped)
+- Use for architecture diagrams, flowcharts, examples
+
+## Error Messages
+
+**"Issue dependency diagram (with I<number> nodes) only allowed in 'Planned' status"**
+A diagram with `I<number>` nodes exists but the document status is not Planned.
+
+**"'Planned' status requires an issue dependency diagram (with I<number> nodes)"**
+The document has Planned status but no diagram with `I<number>` nodes exists.
+
+## How to Fix
+
+**If you have an issue dependency diagram but status is not Planned:**
+- Remove the diagram (when transitioning to Current), OR
+- Change status to Planned (if issues still being tracked)
+
+**If status is Planned but no issue dependency diagram:**
+- Add a dependency diagram with `I<number>` nodes for tracked issues, OR
+- Change status if implementation is complete or not yet planned
+
+**If you want a documentation diagram in any status:**
+- Ensure no nodes use the `I<number>` pattern
+- Use descriptive node names like `A[Component]`, `Client`, `Server`
+
+## Examples
+
+**Invalid - Current status with issue dependency diagram:**
+```yaml
+---
+status: Current
+---
+```
+```mermaid
+graph TD
+    I123["#123: Task"]
+    class I123 done
+```
+
+**Valid - Current status with documentation diagram:**
+```yaml
+---
+status: Current
+---
+```
+```mermaid
+graph TD
+    Client[Web Client] --> Server[API Server]
+    Server --> DB[(Database)]
+```
+
+**Valid - Planned status with issue dependency diagram:**
+```yaml
+---
+status: Planned
+---
+```
+```mermaid
+graph TD
+    I123["#123: Task"]
+    class I123 ready
+```

--- a/.github/scripts/docs/MM08.md
+++ b/.github/scripts/docs/MM08.md
@@ -1,0 +1,56 @@
+# MM08: Only one issue dependency diagram per document
+
+Multiple issue dependency diagrams were found in the design document.
+
+**Note:** This rule only applies to diagrams containing `I<number>` or `M<number>` nodes (issue/milestone dependency graphs). Other diagrams (flowcharts, architecture diagrams, etc.) are allowed anywhere in the document.
+
+## Expected Behavior
+
+Each **Planned** design document should have exactly one issue dependency diagram in the Implementation Issues section. Additional non-dependency diagrams are allowed elsewhere in the document for documentation purposes.
+
+## Why This Matters
+
+- Multiple diagrams create confusion about which is authoritative
+- Tooling expects a single diagram to update when issue status changes
+- The diagram should represent the complete dependency graph for the design
+
+## How to Fix
+
+Consolidate all nodes and edges into a single diagram:
+
+**Before (invalid - multiple diagrams):**
+```mermaid
+graph TD
+    I1["#1: Task A"]
+```
+
+```mermaid
+graph TD
+    I2["#2: Task B"]
+```
+
+**After:**
+```mermaid
+graph TD
+    I1["#1: Task A"]
+    I2["#2: Task B"]
+
+    I1 --> I2
+```
+
+## Using Subgraphs for Organization
+
+If you need to group related issues visually, use subgraphs within a single diagram:
+
+```mermaid
+graph TD
+    subgraph Phase1["Phase 1"]
+        I1["#1: Task A"]
+    end
+
+    subgraph Phase2["Phase 2"]
+        I2["#2: Task B"]
+    end
+
+    I1 --> I2
+```

--- a/.github/scripts/docs/MM09.md
+++ b/.github/scripts/docs/MM09.md
@@ -1,0 +1,40 @@
+# MM09: Node in diagram but not in table
+
+A node in the Mermaid diagram references an issue that doesn't exist in the Implementation Issues table.
+
+## Expected Behavior
+
+Every node in the diagram must correspond to an issue in the table:
+
+**Table:**
+```markdown
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#123: Task A](url) | None | testable |
+| [#124: Task B](url) | [#123](url) | testable |
+```
+
+**Diagram:**
+```mermaid
+graph TD
+    I123["#123: Task A"]
+    I124["#124: Task B"]
+
+    I123 --> I124
+```
+
+## How to Fix
+
+Either add the missing issue to the table, or remove the orphaned node from the diagram:
+
+**Option 1: Add to table**
+Add a row for the missing issue with its title, dependencies, and tier.
+
+**Option 2: Remove from diagram**
+Delete the node definition and any edges that reference it.
+
+## Common Causes
+
+- Issue was removed from table but node left in diagram
+- Copy-paste error with wrong issue number
+- Issue renumbered after diagram was created

--- a/.github/scripts/docs/MM10.md
+++ b/.github/scripts/docs/MM10.md
@@ -1,0 +1,45 @@
+# MM10: Invalid node naming convention
+
+A node in the Mermaid diagram doesn't follow the required naming convention.
+
+## Required Format
+
+All nodes must use one of these naming conventions:
+- `I<issue-number>` for issues (e.g., `I123`, `I404`, `I1`)
+- `M<milestone-number>` for milestones (e.g., `M38`, `M1`)
+
+## Why This Matters
+
+- Consistent naming enables tooling to update diagrams automatically
+- The `I` prefix identifies issue nodes, `M` prefix identifies milestone nodes
+- The number in the ID allows cross-referencing with tables and GitHub
+
+## How to Fix
+
+Rename nodes to follow the `I<number>` or `M<number>` convention:
+
+**Before (invalid):**
+```mermaid
+graph TD
+    task1["#123: Add feature"]
+    AddFeature["#124: Another task"]
+```
+
+**After:**
+```mermaid
+graph TD
+    I123["#123: Add feature"]
+    I124["#124: Another task"]
+    M38["M38: Downstream milestone"]
+```
+
+## Node Labels
+
+The node ID is the part before the brackets. The label inside brackets can be any descriptive text:
+
+```
+I123["#123: Short description"]
+ ^       ^
+ |       +-- Label (displayed)
+ +---------- Node ID (must be I<number> or M<number>)
+```

--- a/.github/scripts/docs/MM11.md
+++ b/.github/scripts/docs/MM11.md
@@ -1,0 +1,55 @@
+# MM11: Node has no class assigned
+
+A node in the Mermaid diagram doesn't have a status class assigned.
+
+## Expected Behavior
+
+Every issue node must have one of these classes assigned:
+
+| Class | Color | Meaning |
+|-------|-------|---------|
+| `done` | Green (#c8e6c9) | Issue is closed |
+| `ready` | Blue (#bbdefb) | Open, no blocking dependencies |
+| `blocked` | Yellow (#fff9c4) | Open, has open blockers |
+| `needsDesign` | Purple (#e1bee7) | Future work, not yet designed |
+
+## How to Fix
+
+Add a class assignment for the node at the end of the diagram:
+
+**Before (invalid - no class):**
+```mermaid
+graph TD
+    I123["#123: Task A"]
+    I124["#124: Task B"]
+
+    I123 --> I124
+```
+
+**After:**
+```mermaid
+graph TD
+    I123["#123: Task A"]
+    I124["#124: Task B"]
+
+    I123 --> I124
+
+    class I123 done
+    class I124 ready
+```
+
+## Grouping Multiple Nodes
+
+Nodes with the same class can be grouped:
+
+```mermaid
+class I123,I124,I125 done
+class I126,I127 blocked
+```
+
+## Initial Status
+
+When /plan creates the diagram:
+- Issues with no dependencies: `ready`
+- Issues with dependencies: `blocked`
+- Future work: `needsDesign`

--- a/.github/scripts/docs/MM12.md
+++ b/.github/scripts/docs/MM12.md
@@ -1,0 +1,40 @@
+# MM12: Invalid classDef color
+
+A `classDef` declaration uses a non-standard color for a known class.
+
+## Standard Colors
+
+| Class | Required Color | Appearance |
+|-------|----------------|------------|
+| `done` | `#c8e6c9` | Light green |
+| `ready` | `#bbdefb` | Light blue |
+| `blocked` | `#fff9c4` | Light yellow |
+| `needsDesign` | `#e1bee7` | Light purple |
+
+## Why Standardization Matters
+
+- Consistent colors across all design documents
+- Users can immediately understand issue status at a glance
+- Tooling relies on these specific colors for rendering
+
+## How to Fix
+
+Update the classDef to use the standard color:
+
+**Before (invalid):**
+```mermaid
+classDef done fill:#00ff00
+classDef ready fill:#0000ff
+```
+
+**After:**
+```mermaid
+classDef done fill:#c8e6c9
+classDef ready fill:#bbdefb
+classDef blocked fill:#fff9c4
+classDef needsDesign fill:#e1bee7
+```
+
+## Note
+
+The classDef declarations are optional - you only need `class` statements to assign classes to nodes. But if you do include classDef, the colors must match the standard.

--- a/.github/scripts/docs/MM13.md
+++ b/.github/scripts/docs/MM13.md
@@ -1,0 +1,55 @@
+# MM13: Invalid subgraph styling
+
+A subgraph (milestone group) uses non-standard styling.
+
+## Standard Subgraph Style
+
+All subgraphs should use consistent styling for visual clarity:
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'clusterBkg': '#f5f5f5', 'clusterBorder': '#e0e0e0' }}}%%
+```
+
+Or with explicit style:
+```
+style Phase1 fill:#f5f5f5,stroke:#e0e0e0
+```
+
+## Standard Colors
+
+| Element | Color | Appearance |
+|---------|-------|------------|
+| Background | `#f5f5f5` | Light gray |
+| Border | `#e0e0e0` | Medium gray |
+
+## Why Standardization Matters
+
+- Subgraphs should be visually distinct from nodes but not distracting
+- Neutral colors ensure status colors (green, blue, yellow, purple) remain prominent
+- Consistent styling across all design documents
+
+## How to Fix
+
+Add the standard styling to your subgraphs:
+
+**Before (non-standard):**
+```mermaid
+graph TD
+    subgraph Phase1["Phase 1: Foundation"]
+        I1["#1: Task"]
+    end
+```
+
+**After:**
+```mermaid
+graph TD
+    subgraph Phase1["Phase 1: Foundation"]
+        I1["#1: Task"]
+    end
+
+    style Phase1 fill:#f5f5f5,stroke:#e0e0e0
+```
+
+## Note
+
+Subgraph styling is optional - the validation only fails if styling IS present but doesn't match the standard.

--- a/.github/scripts/docs/MM14.md
+++ b/.github/scripts/docs/MM14.md
@@ -1,0 +1,58 @@
+# MM14: Legend line required after diagram
+
+The Mermaid dependency diagram is missing a legend explaining the color coding.
+
+## Required Format
+
+Add a legend line immediately after the closing ``` of the mermaid block:
+
+```markdown
+```mermaid
+graph TD
+    ...
+```
+
+**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design
+```
+
+## Why This Matters
+
+- Readers can quickly understand what each color means
+- Provides context without requiring memorization of the color scheme
+- Makes diagrams self-documenting
+
+## How to Fix
+
+Add the legend line after your mermaid diagram:
+
+**Before (invalid):**
+```markdown
+```mermaid
+graph TD
+    I123["#123: Task A"]
+    class I123 done
+```
+
+## Next Section
+```
+
+**After:**
+```markdown
+```mermaid
+graph TD
+    I123["#123: Task A"]
+    class I123 done
+```
+
+**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design
+
+## Next Section
+```
+
+## Standard Legend Text
+
+Use this exact format:
+
+```
+**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design
+```

--- a/.github/scripts/docs/MM15.md
+++ b/.github/scripts/docs/MM15.md
@@ -1,0 +1,36 @@
+# MM15: Class doesn't match issue open/closed status
+
+A node's class assignment doesn't match its GitHub open/closed state.
+
+## Rules
+
+| GitHub State | Expected Class |
+|-------------|----------------|
+| Closed (or PR closing it) | `done` |
+| Open | NOT `done` |
+
+## Why This Matters
+
+- Closed issues showing as `ready` or `blocked` mislead readers
+- Open issues showing as `done` suggest work is complete when it isn't
+- The diagram should reflect actual project state
+
+## How to Fix
+
+**Issue is closed but not marked done:**
+```
+class I123 done
+```
+
+**Issue is open but marked done:**
+Change to the appropriate class (`ready`, `blocked`, or `needsDesign`) based on its actual state.
+
+## Related Rules
+
+- MM16: needs-design label cannot be ready
+- MM17: No open blockers cannot be blocked
+- MM18: Open blocker cannot be ready
+
+## Note
+
+This check requires the `gh` CLI to be available and authenticated. If `gh` is not available or the issue cannot be fetched, this validation is skipped for that node.

--- a/.github/scripts/docs/MM16.md
+++ b/.github/scripts/docs/MM16.md
@@ -1,0 +1,29 @@
+# MM16a: needs-design label must use needsDesign class
+
+An issue with the `needs-design` label has a class other than `needsDesign` in the diagram. The label and class must agree.
+
+## Why This Matters
+
+The `needs-design` label indicates the issue requires its own design exploration before implementation. The Mermaid class must reflect this so the diagram accurately shows the issue's state.
+
+## How to Fix
+
+Change the class to `needsDesign`:
+
+**Before (incorrect):**
+```
+class I123 ready
+```
+
+**After (correct):**
+```
+class I123 needsDesign
+```
+
+Alternatively, if the design work is done, remove the `needs-design` label from the GitHub issue and use the appropriate class.
+
+## Related Rules
+
+- MM16b: needsDesign class must have needs-design label
+- MM16c: tracks-design label must use tracksDesign class
+- MM16d: tracksDesign class must have tracks-design label

--- a/.github/scripts/docs/MM16b.md
+++ b/.github/scripts/docs/MM16b.md
@@ -1,0 +1,27 @@
+# MM16b: needsDesign class must have needs-design label
+
+A node has the `needsDesign` class but the corresponding GitHub issue does not have the `needs-design` label.
+
+## Why This Matters
+
+Label and Mermaid class must agree bidirectionally. If the diagram shows `needsDesign` but the issue lacks the label, the diagram is out of sync with the actual issue state. The issue may have already progressed to `tracks-design` or had its label removed entirely.
+
+## How to Fix
+
+Either add the `needs-design` label to the GitHub issue:
+
+```bash
+gh issue edit 123 --add-label "needs-design"
+```
+
+Or change the class to match the issue's actual state:
+
+```
+class I123 ready
+```
+
+## Related Rules
+
+- MM16a: needs-design label must use needsDesign class
+- MM16c: tracks-design label must use tracksDesign class
+- MM16d: tracksDesign class must have tracks-design label

--- a/.github/scripts/docs/MM16c.md
+++ b/.github/scripts/docs/MM16c.md
@@ -1,0 +1,27 @@
+# MM16c: tracks-design label must use tracksDesign class
+
+An issue with the `tracks-design` label has a class other than `tracksDesign` in the diagram. The label and class must agree.
+
+## Why This Matters
+
+The `tracks-design` label indicates the issue has spawned a child design whose implementation is in progress. The Mermaid class must reflect this so the diagram accurately shows the issue's state.
+
+## How to Fix
+
+Change the class to `tracksDesign`:
+
+**Before (incorrect):**
+```
+class I123 ready
+```
+
+**After (correct):**
+```
+class I123 tracksDesign
+```
+
+## Related Rules
+
+- MM16a: needs-design label must use needsDesign class
+- MM16b: needsDesign class must have needs-design label
+- MM16d: tracksDesign class must have tracks-design label

--- a/.github/scripts/docs/MM16d.md
+++ b/.github/scripts/docs/MM16d.md
@@ -1,0 +1,27 @@
+# MM16d: tracksDesign class must have tracks-design label
+
+A node has the `tracksDesign` class but the corresponding GitHub issue does not have the `tracks-design` label.
+
+## Why This Matters
+
+Label and Mermaid class must agree bidirectionally. If the diagram shows `tracksDesign` but the issue lacks the label, the diagram is out of sync with the actual issue state. The issue may still be in `needs-design` or may have had its label removed.
+
+## How to Fix
+
+Either add the `tracks-design` label to the GitHub issue:
+
+```bash
+gh issue edit 123 --add-label "tracks-design"
+```
+
+Or change the class to match the issue's actual state:
+
+```
+class I123 needsDesign
+```
+
+## Related Rules
+
+- MM16a: needs-design label must use needsDesign class
+- MM16b: needsDesign class must have needs-design label
+- MM16c: tracks-design label must use tracksDesign class

--- a/.github/scripts/docs/MM17.md
+++ b/.github/scripts/docs/MM17.md
@@ -1,0 +1,24 @@
+# MM17: No open blockers but class is blocked
+
+A node has class `blocked` but none of its upstream dependencies are actually open on GitHub. If all blockers are closed (or being closed by the current PR), the node isn't blocked.
+
+## How Blocking is Determined
+
+The validation parses the mermaid diagram's edge relationships (`A --> B` means A blocks B) and checks the actual GitHub state of each blocker. A node is only considered blocked if at least one upstream dependency is open.
+
+## How to Fix
+
+Update the class to reflect the node's actual state:
+
+- If the issue has a `needs-design` label, use `needsDesign`
+- Otherwise, use `ready`
+
+**Before (incorrect -- all blockers are closed):**
+```
+class I123 blocked
+```
+
+**After (correct):**
+```
+class I123 ready
+```

--- a/.github/scripts/docs/MM18.md
+++ b/.github/scripts/docs/MM18.md
@@ -1,0 +1,25 @@
+# MM18: Open blocker but class is ready
+
+A node has class `ready` but at least one of its upstream dependencies is still open on GitHub. An issue can't be ready for implementation if it's waiting on unfinished work.
+
+## How Blocking is Determined
+
+The validation parses the mermaid diagram's edge relationships (`A --> B` means A blocks B) and checks the actual GitHub state of each blocker. A node with any open upstream dependency should use class `blocked`.
+
+## How to Fix
+
+Change the class from `ready` to `blocked`:
+
+**Before (incorrect -- I100 is still open):**
+```
+I100 --> I123
+class I123 ready
+```
+
+**After (correct):**
+```
+I100 --> I123
+class I123 blocked
+```
+
+Alternatively, close the blocking issue first if the work is done.

--- a/.github/scripts/docs/MM19.md
+++ b/.github/scripts/docs/MM19.md
@@ -1,0 +1,17 @@
+# MM19: needsDesign or tracksDesign node has open blockers
+
+A node with class `needsDesign` or `tracksDesign` has open blocking dependencies. Nodes with open blockers should use class `blocked` instead.
+
+## Why This Matters
+
+The `needsDesign` class indicates future work that hasn't been designed yet. The `tracksDesign` class indicates a child design is in progress. However, if a node has open dependencies, it's also blocked -- and the `blocked` status takes precedence since it reflects the actual workflow state.
+
+## How to Fix
+
+Change the node's class from `needsDesign` or `tracksDesign` to `blocked`:
+
+```
+class I1315 blocked
+```
+
+Or if the dependency is already complete, remove the dependency edge and keep the design class.

--- a/.github/scripts/docs/MM20.md
+++ b/.github/scripts/docs/MM20.md
@@ -1,0 +1,49 @@
+# MM20: Parent-child Mermaid consistency
+
+An issue node's Mermaid class does not match the lifecycle status of its child design document.
+
+## Rules
+
+When an issue has a child reference row (`^_Child: [DESIGN-name.md](path)_`), the referenced child design doc's frontmatter status determines the required Mermaid class:
+
+| Child Design Status | Required Parent Class | Required Strikethrough |
+|--------------------|-----------------------|----------------------|
+| Proposed | `tracksDesign` | No |
+| Accepted | `tracksDesign` | No |
+| Planned | `tracksDesign` | No |
+| Current | `done` | Yes |
+| Superseded | `needsDesign` | No |
+
+## Why This Matters
+
+The parent design doc's Mermaid diagram should reflect the current state of each child design. A `tracksDesign` node means the child design is still in progress. When the child reaches Current, the parent node should be marked done. When a child is Superseded, the parent reverts to needing a new design.
+
+## How to Fix
+
+Update the parent node's class to match the child design's status:
+
+**Child is Planned (correct):**
+```
+class I123 tracksDesign
+```
+
+**Child is Current (correct):**
+```
+class I123 done
+```
+And strike through the issue row, child reference row, and description row.
+
+**Child is Superseded (correct):**
+```
+class I123 needsDesign
+```
+And remove the child reference row.
+
+## Cross-repo References
+
+Child design references that point outside the current repository (absolute URLs or paths above the repo root) emit a warning but do not fail this check.
+
+## Related Rules
+
+- MM21: tracksDesign nodes must have child reference rows
+- II06: Child design reference links must point to existing files

--- a/.github/scripts/docs/MM21.md
+++ b/.github/scripts/docs/MM21.md
@@ -1,0 +1,40 @@
+# MM21: tracksDesign validation
+
+A `tracksDesign` node is missing its required child reference row, or a non-`tracksDesign` node has a child reference row it shouldn't.
+
+## Rules
+
+- If a node has class `tracksDesign`, it **must** have a child reference row (`^_Child: [DESIGN-name.md](path)_`) in the Implementation Issues table.
+- If a node does **not** have class `tracksDesign`, it must **not** have a child reference row.
+- **Exception**: A `done` node with a struck-through child reference row is valid. This represents the completed state where the child design reached Current.
+
+## Why This Matters
+
+The `tracksDesign` class and child reference row must be bidirectionally consistent. A `tracksDesign` node without a child reference provides no way to find the child design. A child reference row on a non-tracking node is misleading.
+
+## How to Fix
+
+**tracksDesign without child reference:**
+
+Add a child reference row between the issue row and description row:
+
+```markdown
+| [#123](url) | track design for feature X | None | simple |
+| ^_Child: [DESIGN-feature-x.md](docs/designs/DESIGN-feature-x.md)_ | | | |
+| _Description of the issue._ | | |
+```
+
+**Child reference on wrong class:**
+
+Either change the class to `tracksDesign`:
+```
+class I123 tracksDesign
+```
+
+Or remove the child reference row if the node shouldn't track a child design.
+
+## Related Rules
+
+- MM20: Parent-child Mermaid consistency (class must match child status)
+- II06: Child design reference link validation (file must exist)
+- MM17: tracksDesign nodes are exempt from the dependency-edge requirement

--- a/.github/scripts/docs/SC01.md
+++ b/.github/scripts/docs/SC01.md
@@ -1,0 +1,36 @@
+# SC01: Missing required section
+
+One or more required sections are missing from the design document.
+
+## Required Sections
+
+Design documents must have these 9 sections in order:
+
+1. `## Status`
+2. `## Context and Problem Statement`
+3. `## Decision Drivers`
+4. `## Considered Options`
+5. `## Decision Outcome`
+6. `## Solution Architecture`
+7. `## Implementation Approach`
+8. `## Security Considerations`
+9. `## Consequences`
+
+## How to Fix
+
+Add the missing section(s) with appropriate content.
+
+**Example - Adding a missing section:**
+```markdown
+## Security Considerations
+
+### Download Verification
+All binaries are verified via SHA256 checksums from official sources.
+
+### Execution Isolation
+Tools run with user permissions only; no sudo required.
+```
+
+## Note
+
+Section headers must match exactly, including capitalization. `## security considerations` is not valid.

--- a/.github/scripts/docs/SC02.md
+++ b/.github/scripts/docs/SC02.md
@@ -1,0 +1,49 @@
+# SC02: Wrong section order
+
+A section appears in the wrong position relative to other required sections.
+
+## Required Order
+
+Sections must appear in this order:
+
+1. `## Status`
+2. `## Context and Problem Statement`
+3. `## Decision Drivers`
+4. `## Considered Options`
+5. `## Decision Outcome`
+6. `## Solution Architecture`
+7. `## Implementation Approach`
+8. `## Security Considerations`
+9. `## Consequences`
+
+## How to Fix
+
+Move the section to its correct position in the document.
+
+**Example - Before (wrong order):**
+```markdown
+## Status
+...
+
+## Decision Outcome
+...
+
+## Context and Problem Statement  <-- This should come before Decision Outcome
+...
+```
+
+**Example - After:**
+```markdown
+## Status
+...
+
+## Context and Problem Statement
+...
+
+## Decision Outcome
+...
+```
+
+## Note
+
+Additional sections (like `## Implementation Issues`) can appear anywhere and don't affect ordering validation.

--- a/.github/scripts/docs/SC03.md
+++ b/.github/scripts/docs/SC03.md
@@ -1,0 +1,44 @@
+# SC03: Empty Security Considerations
+
+The Security Considerations section is empty or contains only "N/A".
+
+## Why This Matters
+
+For tsuku (a package manager that downloads and executes binaries), security analysis is mandatory. Every design must address how it handles:
+
+- **Download verification**: How are binaries validated?
+- **Execution isolation**: What permissions are required?
+- **Supply chain risks**: Where do binaries come from?
+- **User data exposure**: What data is accessed or transmitted?
+
+## How to Fix
+
+Add meaningful security analysis to the section.
+
+**Example - Before (invalid):**
+```markdown
+## Security Considerations
+
+N/A
+```
+
+**Example - After:**
+```markdown
+## Security Considerations
+
+### Download Verification
+All binaries are verified via SHA256 checksums published on the tool's official releases page.
+
+### Execution Isolation
+Installed tools run with user permissions only. No sudo or elevated privileges required.
+
+### Supply Chain Risks
+Downloads come directly from official GitHub releases. The recipe specifies exact version and checksum.
+
+### User Data Exposure
+This feature does not access or transmit any user data.
+```
+
+## Note
+
+If a dimension genuinely doesn't apply, explain why instead of writing "N/A".

--- a/.github/scripts/docs/SD01.md
+++ b/.github/scripts/docs/SD01.md
@@ -1,0 +1,36 @@
+# SD01: File in wrong directory
+
+The design document's status doesn't match its directory location.
+
+## Directory Mapping
+
+| Status | Required Directory |
+|--------|-------------------|
+| Proposed | `docs/designs/` |
+| Accepted | `docs/designs/` |
+| Planned | `docs/designs/` |
+| Current | `docs/designs/current/` |
+| Superseded | `docs/designs/archive/` |
+
+## How to Fix
+
+Move the file to the correct directory for its status.
+
+**Example - Status is "Current" but file is in wrong location:**
+```bash
+# Move from docs/designs/ to docs/designs/current/
+git mv docs/designs/DESIGN-feature.md docs/designs/current/DESIGN-feature.md
+```
+
+**Example - Status is "Superseded":**
+```bash
+# Move to archive
+git mv docs/designs/DESIGN-old-feature.md docs/designs/archive/DESIGN-old-feature.md
+```
+
+## Note
+
+The directories must exist. Create them if needed:
+```bash
+mkdir -p docs/designs/current docs/designs/archive
+```

--- a/.github/scripts/docs/SD02.md
+++ b/.github/scripts/docs/SD02.md
@@ -1,0 +1,35 @@
+# SD02: Superseded missing link
+
+A design document with status "Superseded" must include a link to the document that replaces it.
+
+## Expected Format
+
+The `## Status` section should contain a "Superseded by" line with a link:
+
+```markdown
+## Status
+
+Superseded by [DESIGN-new-approach.md](./DESIGN-new-approach.md)
+```
+
+## How to Fix
+
+Add the "Superseded by" line with a link to the new design document.
+
+**Example - Before (invalid):**
+```markdown
+## Status
+
+Superseded
+```
+
+**Example - After:**
+```markdown
+## Status
+
+Superseded by [DESIGN-v2-feature.md](./DESIGN-v2-feature.md)
+```
+
+## Note
+
+The link should be a relative path to the new design document. This helps readers understand the evolution of the design and find current documentation.

--- a/.github/scripts/extract-closing-issues.sh
+++ b/.github/scripts/extract-closing-issues.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# extract-closing-issues.sh - Extract issue numbers that a PR will close on merge
+#
+# Parses PR body (and optionally commit messages) for GitHub closing keywords
+# (Fixes, Closes, Resolves and variants) and extracts the referenced issue numbers.
+#
+# Usage:
+#   extract-closing-issues.sh --pr <number>    # Fetch PR and extract closing issues
+#   extract-closing-issues.sh --stdin          # Read text from stdin
+#
+# Output (JSON array):
+#   [123, 456]
+#
+# Exit codes:
+#   0 - Success (array may be empty)
+#   1 - PR not found (--pr mode only)
+#   2 - Operational error (missing argument, invalid usage)
+#
+# Supported closing keywords (case-insensitive):
+#   close, closes, closed
+#   fix, fixes, fixed
+#   resolve, resolves, resolved
+#
+# Supported reference formats:
+#   #N                                    - Issue number
+#   https://github.com/owner/repo/issues/N - Full URL
+#
+# Example:
+#   echo "Fixes #123 and closes #456" | ./extract-closing-issues.sh --stdin
+#   # Output: [123, 456]
+#
+#   ./extract-closing-issues.sh --pr 42
+#   # Output: [123, 456] (from PR body and commit messages)
+
+set -euo pipefail
+
+# Show usage
+usage() {
+    echo "Usage: extract-closing-issues.sh --pr <number> | --stdin" >&2
+    echo "" >&2
+    echo "Options:" >&2
+    echo "  --pr <number>   Fetch PR body and commits via gh" >&2
+    echo "  --stdin         Read text from stdin" >&2
+    exit 2
+}
+
+# Extract closing issue numbers from text
+# Outputs one issue number per line (for later deduplication)
+extract_issues() {
+    local text="$1"
+
+    # Pattern for closing keywords (case-insensitive)
+    # Matches: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved
+    # Followed by whitespace and either #N or a GitHub URL
+
+    # Extract #N format
+    echo "$text" | grep -oiE '(close[sd]?|fix(es|ed)?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' || true
+
+    # Extract URL format: github.com/owner/repo/issues/N
+    echo "$text" | grep -oiE '(close[sd]?|fix(es|ed)?|resolve[sd]?)\s+https?://github\.com/[^/]+/[^/]+/issues/[0-9]+' | grep -oE 'issues/[0-9]+' | grep -oE '[0-9]+' || true
+}
+
+# Main
+if [[ $# -lt 1 ]]; then
+    usage
+fi
+
+MODE=""
+PR_NUMBER=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr)
+            MODE="pr"
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --pr requires a PR number" >&2
+                usage
+            fi
+            PR_NUMBER="$2"
+            shift 2
+            ;;
+        --stdin)
+            MODE="stdin"
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Error: unknown option: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+if [[ -z "$MODE" ]]; then
+    usage
+fi
+
+TEXT=""
+
+if [[ "$MODE" == "pr" ]]; then
+    # Fetch PR body and commit messages via gh
+    if ! command -v gh &> /dev/null; then
+        echo "Error: gh CLI not found" >&2
+        exit 2
+    fi
+
+    # Get PR body and commit messages as combined text
+    PR_DATA=$(gh pr view "$PR_NUMBER" --json body,commits 2>/dev/null) || {
+        echo "Error: PR #$PR_NUMBER not found" >&2
+        exit 1
+    }
+
+    # Extract body and all commit message headlines/bodies, join with newlines
+    TEXT=$(echo "$PR_DATA" | jq -r '([.body // ""] + [.commits[]? | .messageHeadline, .messageBody] | map(select(. != null))) | join("\n")')
+
+elif [[ "$MODE" == "stdin" ]]; then
+    TEXT=$(cat)
+fi
+
+# Extract issue numbers, deduplicate, sort, and output as JSON array
+ISSUES=$(extract_issues "$TEXT" | sort -n | uniq)
+
+if [[ -z "$ISSUES" ]]; then
+    echo "[]"
+else
+    # Convert newline-separated numbers to JSON array
+    echo "$ISSUES" | jq -R -s 'split("\n") | map(select(length > 0) | tonumber)'
+fi

--- a/.github/scripts/extract-design-issues.sh
+++ b/.github/scripts/extract-design-issues.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+#
+# extract-design-issues.sh - Extract Implementation Issues from a design doc as JSON
+#
+# Parses the Implementation Issues tables from a design document and outputs
+# structured JSON with all milestones and their issues, status, dependencies, and tier.
+#
+# Usage:
+#   extract-design-issues.sh <doc-path>
+#
+# Output (JSON):
+#   {
+#     "milestones": [
+#       {
+#         "name": "...",
+#         "url": "...",
+#         "entries": [
+#           { "type": "issue", "number": 123, "url": "...", "title": "...", ... }
+#         ]
+#       }
+#     ]
+#   }
+#
+# Exit codes:
+#   0 - Success
+#   1 - No Implementation Issues section found
+#   2 - Operational error (missing argument, file not found)
+#
+# Example:
+#   ./extract-design-issues.sh docs/designs/DESIGN-feature.md
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Error: missing required argument <doc-path>" >&2
+    echo "Usage: extract-design-issues.sh <doc-path>" >&2
+    exit 2
+fi
+
+DOC_PATH="$1"
+
+if [[ ! -f "$DOC_PATH" ]]; then
+    echo "Error: file not found: $DOC_PATH" >&2
+    exit 2
+fi
+
+# Check for Implementation Issues section
+if ! grep -q "^## Implementation Issues" "$DOC_PATH"; then
+    echo "Error: no Implementation Issues section found in $DOC_PATH" >&2
+    exit 1
+fi
+
+# Extract the Implementation Issues section content
+ISSUES_SECTION=$(awk '
+    /^## Implementation Issues/ { in_section = 1; next }
+    in_section && /^## / { exit }
+    in_section { print }
+' "$DOC_PATH")
+
+# Helper to strip strikethrough: ~~text~~ -> text
+strip_strikethrough() {
+    echo "$1" | sed 's/^~~//;s/~~$//'
+}
+
+# Helper to check if value has strikethrough
+has_strikethrough() {
+    [[ "$1" =~ ^~~.*~~$ ]]
+}
+
+# Helper to extract link text: [text](url) -> text
+extract_link_text() {
+    local val
+    val=$(strip_strikethrough "$1")
+    echo "$val" | sed -n 's/^\[\([^]]*\)\].*/\1/p'
+}
+
+# Helper to extract link URL: [text](url) -> url
+extract_link_url() {
+    local val
+    val=$(strip_strikethrough "$1")
+    echo "$val" | sed -n 's/.*(\([^)]*\))$/\1/p'
+}
+
+# Helper to determine entry type (issue or milestone)
+get_entry_type() {
+    local issue_val="$1"
+    local tier_val="$2"
+    local clean_issue
+    clean_issue=$(strip_strikethrough "$issue_val")
+    local clean_tier
+    clean_tier=$(strip_strikethrough "$tier_val")
+
+    # Milestone if tier is "milestone" or URL contains /milestone/
+    if [[ "$clean_tier" == "milestone" ]] || [[ "$clean_issue" =~ milestone/ ]]; then
+        echo "milestone"
+    else
+        echo "issue"
+    fi
+}
+
+# Helper to extract issue/milestone number from link
+extract_number() {
+    local val="$1"
+    local entry_type="$2"
+    local url
+    url=$(extract_link_url "$val")
+
+    if [[ "$entry_type" == "issue" ]]; then
+        # Extract from [#N](url) or [#N: title](url) format
+        local text
+        text=$(extract_link_text "$val")
+        # Only extract the number after #, not digits in the title
+        echo "$text" | grep -oE '^#[0-9]+' | grep -oE '[0-9]+' || true
+    else
+        # Extract from milestone URL: .../milestone/N
+        echo "$url" | grep -oE 'milestone/[0-9]+' | grep -oE '[0-9]+' || true
+    fi
+}
+
+# Parse dependencies: "None" or "[#X](url), [#Y](url)"
+parse_dependencies() {
+    local dep_val="$1"
+    local dep_clean
+    dep_clean=$(strip_strikethrough "$dep_val")
+
+    if [[ "$dep_clean" == "None" || -z "$dep_clean" ]]; then
+        echo "[]"
+        return
+    fi
+
+    # Split on comma and extract each reference
+    local deps=()
+    IFS=',' read -ra DEP_PARTS <<< "$dep_val"
+    for part in "${DEP_PARTS[@]}"; do
+        part=$(echo "$part" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        local text
+        text=$(extract_link_text "$part")
+        if [[ -n "$text" ]]; then
+            deps+=("$text")
+        fi
+    done
+
+    # Output as JSON array
+    printf '%s\n' "${deps[@]}" | jq -R -s 'split("\n") | map(select(length > 0))'
+}
+
+# Get column positions from header
+get_column_position() {
+    local header="$1"
+    local col_name="$2"
+    echo "$header" | awk -v col="$col_name" '
+    BEGIN { FS = "|" }
+    {
+        for (i = 1; i <= NF; i++) {
+            gsub(/^[ \t]+|[ \t]+$/, "", $i)
+            if (tolower($i) == tolower(col)) {
+                print i
+                exit
+            }
+        }
+    }
+    '
+}
+
+# Parse a table and return its entries as JSON array
+parse_table() {
+    local table_content="$1"
+    local header
+    header=$(echo "$table_content" | grep -E "^\| *Issue" | head -1 || true)
+
+    if [[ -z "$header" ]]; then
+        echo "[]"
+        return
+    fi
+
+    local issue_col title_col dep_col tier_col
+    issue_col=$(get_column_position "$header" "Issue")
+    title_col=$(get_column_position "$header" "Title")
+    dep_col=$(get_column_position "$header" "Dependencies")
+    tier_col=$(get_column_position "$header" "Tier")
+
+    # Extract table data rows (skip header, separator, description rows, and child reference rows)
+    # Description rows: | _text_ | | | | or struck-through: | ~~_text_~~ | | | |
+    # Child reference rows: | ^_Child: ..._ | | | | or struck-through: | ~~^_Child: ..._~~ | | | |
+    local rows
+    rows=$(echo "$table_content" | awk '
+        /^\|/ && !/^\| *-/ && !/^\| *Issue/ && !/^\| *_/ && !/^\| *~~_/ && !/^\| *\^_/ && !/^\| *~~\^_/ { print }
+    ')
+
+    local entries="[]"
+
+    while IFS= read -r row; do
+        [[ -z "$row" ]] && continue
+
+        # Extract column values
+        local issue_val title_val dep_val tier_val
+        issue_val=$(echo "$row" | awk -F'|' -v col="$issue_col" '{ gsub(/^[ \t]+|[ \t]+$/, "", $col); print $col }')
+        title_val=$(echo "$row" | awk -F'|' -v col="$title_col" '{ gsub(/^[ \t]+|[ \t]+$/, "", $col); print $col }')
+        dep_val=$(echo "$row" | awk -F'|' -v col="$dep_col" '{ gsub(/^[ \t]+|[ \t]+$/, "", $col); print $col }')
+        tier_val=$(echo "$row" | awk -F'|' -v col="$tier_col" '{ gsub(/^[ \t]+|[ \t]+$/, "", $col); print $col }')
+
+        [[ -z "$issue_val" ]] && continue
+
+        # Determine type, number, URL, completion status
+        local entry_type entry_number entry_url entry_title entry_tier entry_deps completed number_json
+        entry_type=$(get_entry_type "$issue_val" "$tier_val")
+        entry_number=$(extract_number "$issue_val" "$entry_type")
+        entry_url=$(extract_link_url "$issue_val")
+        # Title: from Title column (legacy) or from issue link text [#N: title](url)
+        if [[ -n "$title_col" && -n "$title_val" ]]; then
+            entry_title=$(strip_strikethrough "$title_val")
+        else
+            # Extract title from issue link: [#N: title](url) -> title
+            local link_text
+            link_text=$(extract_link_text "$issue_val")
+            entry_title=$(echo "$link_text" | sed 's/^#[0-9]*: *//')
+        fi
+        entry_tier=$(strip_strikethrough "$tier_val")
+        entry_deps=$(parse_dependencies "$dep_val")
+
+        # Check if completed (strikethrough on issue column)
+        if has_strikethrough "$issue_val"; then
+            completed="true"
+        else
+            completed="false"
+        fi
+
+        # Handle null number for named milestones without numeric ID
+        if [[ -z "$entry_number" ]]; then
+            number_json="null"
+        else
+            number_json="$entry_number"
+        fi
+
+        # Build entry JSON
+        local entry
+        entry=$(jq -n \
+            --arg type "$entry_type" \
+            --argjson number "$number_json" \
+            --arg url "$entry_url" \
+            --arg title "$entry_title" \
+            --argjson deps "$entry_deps" \
+            --arg tier "$entry_tier" \
+            --argjson completed "$completed" \
+            '{
+                "type": $type,
+                "number": $number,
+                "url": $url,
+                "title": $title,
+                "dependencies": $deps,
+                "tier": $tier,
+                "completed": $completed
+            }')
+
+        entries=$(echo "$entries" | jq --argjson entry "$entry" '. + [$entry]')
+    done <<< "$rows"
+
+    echo "$entries"
+}
+
+# Split content by milestone headings and parse each section
+MILESTONES="[]"
+
+# Find all milestone headings with their line numbers
+MILESTONE_LINES=$(echo "$ISSUES_SECTION" | grep -n "^### Milestone:" || true)
+
+if [[ -z "$MILESTONE_LINES" ]]; then
+    # No milestone headings - treat entire section as unnamed milestone
+    TABLE_HEADER=$(echo "$ISSUES_SECTION" | grep -E "^\| *Issue" | head -1 || true)
+    if [[ -n "$TABLE_HEADER" ]]; then
+        entries=$(parse_table "$ISSUES_SECTION")
+        milestone_obj=$(jq -n --arg name "" --arg url "" --argjson entries "$entries" \
+            '{ "name": $name, "url": $url, "entries": $entries }')
+        MILESTONES=$(echo "$MILESTONES" | jq --argjson m "$milestone_obj" '. + [$m]')
+    fi
+else
+    # Multiple milestones - split by heading
+    TOTAL_LINES=$(echo "$ISSUES_SECTION" | wc -l)
+
+    # Parse each milestone section
+    while IFS= read -r line_info; do
+        [[ -z "$line_info" ]] && continue
+
+        LINE_NUM=$(echo "$line_info" | cut -d: -f1)
+        MILESTONE_LINE=$(echo "$line_info" | cut -d: -f2-)
+
+        # Extract milestone name and URL
+        MILESTONE_NAME=$(echo "$MILESTONE_LINE" | sed -n 's/.*\[\([^]]*\)\].*/\1/p')
+        MILESTONE_URL=$(echo "$MILESTONE_LINE" | sed -n 's/.*(\([^)]*\)).*/\1/p')
+
+        # Find the end of this milestone section (next milestone or end of section)
+        NEXT_LINE=$(echo "$MILESTONE_LINES" | awk -F: -v current="$LINE_NUM" '$1 > current { print $1; exit }')
+        if [[ -z "$NEXT_LINE" ]]; then
+            NEXT_LINE=$((TOTAL_LINES + 1))
+        fi
+
+        # Extract content for this milestone (from heading to next heading)
+        SECTION_CONTENT=$(echo "$ISSUES_SECTION" | sed -n "${LINE_NUM},$((NEXT_LINE - 1))p")
+
+        # Parse the table in this section
+        entries=$(parse_table "$SECTION_CONTENT")
+
+        # Build milestone object
+        milestone_obj=$(jq -n \
+            --arg name "$MILESTONE_NAME" \
+            --arg url "$MILESTONE_URL" \
+            --argjson entries "$entries" \
+            '{ "name": $name, "url": $url, "entries": $entries }')
+
+        MILESTONES=$(echo "$MILESTONES" | jq --argjson m "$milestone_obj" '. + [$m]')
+    done <<< "$MILESTONE_LINES"
+fi
+
+# Output final JSON
+jq -n --argjson milestones "$MILESTONES" '{ "milestones": $milestones }'

--- a/.github/scripts/get-file-creation-commit.sh
+++ b/.github/scripts/get-file-creation-commit.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# get-file-creation-commit.sh - Get the commit that first introduced a file
+#
+# Returns the commit hash and ISO date when a file was first added to git.
+# Follows renames to find the true origin.
+#
+# Usage:
+#   get-file-creation-commit.sh <file-path>
+#
+# Output (JSON):
+#   {"commit": "abc123...", "date": "2025-01-15T10:30:00+00:00"}
+#
+# Exit codes:
+#   0 - Success
+#   1 - File not tracked by git
+#   2 - Operational error (missing argument, file not found)
+#
+# Example usage in orchestrator:
+#   CREATED=$(./get-file-creation-commit.sh "$file")
+#   CREATED_DATE=$(echo "$CREATED" | jq -r '.date')
+#   if [[ "$CREATED_DATE" < "2025-01-20" ]]; then
+#     echo "Skipping check for grandfathered file"
+#   fi
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Error: missing required argument <file-path>" >&2
+    echo "Usage: get-file-creation-commit.sh <file-path>" >&2
+    exit 2
+fi
+
+FILE_PATH="$1"
+
+if [[ ! -e "$FILE_PATH" ]]; then
+    echo "Error: file not found: $FILE_PATH" >&2
+    exit 2
+fi
+
+# Get the first commit that introduced this file (follows renames)
+# --diff-filter=A shows only commits where file was Added
+# --follow traces through renames
+# tail -1 gets the oldest (first) commit
+FIRST_COMMIT=$(git log --follow --diff-filter=A --format=%H -- "$FILE_PATH" 2>/dev/null | tail -1)
+
+if [[ -z "$FIRST_COMMIT" ]]; then
+    echo "Error: file not tracked by git: $FILE_PATH" >&2
+    exit 1
+fi
+
+# Get the commit date in ISO 8601 format
+COMMIT_DATE=$(git show -s --format=%cI "$FIRST_COMMIT")
+
+# Output as JSON for easy parsing
+echo "{\"commit\": \"$FIRST_COMMIT\", \"date\": \"$COMMIT_DATE\"}"

--- a/.github/scripts/get-github-status.sh
+++ b/.github/scripts/get-github-status.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# get-github-status.sh - Get GitHub status for issues and milestones
+#
+# Queries the GitHub API to get the current status (open/closed) for a list
+# of issues and milestones. Handles rate limiting and caches responses.
+#
+# Usage:
+#   get-github-status.sh --issues <json-array>
+#   get-github-status.sh --from-doc <doc-path>
+#   echo '<json-array>' | get-github-status.sh --stdin
+#
+# Input format (JSON array):
+#   [
+#     { "type": "issue", "number": 123, "url": "https://github.com/owner/repo/issues/123" },
+#     { "type": "milestone", "number": 38, "url": "https://github.com/owner/repo/milestone/38" }
+#   ]
+#
+# Output (JSON object mapping number to status):
+#   {
+#     "issues": { "123": "open", "456": "closed" },
+#     "milestones": { "38": "closed" }
+#   }
+#
+# Exit codes:
+#   0 - Success
+#   1 - Partial success (some API calls failed)
+#   2 - Operational error (missing argument, no gh CLI)
+#
+# Environment:
+#   GH_TOKEN - GitHub token for API access (optional but recommended)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Check for required tools
+if ! command -v gh &> /dev/null; then
+    echo "Error: gh CLI not found" >&2
+    exit 2
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq required but not found" >&2
+    exit 2
+fi
+
+usage() {
+    echo "Usage: get-github-status.sh --issues <json-array>" >&2
+    echo "       get-github-status.sh --from-doc <doc-path>" >&2
+    echo "       echo '<json>' | get-github-status.sh --stdin" >&2
+    exit 2
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+fi
+
+INPUT_JSON=""
+
+case "$1" in
+    --issues)
+        if [[ $# -lt 2 ]]; then
+            echo "Error: --issues requires a JSON array" >&2
+            usage
+        fi
+        INPUT_JSON="$2"
+        ;;
+    --from-doc)
+        if [[ $# -lt 2 ]]; then
+            echo "Error: --from-doc requires a doc path" >&2
+            usage
+        fi
+        DOC_PATH="$2"
+        if [[ ! -f "$DOC_PATH" ]]; then
+            echo "Error: file not found: $DOC_PATH" >&2
+            exit 2
+        fi
+        # Extract issues from design doc
+        DESIGN_DATA=$("$SCRIPT_DIR/extract-design-issues.sh" "$DOC_PATH" 2>/dev/null) || {
+            echo '{"issues": {}, "milestones": {}}'
+            exit 0
+        }
+        INPUT_JSON=$(echo "$DESIGN_DATA" | jq '[.milestones[].entries[] | {type, number, url}]')
+        ;;
+    --stdin)
+        INPUT_JSON=$(cat)
+        ;;
+    -h|--help)
+        usage
+        ;;
+    *)
+        echo "Error: unknown option: $1" >&2
+        usage
+        ;;
+esac
+
+# Validate JSON
+if ! echo "$INPUT_JSON" | jq empty 2>/dev/null; then
+    echo "Error: invalid JSON input" >&2
+    exit 2
+fi
+
+# Initialize output
+ISSUE_STATUSES="{}"
+MILESTONE_STATUSES="{}"
+PARTIAL_FAILURE=0
+
+# Process each entry
+while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+
+    TYPE=$(echo "$entry" | jq -r '.type')
+    NUMBER=$(echo "$entry" | jq -r '.number')
+    URL=$(echo "$entry" | jq -r '.url')
+
+    # Skip entries without a number
+    if [[ "$NUMBER" == "null" || -z "$NUMBER" ]]; then
+        continue
+    fi
+
+    # Extract owner/repo from URL
+    owner_repo=""
+    if [[ "$TYPE" == "issue" ]]; then
+        owner_repo=$(echo "$URL" | sed -n 's|https://github.com/\([^/]*/[^/]*\)/issues/.*|\1|p')
+    else
+        owner_repo=$(echo "$URL" | sed -n 's|https://github.com/\([^/]*/[^/]*\)/milestone/.*|\1|p')
+    fi
+
+    if [[ -z "$owner_repo" ]]; then
+        PARTIAL_FAILURE=1
+        continue
+    fi
+
+    # Query GitHub API
+    state=""
+    if [[ "$TYPE" == "issue" ]]; then
+        state=$(gh api "repos/$owner_repo/issues/$NUMBER" --jq '.state' 2>/dev/null) || {
+            PARTIAL_FAILURE=1
+            continue
+        }
+        ISSUE_STATUSES=$(echo "$ISSUE_STATUSES" | jq --arg num "$NUMBER" --arg state "$state" '. + {($num): $state}')
+    else
+        state=$(gh api "repos/$owner_repo/milestones/$NUMBER" --jq '.state' 2>/dev/null) || {
+            PARTIAL_FAILURE=1
+            continue
+        }
+        MILESTONE_STATUSES=$(echo "$MILESTONE_STATUSES" | jq --arg num "$NUMBER" --arg state "$state" '. + {($num): $state}')
+    fi
+done <<< "$(echo "$INPUT_JSON" | jq -c '.[]')"
+
+# Output combined result
+jq -n --argjson issues "$ISSUE_STATUSES" --argjson milestones "$MILESTONE_STATUSES" \
+    '{"issues": $issues, "milestones": $milestones}'
+
+if [[ $PARTIAL_FAILURE -eq 1 ]]; then
+    exit 1
+else
+    exit 0
+fi

--- a/.github/scripts/tests/test-implementation-issues.sh
+++ b/.github/scripts/tests/test-implementation-issues.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+#
+# test-implementation-issues.sh - Tests for implementation-issues.sh
+#
+# Tests the skip filter fix, II07, and II08 checks.
+# Creates temporary design doc files and runs the check script against them.
+#
+# Usage:
+#   ./test-implementation-issues.sh
+#
+# Exit codes:
+#   0 - All tests passed
+#   1 - One or more tests failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/../checks/implementation-issues.sh"
+EXTRACT_SCRIPT="$SCRIPT_DIR/../extract-design-issues.sh"
+
+# Test counters
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Temp directory for test files
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Create a test doc with given Implementation Issues table content
+# The doc is created in a git-tracked temp location to support get-file-creation-commit.sh
+# but since these are tmpfiles outside git, II07 grandfathering won't work via git.
+# Instead we use a workaround: set II07_CUTOFF_OVERRIDE env var (see below).
+create_test_doc() {
+    local name="$1"
+    local status="$2"
+    local table_content="$3"
+    local path="$TMPDIR/DESIGN-${name}.md"
+
+    cat > "$path" <<EOF
+---
+status: $status
+---
+
+# DESIGN: Test $name
+
+## Status
+
+$status
+
+## Implementation Issues
+
+### Milestone: [test-milestone](https://github.com/org/repo/milestone/1)
+
+$table_content
+
+### Dependency Graph
+
+\`\`\`mermaid
+graph TD
+    I1["#1"]
+\`\`\`
+EOF
+    echo "$path"
+}
+
+# Run a test and check expected outcome
+# Usage: run_test "test name" <expected_exit_code> <expected_stderr_pattern> <doc_path>
+run_test() {
+    local test_name="$1"
+    local expected_exit="$2"
+    local expected_pattern="$3"
+    local doc_path="$4"
+    local actual_exit=0
+    local output=""
+
+    TESTS_RUN=$((TESTS_RUN + 1))
+
+    # Capture both stdout and stderr
+    output=$("$CHECK_SCRIPT" "$doc_path" 2>&1) || actual_exit=$?
+
+    if [[ "$actual_exit" -ne "$expected_exit" ]]; then
+        echo "FAIL: $test_name"
+        echo "  Expected exit code: $expected_exit"
+        echo "  Actual exit code:   $actual_exit"
+        echo "  Output: $output"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+
+    if [[ -n "$expected_pattern" ]]; then
+        if ! echo "$output" | grep -qE "$expected_pattern"; then
+            echo "FAIL: $test_name"
+            echo "  Expected pattern: $expected_pattern"
+            echo "  Output: $output"
+            TESTS_FAILED=$((TESTS_FAILED + 1))
+            return 1
+        fi
+    fi
+
+    echo "PASS: $test_name"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+    return 0
+}
+
+echo "=== Testing skip filter fix (scenario-1, scenario-2) ==="
+echo ""
+
+# scenario-1: Struck-through description rows do not trigger false II03 failures
+DOC=$(create_test_doc "strikethrough-desc" "Planned" "$(cat <<'TABLE'
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#1: feature one](https://github.com/org/repo/issues/1) | None | testable |
+| _Implement feature one._ | | |
+| ~~[#2: feature two](https://github.com/org/repo/issues/2)~~ | ~~None~~ | ~~testable~~ |
+| ~~_Implement feature two._~~ | | |
+TABLE
+)")
+run_test "scenario-1: Struck-through description rows don't trigger II03" 0 "" "$DOC"
+
+# scenario-2: Struck-through child reference rows do not trigger false II03 failures
+DOC=$(create_test_doc "strikethrough-child-ref" "Planned" "$(cat <<'TABLE'
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| ~~[#3: design something](https://github.com/org/repo/issues/3)~~ | ~~None~~ | ~~simple~~ |
+| ~~^_Child: [DESIGN-something.md](docs/designs/DESIGN-something.md)_~~ | | | |
+| ~~_Designs the something feature._~~ | | |
+TABLE
+)")
+run_test "scenario-2: Struck-through child reference rows don't trigger II03" 0 "" "$DOC"
+
+# Additional: non-struck child reference rows are also skipped
+DOC=$(create_test_doc "child-ref-nonstruck" "Planned" "$(cat <<'TABLE'
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#4: design other](https://github.com/org/repo/issues/4) | None | simple |
+| ^_Child: [DESIGN-other.md](docs/designs/DESIGN-other.md)_ | | | |
+| _Designs the other feature._ | | |
+TABLE
+)")
+run_test "Non-struck child reference rows don't trigger II03" 0 "" "$DOC"
+
+echo ""
+echo "=== Testing II07: description row required (scenario-3, scenario-4) ==="
+echo ""
+
+# For II07 testing, we need to bypass the grandfathering since our temp files
+# aren't in git. We'll create a wrapper that overrides the cutoff date to a
+# far-future date (so nothing is grandfathered) or a far-past date (so everything is).
+# Actually, the simplest approach: since get-file-creation-commit.sh will fail for
+# files not in git, ii07_grandfathered() will return 1 (non-zero), meaning
+# "not grandfathered" -> enforce II07. This works for our test purposes.
+
+# scenario-3: II07 rejects issues missing description rows
+DOC=$(create_test_doc "missing-desc" "Planned" "$(cat <<'TABLE'
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#5: some feature](https://github.com/org/repo/issues/5) | None | testable |
+| [#6: another feature](https://github.com/org/repo/issues/6) | None | testable |
+TABLE
+)")
+run_test "scenario-3: II07 rejects issues missing description rows" 1 "II07" "$DOC"
+
+# scenario-4: II07 passes when all issues have description rows
+DOC=$(create_test_doc "all-descs" "Planned" "$(cat <<'TABLE'
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#7: feature a](https://github.com/org/repo/issues/7) | None | testable |
+| _Implement feature a._ | | |
+| [#8: feature b](https://github.com/org/repo/issues/8) | [#7](https://github.com/org/repo/issues/7) | testable |
+| _Implement feature b._ | | |
+TABLE
+)")
+run_test "scenario-4: II07 passes when all issues have description rows" 0 "" "$DOC"
+
+echo ""
+echo "=== Testing II08: strikethrough consistency (scenario-5, scenario-6) ==="
+echo ""
+
+# scenario-5: II08 rejects struck-through issue with non-struck description row
+DOC=$(create_test_doc "inconsistent-desc-strike" "Planned" "$(cat <<'TABLE'
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| ~~[#9: done feature](https://github.com/org/repo/issues/9)~~ | ~~None~~ | ~~testable~~ |
+| _Description not struck through._ | | |
+TABLE
+)")
+run_test "scenario-5: II08 rejects struck issue with non-struck description" 1 "II08" "$DOC"
+
+# scenario-6: II08 rejects struck-through issue with non-struck child reference row
+DOC=$(create_test_doc "inconsistent-child-strike" "Planned" "$(cat <<'TABLE'
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| ~~[#10: done design](https://github.com/org/repo/issues/10)~~ | ~~None~~ | ~~simple~~ |
+| ^_Child: [DESIGN-thing.md](docs/designs/DESIGN-thing.md)_ | | | |
+| ~~_Description is struck._~~ | | |
+TABLE
+)")
+run_test "scenario-6: II08 rejects struck issue with non-struck child ref" 1 "II08" "$DOC"
+
+# Additional: consistent strikethrough passes
+DOC=$(create_test_doc "consistent-strike" "Planned" "$(cat <<'TABLE'
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| ~~[#11: done design](https://github.com/org/repo/issues/11)~~ | ~~None~~ | ~~simple~~ |
+| ~~^_Child: [DESIGN-thing.md](docs/designs/DESIGN-thing.md)_~~ | | | |
+| ~~_Description is struck._~~ | | |
+TABLE
+)")
+run_test "Consistent strikethrough passes II08" 0 "" "$DOC"
+
+# Additional: non-struck issue with non-struck description passes
+DOC=$(create_test_doc "nonstruck-all" "Planned" "$(cat <<'TABLE'
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#12: active feature](https://github.com/org/repo/issues/12) | None | testable |
+| _Working on this feature._ | | |
+TABLE
+)")
+run_test "Non-struck issue with non-struck description passes" 0 "" "$DOC"
+
+echo ""
+echo "=== Testing extract-design-issues.sh skip filter ==="
+echo ""
+
+# Test that extract-design-issues.sh correctly skips struck-through description and child ref rows
+DOC=$(create_test_doc "extract-filter" "Planned" "$(cat <<'TABLE'
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#13: active feature](https://github.com/org/repo/issues/13) | None | testable |
+| _Active description._ | | |
+| ~~[#14: done feature](https://github.com/org/repo/issues/14)~~ | ~~None~~ | ~~simple~~ |
+| ~~^_Child: [DESIGN-done.md](path)_~~ | | | |
+| ~~_Done description._~~ | | |
+TABLE
+)")
+
+EXTRACT_OUTPUT=$("$EXTRACT_SCRIPT" "$DOC" 2>&1)
+ENTRY_COUNT=$(echo "$EXTRACT_OUTPUT" | jq '.milestones[0].entries | length')
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$ENTRY_COUNT" -eq 2 ]]; then
+    echo "PASS: extract-design-issues.sh returns exactly 2 entries (skips desc/child ref rows)"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    echo "FAIL: extract-design-issues.sh expected 2 entries, got $ENTRY_COUNT"
+    echo "  Output: $EXTRACT_OUTPUT"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+echo ""
+echo "=== Testing existing checks still pass (no regressions) ==="
+echo ""
+
+# Run against the actual design doc that has description rows
+REAL_DOC="/home/dgazineu/dev/workspace/tsuku/tsuku-5/private/tools/docs/designs/DESIGN-needs-design-lifecycle.md"
+if [[ -f "$REAL_DOC" ]]; then
+    run_test "Real design doc (DESIGN-needs-design-lifecycle.md) passes" 0 "" "$REAL_DOC"
+fi
+
+echo ""
+echo "=== Testing scenario-7: doc files exist ==="
+echo ""
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -f "$SCRIPT_DIR/../docs/II07.md" ]] && [[ -f "$SCRIPT_DIR/../docs/II08.md" ]]; then
+    echo "PASS: scenario-7: II07.md and II08.md doc files exist"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+else
+    echo "FAIL: scenario-7: II07.md and/or II08.md doc files missing"
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+echo ""
+echo "==============================="
+echo "Tests: $TESTS_RUN | Passed: $TESTS_PASSED | Failed: $TESTS_FAILED"
+echo "==============================="
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/.github/scripts/validate-design-doc.sh
+++ b/.github/scripts/validate-design-doc.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2310,SC2312
+#
+# validate-design-doc.sh - Validate a design document
+#
+# This is the orchestrator for modular design document validation.
+# It runs location/naming checks inline and delegates category-specific
+# checks to scripts in the checks/ directory.
+#
+# Check categories:
+#   - frontmatter.sh  : Frontmatter validation
+#   - sections.sh     : Required sections (future)
+#   - status-directory.sh : Status/directory alignment (future)
+#   - implementation-issues.sh : Issues table format (future)
+#   - mermaid.sh      : Diagram syntax (future)
+#
+# Usage:
+#   validate-design-doc.sh [-q|--quiet] <doc-path>
+#
+# Options:
+#   -q, --quiet  Suppress [PASS] messages, only show failures
+#
+# Exit codes:
+#   0 - Valid (all checks passed)
+#   1 - Invalid (one or more checks failed)
+#   2 - Operational error (missing argument, file not found)
+#
+# Example:
+#   validate-design-doc.sh docs/designs/DESIGN-foo.md
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECKS_DIR="$SCRIPT_DIR/checks"
+
+# Source common utilities
+source "$CHECKS_DIR/common.sh"
+
+# Grandfathering: Files created before a check was introduced are exempt
+# Cutoff dates for each check category (ISO 8601 format)
+readonly II_CHECK_CUTOFF="2026-01-01"  # Implementation Issues validation introduced
+
+
+# Check if file was created before a cutoff date
+# Usage: file_predates_check "$DOC_PATH" "$CUTOFF_DATE"
+# Returns: 0 if file predates cutoff (should skip), 1 if file is newer (should check)
+file_predates_check() {
+    local file="$1"
+    local cutoff="$2"
+
+    # Get file creation info
+    local creation_info
+    creation_info=$("$SCRIPT_DIR/get-file-creation-commit.sh" "$file" 2>/dev/null) || return 1
+
+    # Extract date (format: 2026-01-24T10:30:00-05:00, we just need YYYY-MM-DD)
+    local file_date
+    file_date=$(echo "$creation_info" | sed 's/.*"date": "\([0-9-]*\)T.*/\1/')
+
+    # Compare dates (lexicographic comparison works for ISO dates)
+    [[ "$file_date" < "$cutoff" ]]
+}
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: validate-design-doc.sh [-q|--quiet] <doc-path>
+
+Validates a design document for:
+- Location: must be under docs/designs/
+- Naming: filename must start with DESIGN-
+- Frontmatter: must have valid YAML frontmatter
+
+Options:
+  -q, --quiet  Suppress [PASS] messages, only show failures
+
+Exit codes:
+  0 - Valid
+  1 - Invalid
+  2 - Operational error
+EOF
+    exit $EXIT_ERROR
+}
+
+# Parse arguments
+DOC_PATH=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -q|--quiet)
+            export QUIET_MODE=1
+            shift
+            ;;
+        -*)
+            echo "Error: unknown option: $1" >&2
+            usage
+            ;;
+        *)
+            DOC_PATH="$1"
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$DOC_PATH" ]]; then
+    echo "Error: missing required argument <doc-path>" >&2
+    usage
+fi
+
+# Check file exists
+if [[ ! -f "$DOC_PATH" ]]; then
+    echo "Error: file not found: $DOC_PATH" >&2
+    exit $EXIT_ERROR
+fi
+
+[[ "${QUIET_MODE:-0}" -ne 1 ]] && echo "Validating $DOC_PATH..."
+
+# Export for emit_fail to include in error messages
+export VALIDATE_DOC_PATH="$DOC_PATH"
+
+FAILED=0
+
+# Inline check: Location - must be under docs/designs/
+check_location() {
+    local path="$1"
+    if [[ "$path" == docs/designs/* ]] || [[ "$path" == ./docs/designs/* ]]; then
+        emit_pass "Location: under docs/designs/"
+        return 0
+    else
+        emit_fail "Location: not under docs/designs/ (got: $path)"
+        return 1
+    fi
+}
+
+# Inline check: Naming - filename must start with DESIGN-
+check_naming() {
+    local path="$1"
+    local filename
+    filename=$(basename "$path")
+    if [[ "$filename" == DESIGN-* ]]; then
+        emit_pass "Naming: starts with DESIGN-"
+        return 0
+    else
+        emit_fail "Naming: filename must start with DESIGN- (got: $filename)"
+        return 1
+    fi
+}
+
+# Run inline checks
+check_location "$DOC_PATH" || FAILED=1
+check_naming "$DOC_PATH" || FAILED=1
+
+# Run modular checks from checks/ directory
+# Each check script is called as a subprocess
+run_check() {
+    local check_script="$1"
+    local check_name
+    check_name=$(basename "$check_script" .sh)
+
+    if [[ -x "$check_script" ]]; then
+        # Run check and capture output
+        # Check scripts output [PASS]/[FAIL] messages
+        if ! "$check_script" "$DOC_PATH"; then
+            return 1
+        fi
+    fi
+    return 0
+}
+
+# Run frontmatter check
+if [[ -x "$CHECKS_DIR/frontmatter.sh" ]]; then
+    run_check "$CHECKS_DIR/frontmatter.sh" || FAILED=1
+fi
+
+# Run sections check
+if [[ -x "$CHECKS_DIR/sections.sh" ]]; then
+    run_check "$CHECKS_DIR/sections.sh" || FAILED=1
+fi
+
+# Run status-directory check
+if [[ -x "$CHECKS_DIR/status-directory.sh" ]]; then
+    run_check "$CHECKS_DIR/status-directory.sh" || FAILED=1
+fi
+
+# Run implementation-issues check (with grandfathering)
+if [[ -x "$CHECKS_DIR/implementation-issues.sh" ]]; then
+    if file_predates_check "$DOC_PATH" "$II_CHECK_CUTOFF"; then
+        : # Grandfathered - skip silently
+    else
+        run_check "$CHECKS_DIR/implementation-issues.sh" || FAILED=1
+    fi
+fi
+
+# Run mermaid diagram check (skip status validation for all-docs check)
+if [[ -x "$CHECKS_DIR/mermaid.sh" ]]; then
+    if ! "$CHECKS_DIR/mermaid.sh" --skip-status-check "$DOC_PATH"; then
+        FAILED=1
+    fi
+fi
+
+# Future: Run all check scripts dynamically
+# for check_script in "$CHECKS_DIR"/*.sh; do
+#     [[ "$check_script" == */common.sh ]] && continue
+#     run_check "$check_script" || FAILED=1
+# done
+
+# Report final result
+if [[ "$FAILED" -eq 0 ]]; then
+    [[ "${QUIET_MODE:-0}" -ne 1 ]] && echo "Result: VALID"
+    exit $EXIT_PASS
+else
+    echo "Result: INVALID"
+    exit $EXIT_FAIL
+fi

--- a/.github/workflows/validate-closing-issues.yml
+++ b/.github/workflows/validate-closing-issues.yml
@@ -1,0 +1,28 @@
+name: Validate Closing Issues in Design Docs
+
+on:
+  pull_request:
+    types: [opened, synchronize, edited]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Validate closing issues are marked complete
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+
+          if ! .github/scripts/checks/strikethrough-all-docs.sh --pr "$PR_NUMBER" 2>&1; then
+            echo "::error::Issues being closed are not marked complete in all design docs that reference them."
+            exit 1
+          fi
+          echo "All closing issues are properly marked in design docs"

--- a/.github/workflows/validate-design-docs.yml
+++ b/.github/workflows/validate-design-docs.yml
@@ -1,0 +1,44 @@
+name: Validate Design Docs
+on:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0  # Full history needed for grandfathering based on file creation date
+
+      - name: Find all design docs
+        id: find
+        run: |
+          # Find all DESIGN-*.md files anywhere in the repo
+          FILES=$(find . -name 'DESIGN-*.md' -type f | sed 's|^\./||' | sort)
+          echo "files<<EOF" >> $GITHUB_OUTPUT
+          echo "$FILES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          if [ -n "$FILES" ]; then
+            echo "Found design docs:"
+            echo "$FILES"
+          else
+            echo "No DESIGN-*.md files found"
+          fi
+
+      - name: Validate design docs
+        if: steps.find.outputs.files != ''
+        run: |
+          FAILED=0
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            if ! .github/scripts/validate-design-doc.sh -q "$file"; then
+              FAILED=1
+            fi
+          done <<< "${{ steps.find.outputs.files }}"
+
+          if [ "$FAILED" -eq 1 ]; then
+            echo "One or more design docs failed validation"
+            exit 1
+          fi
+          echo "All design docs valid"

--- a/.github/workflows/validate-diagram-classes.yml
+++ b/.github/workflows/validate-diagram-classes.yml
@@ -1,0 +1,75 @@
+name: Validate Diagram Classes for Changed Docs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'docs/designs/DESIGN-*.md'
+      - 'docs/designs/current/DESIGN-*.md'
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Get changed design docs
+        id: changed
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+
+          # Find changed DESIGN-*.md files (not in archive)
+          CHANGED=$(git diff --name-only "$BASE"...HEAD -- \
+            'docs/designs/DESIGN-*.md' \
+            'docs/designs/current/DESIGN-*.md' 2>/dev/null || true)
+
+          # Save for next step
+          echo "docs<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGED" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Validate diagram classes (MM15)
+        if: steps.changed.outputs.docs != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Source common utilities for get_frontmatter_status
+          source .github/scripts/checks/common.sh
+
+          FAILED=0
+
+          while IFS= read -r doc; do
+            [[ -z "$doc" ]] && continue
+            [[ ! -f "$doc" ]] && continue
+
+            # Skip if no mermaid diagram
+            if ! grep -q '```mermaid' "$doc"; then
+              continue
+            fi
+
+            # Skip archived/superseded docs
+            STATUS=$(get_frontmatter_status "$doc")
+            if [[ "$STATUS" == "Superseded" ]]; then
+              continue
+            fi
+
+            # Run MM15 validation with PR context for closing-issue awareness
+            if ! .github/scripts/checks/mermaid.sh -q --pr "${{ github.event.pull_request.number }}" "$doc"; then
+              echo "::error file=$doc::Diagram class validation failed (MM15)"
+              FAILED=1
+            fi
+          done <<< "${{ steps.changed.outputs.docs }}"
+
+          if [[ $FAILED -eq 1 ]]; then
+            echo "One or more design docs have incorrect diagram classes."
+            echo "Update the Mermaid diagram class assignments to match issue status."
+            exit 1
+          fi
+          echo "All diagram classes valid"

--- a/.github/workflows/validate-diagram-status.yml
+++ b/.github/workflows/validate-diagram-status.yml
@@ -1,0 +1,62 @@
+name: Validate Diagram Status for Closing Issues
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Extract issues closed by this PR
+        id: closed-issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+
+          # Use existing script to extract closing issues, compact to single line
+          ISSUES=$(.github/scripts/extract-closing-issues.sh --pr "$PR_NUMBER" | jq -c '.')
+          echo "issues=$ISSUES" >> $GITHUB_OUTPUT
+
+      - name: Validate diagram status for closed issues
+        if: steps.closed-issues.outputs.issues != '[]'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ISSUES='${{ steps.closed-issues.outputs.issues }}'
+          FAILED=0
+
+          # Parse JSON array to iterate over issue numbers
+          for issue_num in $(echo "$ISSUES" | jq -r '.[]'); do
+            # Find all design docs referencing this issue in Implementation Issues section
+            # Search both active and current design doc directories
+            DOCS=$(grep -l "\[#${issue_num}\]" docs/designs/DESIGN-*.md docs/designs/current/DESIGN-*.md 2>/dev/null || true)
+
+            [[ -z "$DOCS" ]] && continue
+
+            for doc in $DOCS; do
+              # Skip docs without mermaid diagrams
+              grep -q '```mermaid' "$doc" || continue
+
+              # Verify issue is marked as 'done' in the Mermaid diagram
+              if ! .github/scripts/check-issue-status.sh "$doc" "$issue_num" "done"; then
+                echo "::error file=$doc::Issue #$issue_num should be marked 'done' in diagram (PR closes this issue)"
+                FAILED=1
+              fi
+            done
+          done
+
+          if [[ $FAILED -eq 1 ]]; then
+            echo "Some issues being closed are not marked 'done' in their design doc diagrams."
+            echo "Update the Mermaid diagram class assignments before merging."
+            exit 1
+          fi
+          echo "All closing issues have correct status in design docs"


### PR DESCRIPTION
Update design document validation scripts and workflow.

---

## What This Changes

- `.github/scripts/validate-design-doc.sh` - Orchestrator that runs modular validation checks
- `.github/scripts/checks/` - Modular check scripts (common.sh, frontmatter.sh, etc.)
- `.github/workflows/validate-design-docs.yml` - Runs validation on all PRs

## How It Works

The workflow finds all DESIGN-*.md files in the repo and validates each one:
- Location: must be under docs/designs/
- Naming: must start with DESIGN-
- Frontmatter: must have valid YAML frontmatter