### PR TITLE
fix(execute): self-resolve plugin root in preflight.sh

### DIFF
--- a/.github/workflows/check-execute-scripts.yml
+++ b/.github/workflows/check-execute-scripts.yml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Run cascade tests
         run: bash skills/execute/scripts/run-cascade_test.sh
+
+      - name: Run preflight tests
+        run: bash skills/execute/scripts/preflight_test.sh

--- a/skills/execute/scripts/preflight.sh
+++ b/skills/execute/scripts/preflight.sh
@@ -11,7 +11,12 @@
 # (the load-bearing cross-skill coupling). This preflight makes it loud and early.
 set -euo pipefail
 
-ROOT="${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT is not set; /execute cannot resolve the cross-skill child template}"
+# Resolve the plugin root. Prefer $CLAUDE_PLUGIN_ROOT when the loader exported it,
+# but fall back to the script's own location so the preflight works from a plain
+# shell (e.g. an agent running it directly) where the env var may be unset. This
+# script lives at skills/execute/scripts/, so ../../.. is the plugin root. The
+# real assertion remains the child-template existence check below.
+ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}"
 CHILD="$ROOT/skills/work-on/koto-templates/work-on.md"
 
 if [[ ! -f "$CHILD" ]]; then

--- a/skills/execute/scripts/preflight_test.sh
+++ b/skills/execute/scripts/preflight_test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# preflight_test.sh — Test harness for preflight.sh
+# Part of the execute skill
+#
+# Asserts that the /execute preflight resolves the plugin root without depending
+# on $CLAUDE_PLUGIN_ROOT being exported, while keeping the cross-skill child
+# template (work-on.md) existence check as the real assertion.
+#
+# Usage: preflight_test.sh
+#
+# Exit codes:
+#   0 — all cases pass
+#   1 — one or more cases failed
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+PREFLIGHT="$SCRIPT_DIR/preflight.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}PASS${NC}: $*"; ((PASS_COUNT++)) || true; }
+fail() { echo -e "${RED}FAIL${NC}: $*"; ((FAIL_COUNT++)) || true; }
+
+TMPS=()
+cleanup() { for d in "${TMPS[@]:-}"; do [[ -n "$d" ]] && rm -rf "$d"; done; }
+trap cleanup EXIT
+
+# Case 1 — unset CLAUDE_PLUGIN_ROOT: self-resolves from the script's own location
+# (the real checkout, where work-on.md exists) and succeeds.
+if env -u CLAUDE_PLUGIN_ROOT bash "$PREFLIGHT" >/dev/null 2>&1; then
+    pass "unset CLAUDE_PLUGIN_ROOT -> self-resolves and exits 0"
+else
+    fail "unset CLAUDE_PLUGIN_ROOT should self-resolve and exit 0, but it failed"
+fi
+
+# Case 2 — env-var precedence: point CLAUDE_PLUGIN_ROOT at a DISTINCT valid root
+# (a temp tree with its own work-on.md) and confirm the preflight resolves
+# against THAT root, not the self-resolved checkout.
+ALT_ROOT=$(mktemp -d); TMPS+=("$ALT_ROOT")
+mkdir -p "$ALT_ROOT/skills/work-on/koto-templates"
+touch "$ALT_ROOT/skills/work-on/koto-templates/work-on.md"
+out=$(CLAUDE_PLUGIN_ROOT="$ALT_ROOT" bash "$PREFLIGHT" 2>&1) || true
+if [[ "$out" == *"$ALT_ROOT/skills/work-on/koto-templates/work-on.md"* ]]; then
+    pass "CLAUDE_PLUGIN_ROOT takes precedence over self-resolution"
+else
+    fail "CLAUDE_PLUGIN_ROOT should take precedence; got: $out"
+fi
+
+# Case 3 — env-var path, missing child: the existence assertion must fire (exit 1).
+EMPTY_DIR=$(mktemp -d); TMPS+=("$EMPTY_DIR")
+if CLAUDE_PLUGIN_ROOT="$EMPTY_DIR" bash "$PREFLIGHT" >/dev/null 2>&1; then
+    fail "missing child template (env-var root) should exit 1, but it passed"
+else
+    pass "missing child template (env-var root) -> exits 1 (assertion fires)"
+fi
+
+# Case 4 — self-resolve path, missing child: copy the script into a fake plugin
+# tree that lacks work-on.md and run with the env var unset; the assertion must fire.
+FAKE_ROOT=$(mktemp -d); TMPS+=("$FAKE_ROOT")
+mkdir -p "$FAKE_ROOT/skills/execute/scripts"
+cp "$PREFLIGHT" "$FAKE_ROOT/skills/execute/scripts/preflight.sh"
+if env -u CLAUDE_PLUGIN_ROOT bash "$FAKE_ROOT/skills/execute/scripts/preflight.sh" >/dev/null 2>&1; then
+    fail "missing child template (self-resolved root) should exit 1, but it passed"
+else
+    pass "missing child template (self-resolved root) -> exits 1 (assertion fires)"
+fi
+
+echo
+echo "preflight_test.sh: $PASS_COUNT passed, $FAIL_COUNT failed"
+[[ "$FAIL_COUNT" -eq 0 ]]


### PR DESCRIPTION
preflight.sh resolved the plugin root with `${CLAUDE_PLUGIN_ROOT:?...}`, which aborts the script when that variable is not exported into the shell, even though the script sits at a fixed location inside the plugin. Resolve the root from the script's own path via BASH_SOURCE, keeping `$CLAUDE_PLUGIN_ROOT` as an override when set; the cross-skill work-on.md existence check stays the real assertion. Add preflight_test.sh and run it in the check-execute-scripts workflow.

---

## What This Fixes

`/execute`'s Step-1 preflight is the load-bearing check that the cross-skill `work-on.md` child template resolves before any child is spawned. It aborted with `CLAUDE_PLUGIN_ROOT is not set` whenever the variable was not exported — e.g. when an agent drives the script from a plain Bash shell — failing before it could do its real job. Since the script lives at a fixed path (`skills/execute/scripts/`), it can resolve the plugin root from its own location.

The change is `${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}`: prefer the env var when set, otherwise self-resolve. This matches the existing repo idiom (`run-cascade_test.sh` and the evals `test-cli.sh` scripts use the same form). The `[[ -f "$CHILD" ]]` assertion is unchanged, so a genuinely missing/misresolved template still fails loudly.

## Changes

- `skills/execute/scripts/preflight.sh`: self-resolving plugin-root fallback with env-var precedence.
- `skills/execute/scripts/preflight_test.sh`: new harness — unset self-resolves; env var takes precedence over a distinct root; missing template fails on both the env-var and self-resolve paths.
- `.github/workflows/check-execute-scripts.yml`: run `preflight_test.sh` alongside the cascade tests.

## Verification

- `preflight_test.sh` 4/4; `run-cascade_test.sh` 16/0 (no sibling regression).

Fixes #215