### PR TITLE
docs(work-on): trim the imported work-on extension to its map; rationale to README

### DIFF
--- a/.claude/shirabe-extensions/README.md
+++ b/.claude/shirabe-extensions/README.md
@@ -1,0 +1,27 @@
+# shirabe-extensions
+
+Project-specific `/work-on` configuration for the shirabe repo. The work-on skill imports
+`work-on.md` here via `@.claude/shirabe-extensions/work-on.md`, so that file is pulled into
+context on every `/work-on` run — keep it minimal. This README holds the rationale a reader
+wants but the skill does not need loaded (it is **not** imported).
+
+## `work-on.md` — the verification map
+
+`work-on.md` declares shirabe's verification map per the schema in
+[`skills/work-on/references/verification-map.md`](../../skills/work-on/references/verification-map.md).
+At the definition-of-done gate, `/work-on` matches an issue's changed files against the map,
+runs each matched entry's command(s), and requires every run to pass before the issue can
+finalize. A change matching no entry falls through to the default; a change with no match and
+no usable default yields cannot-verify and **fails closed** (never reads as "verified").
+
+### Entries
+
+- **`skills/** -> scripts/run-evals.sh <skill>`** — an issue that changes a skill must have
+  that skill's evals **executed and passing**, not merely present. `<skill>` is the changed
+  skill's directory name under `skills/`. This closes the `## Skill Evals` enforcement gap in
+  `CLAUDE.md`: the existence check (`check-evals-exist.sh`) is not a substitute for running the
+  evals.
+
+- **Default** (no entry matches) — every one of `cargo test --workspace`,
+  `skills/plan/scripts/plan-to-tasks_test.sh`, and `skills/work-on/scripts/run-cascade_test.sh`
+  must pass.

--- a/.claude/shirabe-extensions/work-on.md
+++ b/.claude/shirabe-extensions/work-on.md
@@ -1,30 +1,15 @@
 # work-on extension: shirabe
 
-Project-specific `/work-on` guidance for the shirabe repo. `/work-on` imports this file via
-`@.claude/shirabe-extensions/work-on.md` and reads the verification map below at its
-definition-of-done gate.
-
-This file declares shirabe's verification map per the schema in
-`skills/work-on/references/verification-map.md`. The gate matches an issue's changed files
-against the map, runs each matched entry's command(s), and requires every run to pass before
-the issue can finalize. A change matching no entry falls through to the default; a change with
-no match and no usable default yields cannot-verify and fails closed.
+shirabe's `/work-on` verification map (read by the definition-of-done gate). Schema:
+`skills/work-on/references/verification-map.md`. Rationale: `README.md` in this directory.
+This file is `@`-imported by the work-on skill, so it stays minimal.
 
 ## Verification map
 
 - `skills/**` -> `scripts/run-evals.sh <skill>`
 
-  An issue that changes a skill must have that skill's evals **executed and passing**, not
-  merely present. `<skill>` is the changed skill's name (the directory under `skills/`). This
-  closes the `## Skill Evals` enforcement gap in CLAUDE.md: the existence check
-  (`check-evals-exist.sh`) is not a substitute for running the evals.
-
-### Default verification command
-
-When no map entry matches the changed files, run all of:
+### Default verification command (when no map entry matches; all must pass)
 
 - `cargo test --workspace`
 - `skills/plan/scripts/plan-to-tasks_test.sh`
 - `skills/work-on/scripts/run-cascade_test.sh`
-
-Every one must pass for the default to pass.


### PR DESCRIPTION
Trim `.claude/shirabe-extensions/work-on.md` — which the work-on skill `@`-imports into
context on every `/work-on` run — to just its load-bearing content: the verification map
(`skills/** -> scripts/run-evals.sh <skill>`) and the default verification commands, plus a
one-line pointer to the schema and README. Move the explanatory rationale (why evals must run,
the cannot-verify/fail-closed contract, the `## Skill Evals` gap it closes) into a new
`.claude/shirabe-extensions/README.md`, which is not imported. The imported file drops from 31
to 15 lines.

---

## Why

`@`-imports pull the **raw file bytes** into context verbatim — Markdown/HTML comments are not
stripped, so the only way to cut the per-session token cost of an imported file is to remove
text from it. Moving the reader-oriented rationale to a sibling `README.md` (which the skill
does not import) keeps it on disk for humans while taking it out of every `/work-on` context
load.

## Behavior

Behavior-neutral. The only machine-consumed content — the verification map and default
commands the definition-of-done gate reads — is preserved verbatim; only reader prose moved.
The `@.claude/shirabe-extensions/work-on.md` import still resolves and the map is unchanged, so
the gate's behavior is identical. (For that reason this doesn't re-run the `work-on` eval suite:
the change alters no skill behavior, and the suite's pre-existing failures are tracked in #186
and #202.)

## Test Plan

- [x] Verification map intact in the imported file (`skills/**` entry + the three default commands)
- [x] `@`-import target resolves; `README.md` is git-trackable (dir negation in `.gitignore`)
- [x] `shirabe validate` clean on both files
- [x] Rationale present in `README.md`, absent from the imported file

Follows #201 (which introduced the extension file).
