### PR TITLE
test(execute): align plan-only (tier-1) assertions with describe-only output

### DIFF
--- a/skills/execute/evals/evals.json
+++ b/skills/execute/evals/evals.json
@@ -123,7 +123,7 @@
       "files": [],
       "expectations": [
         "Agent recognizes that a failed issue (issue 3 done_blocked) causes its dependent (issue 4) to be skipped via failure_policy: skip_dependents",
-        "Agent understands the skipped dependent enters with mode: skipped and routes to skipped_due_to_dep_failure without implementation work",
+        "Agent describes that the skipped dependent (issue 4) is marked skipped due to its dependency's failure and does no implementation work for it (the koto runtime routes it to the work-on skipped terminal; the agent need not reproduce the runtime tokens mode: skipped / skipped_due_to_dep_failure verbatim)",
         "Agent submits batch_outcome: needs_attention and routes to escalate (not pr_finalization)",
         "Agent names the failed child and the skipped dependent (with skipped_because_chain) in the failure_reason",
         "Agent does NOT retry the failed child"
@@ -195,7 +195,7 @@
         "Agent submits batch_outcome: needs_attention when a child reaches done_blocked",
         "Agent routes to escalate state (not pr_finalization) when needs_attention",
         "Agent reads batch_final_view in escalate state for per-child failure details",
-        "Agent includes failure_reason from batch_final_view in the summary",
+        "Agent describes surfacing the failed child's name and reason (drawn from the batch_final_view per-child data it plans to read) in the failure_reason summary, rather than producing the runtime-read values verbatim",
         "Agent routes to done_blocked after escalate (no retry) and records the abandonment-forced forced-stop summary"
       ]
     },


### PR DESCRIPTION
Reword two tier-1 `plan_only` execute eval expectations that demanded koto-emitted runtime tokens a describe-only run cannot produce. In `parity-failed-issue-skips-dependents` (id 8) and `execute-plan-needs-attention` (id 12), accept the equivalently-described behavior instead of the verbatim runtime literals (`mode: skipped`, `skipped_due_to_dep_failure`, and the runtime content read from `batch_final_view`), while preserving the behavioral distinction each eval checks. Expectations whose tokens appear verbatim in the execute skill prose are left unchanged.

---

## What This Fixes

The runner instructs tier-1 agents to "describe the exact sequence of commands... Do NOT execute any commands," so no tools run and no koto/gh runtime output is captured. Two expectations nonetheless required runtime literals that exist only in koto's output or in the work-on skill prose, not in the execute skill the agent reads. Substantively-correct plans failed on those literals rather than on behavioral signal.

## Expectations changed

`parity-failed-issue-skips-dependents` (id 8), expectation 2:
- Before: "Agent understands the skipped dependent enters with mode: skipped and routes to skipped_due_to_dep_failure without implementation work"
- After: "Agent describes that the skipped dependent (issue 4) is marked skipped due to its dependency's failure and does no implementation work for it (the koto runtime routes it to the work-on skipped terminal; the agent need not reproduce the runtime tokens mode: skipped / skipped_due_to_dep_failure verbatim)"
- `mode: skipped` and `skipped_due_to_dep_failure` appear only in `skills/work-on/` prose, not in the execute skill, and are emitted by koto's `failure_policy: skip_dependents` machinery. The reworded expectation still requires recognizing the skip-due-to-dependency-failure semantics and that no implementation work happens for the dependent.

`execute-plan-needs-attention` (id 12), expectation 4:
- Before: "Agent includes failure_reason from batch_final_view in the summary"
- After: "Agent describes surfacing the failed child's name and reason (drawn from the batch_final_view per-child data it plans to read) in the failure_reason summary, rather than producing the runtime-read values verbatim"
- The `batch_final_view` field name is in execute prose (so reading it stays describable, and expectation 3 is unchanged), but the values read from it at runtime cannot exist in a plan.

## Left unchanged

`execute-plan-detection-from-path` (id 14) and `execute-plan-completion-cascade` (id 18): their tokens (`execute.md` template, `PLAN_DOC`, `plan-to-tasks.sh`, `koto next --with-data`, `run-cascade.sh --push {{PLAN_DOC}}`, `cascade_status` field and enum, `gh pr ready`) appear verbatim in `skills/execute/koto-templates/execute.md` / `SKILL.md`, so a correct plan can cite them. The runtime/in-prose split was verified by grepping each token against those files.

## Validation

Deterministic: `python3 -m json.tool` confirms `evals.json` stays valid; the token-presence audit confirms the runtime-versus-prose split above.

Direct describe-only runs of the four target evals, graded against the reworded expectations: `parity-failed-issue-skips-dependents` 5/5, `execute-plan-needs-attention` 5/5, and the unchanged `execute-plan-completion-cascade` 5/5. The correct `parity-failed-issue-skips-dependents` plan contained zero occurrences of `mode: skipped` / `skipped_due_to_dep_failure` while containing every in-prose token, which confirms two things: the original expectation 2 would have failed a substantively-correct plan (the root mismatch), and the rewording accepts described behavior without making the eval pass trivially (the in-prose expectations still discriminate). No eval is re-tiered, which avoids duplicating the existing tier-2 coverage in `e2e-execute-escalate-recovery` / `e2e-execute-happy-path` / `parity-finalization-cascade-atomic`.

The model-graded suite (`scripts/run-evals.sh execute`) could not run here: the nested `claude -p` invocation of `/skill-creator` enters plan mode and blocks because the harness passes no `--permission-mode`, so it grades 0/33 (pre-existing, harness untouched by this change; tracked in #214). The direct runs above are the validation of record.

Fixes #209
Part of #205
