### PR TITLE
docs: make DRAFT-vs-READY handoff trigger and coordination-PR exception explicit

### DIFF
--- a/docs/designs/current/DESIGN-lifecycle-draft-ready-discipline.md
+++ b/docs/designs/current/DESIGN-lifecycle-draft-ready-discipline.md
@@ -38,6 +38,39 @@ The DESIGN is at Planned while the implementation lands. On chain
 completion the file promotes to `docs/designs/current/` at status
 Current.
 
+## The Discipline
+
+The rule this design enforces is one sentence: **a PR flips from draft
+to ready-for-review at the moment verified work is handed to a human to
+review.** The flip is gated on verification passing — tests green, the
+adversarial review clean. Draft is *only* for work that is still in
+progress or not yet verified. The instant an agent asks a human to look,
+the PR must already read "ready": on GitHub a draft PR tells reviewers to
+hold off and suppresses review-request notifications and some CI, so
+handing a human a draft to review sends the opposite signal from the PR's
+own state.
+
+Two events are distinct and easy to conflate:
+
+- **Marking ready is the agent's signal** — "this is verified; review is
+  now invited." The agent does it at the handoff, gated on verification.
+- **Merging is the human's action**, taken after review.
+
+The agent marks ready; the human merges. An agent must never leave
+verified, review-ready work sitting in draft on the assumption that the
+human will "mark it ready and merge" — those are two different events with
+two different owners.
+
+**The one exception — the coordination PR.** In a coordinated multi-repo
+effort the per-repo implementation PRs follow the rule above: each flips
+to ready at its own review handoff. The coordination PR does not. It is
+docs-only and gated on every indexed per-repo PR merging first, so draft
+is its correct resting state throughout review — it **stays draft until it
+merges last**. The rule is therefore: per-repo impl PRs go ready at
+handoff; the coordination PR stays draft until it merges last. See
+[`references/coordination-strategy.md`](../../../references/coordination-strategy.md)
+for the merge-last contract.
+
 ## Context and Problem Statement
 
 The previous increment landed `shirabe validate --lifecycle <root>` —

--- a/docs/guides/execute-friction.md
+++ b/docs/guides/execute-friction.md
@@ -42,7 +42,11 @@ PR-Index and the merge-order block. Code never lands there.
 For each repository that needs changes, `/execute` works that repo in its own
 worktree on that repo's own branch and lands its changes as a separate per-repo PR.
 Cross-unit context flows through the coordination PR's durable state, not through a
-shared branch. The coordination PR merges last, once every per-repo PR has merged.
+shared branch. The coordination PR merges last, once every per-repo PR has merged —
+and it stays draft until then, while each per-repo PR flips to ready-for-review at
+its own review handoff. The coordination PR is the one PR whose correct resting
+state throughout review is draft; every other PR goes ready when its verified work
+is handed off.
 
 What this means for you: do not expect cross-repo code on the coordination branch.
 Each repo gets its own PR; the coordination PR is the index that ties them together

--- a/references/coordination-strategy.md
+++ b/references/coordination-strategy.md
@@ -31,6 +31,14 @@ coordination state (the PR-index and the merge-order block). Per-repo
 implementation lands as separate PRs. The coordination PR merges **last**, and
 that merge is the effort's done-signal.
 
+Because it is gated on every indexed per-repo PR merging first, the coordination
+PR **stays draft until it merges last** — draft is its correct resting state
+throughout review, not an oversight. This is the standing exception to the
+[DRAFT-vs-READY discipline](../docs/designs/current/DESIGN-lifecycle-draft-ready-discipline.md):
+the per-repo implementation PRs each flip to ready-for-review at their own review
+handoff once their work is verified, while the coordination PR alone stays draft
+until last.
+
 Coordinated mode is the third `execution_mode` value (`single-pr | multi-pr |
 coordinated`). It is always multi-PR, and adds what `multi-pr` lacks: a
 coordination PR that merges last, cross-repo per-repo grouping, and a two-node


### PR DESCRIPTION
Sharpen the wording of shirabe's DRAFT-vs-READY discipline docs so the flip-to-ready trigger and the coordination-PR exception are stated explicitly rather than left implicit in the automated-cascade framing.

Add a "The Discipline" section to `DESIGN-lifecycle-draft-ready-discipline.md` stating the rule as first-class: a PR flips from draft to ready-for-review at the review handoff (gated on verification passing), draft is only for in-progress or unverified work, marking ready (the agent's signal) is distinct from merging (the human's action after review), and the coordination PR is the one exception that stays draft until it merges last. State that coordination-PR exception in plain words in `references/coordination-strategy.md` with a cross-link back to the design doc as the single source, and sharpen the agent-facing coordinated section of `docs/guides/execute-friction.md` to match.

---

## What This Accomplishes

The discipline docs framed the draft-to-ready flip almost entirely as "the work-on/execute cascade fires `gh pr ready` after the verify step," which left the general rule implicit for anyone driving a manual or coordinated process. An agent could finish verified work, pass review with tests green, and still hand a human a draft PR to review — self-contradictory, since a draft PR signals "not ready for review."

This makes the rule first-class in the canonical doc and states the single carve-out (the coordination PR stays draft until it merges last, while per-repo impl PRs go ready at handoff) in plain words. Wording only: no new lifecycle states, no CLI changes, no SKILL.md changes. Net +46/-1 across three docs, single-sourced from the canonical design doc.

Validation: `shirabe validate` passes on all three touched docs; `shirabe validate --lifecycle .` passes clean.
