### PR TITLE
feat: add client-side PR-body PreToolUse hook

### DIFF
--- a/crates/shirabe-validate/src/lib.rs
+++ b/crates/shirabe-validate/src/lib.rs
@@ -57,7 +57,7 @@ pub use merge_gate::{
     check_index_visibility, coordination_pr_visibility, run_merge_gate, split_pr_arg,
     GhVisibilityResolver, MergeGateOutcome,
 };
-pub use pr_body::{check_pr_body, PrBodyFinding};
+pub use pr_body::{check_pr_body, check_pr_title, PrBodyFinding};
 pub use report::{
     render_human, render_human_with_advisory, render_json, render_json_with_advisory,
 };

--- a/crates/shirabe-validate/src/pr_body.rs
+++ b/crates/shirabe-validate/src/pr_body.rs
@@ -124,6 +124,18 @@ pub fn check_pr_body(body: &str, title: Option<&str>) -> Vec<PrBodyFinding> {
     findings
 }
 
+/// Check only PB1 (the Conventional Commits title) and nothing else.
+///
+/// This exposes the same title rule [`check_pr_body`] applies, without the
+/// body-level PB2/PB3 checks, for a caller that has a title but no body — for
+/// instance the client-side PreToolUse hook evaluating a `gh pr edit --title`
+/// that changes only the title. It reuses the existing private [`check_title`]
+/// scan; it does not restate PB1. Returns `Some(finding)` (with `line: 1`, the
+/// title-level line) when the title is non-conforming, `None` when it passes.
+pub fn check_pr_title(title: &str) -> Option<PrBodyFinding> {
+    check_title(title).map(|message| PrBodyFinding { line: 1, message })
+}
+
 /// PB1: return `Some(message)` when `title` is not a valid Conventional Commits
 /// header, `None` when it conforms. The parse is a small hand-written scan
 /// (no regex dependency), matching this crate's style.

--- a/crates/shirabe/src/main.rs
+++ b/crates/shirabe/src/main.rs
@@ -22,6 +22,7 @@ use shirabe_validate::{
 };
 
 mod populate;
+mod pr_body_hook;
 mod work_summary;
 
 /// The maximum accepted size of the `--custom-statuses` value, matching the
@@ -89,6 +90,15 @@ enum Commands {
     /// emit hook JSON) and the `/inflight` skill (`render`, which prints the
     /// plain block). Every subcommand exits 0 (fail-safe).
     WorkSummary(work_summary::WorkSummaryArgs),
+    /// Client-side PreToolUse hook: gate a `gh pr create` / `gh pr edit`
+    /// command against the mechanical PR-body rule
+    /// (references/pr-body-conformance.md) before it runs. Reads a Claude Code
+    /// hook JSON on stdin, reuses the `validate --pr-body` engine, and emits a
+    /// PreToolUse `deny` decision naming the findings — or nothing (allow) when
+    /// the body/title is clean or cannot be confidently extracted. Fail-safe:
+    /// always exits 0. Registered via dot-niwa; the CI `pr-body.yml` gate is
+    /// the authoritative backstop.
+    PrBodyHook,
 }
 
 #[derive(clap::Args)]
@@ -358,6 +368,7 @@ fn main() -> ExitCode {
         Some(Commands::SlugPrefixDetect(args)) => run_slug_prefix_detect(&args),
         Some(Commands::InstallHooks(args)) => run_install_hooks_cmd(&args),
         Some(Commands::WorkSummary(args)) => work_summary::run(&args.command),
+        Some(Commands::PrBodyHook) => pr_body_hook::run(),
         // Bare invocation: print the long help to stdout and exit 0,
         // matching cobra's behavior for a command with no `Run`. clap would
         // otherwise leave `command` as `None` and exit 0 silently.

--- a/crates/shirabe/src/pr_body_hook.rs
+++ b/crates/shirabe/src/pr_body_hook.rs
@@ -1,0 +1,581 @@
+//! The `shirabe pr-body-hook` subcommand: a Claude Code **PreToolUse** adapter
+//! that gates a `gh pr create` / `gh pr edit` command against the mechanical
+//! PR-body rule before the command runs.
+//!
+//! This is the authoring-time analog of the reactive `pr-body.yml` CI gate
+//! (DESIGN-pr-template-gate, "client-side PreToolUse hook" increment). It is a
+//! fail-safe hook adapter in the shape of [`crate::work_summary`], **not** a
+//! `validate` mode: it reads a hook JSON on stdin, emits hook JSON with a
+//! permission decision, and ALWAYS exits 0. It adds no rule — it reuses
+//! [`shirabe_validate::check_pr_body`] / [`shirabe_validate::check_pr_title`],
+//! the same engine `validate --pr-body` calls, so PB1-PB3 are stated once in
+//! `references/pr-body-conformance.md` and enforced by CI, the skills, and this
+//! hook alike.
+//!
+//! Behavior (DESIGN D8/D9):
+//!
+//! - It extracts the submitted `--title`, `--body`, and `--body-file <path>`
+//!   from the command's **argv tokens** (never by shell-evaluating the
+//!   command). A `--body-file` path is read from disk.
+//! - When a title and/or body is extractable and the checks return findings,
+//!   it **denies** the tool call and returns the findings as the decision
+//!   reason, so the agent sees what to fix and re-issues a corrected command.
+//! - In every ambiguous case — the command is not a recognized
+//!   `gh pr create`/`edit`, no title/body can be extracted, a `--body-file`
+//!   cannot be read, `--fill`/`--web`/`--body-file -` is used, a body carries a
+//!   command substitution, or the stdin is malformed — it **allows** (emits
+//!   nothing). The CI gate is the authoritative backstop that makes fail-open
+//!   safe.
+//!
+//! Security: the command, title, and body are attacker-controlled. The command
+//! is never shell-evaluated; the deny reason is assembled with `serde_json`, so
+//! the title/body is always a JSON string value, never concatenated into a
+//! terminal control sequence. The adapter runs no subprocess and writes nothing.
+//!
+//! Env seam: `PR_BODY_HOOK_DISABLE=1` short-circuits to allow (an operator kill
+//! switch that does not require unwiring the hook), mirroring the `WS_*` seams.
+
+use std::io::Read;
+use std::process::ExitCode;
+
+use shirabe_validate::{check_pr_body, check_pr_title, PrBodyFinding};
+
+/// Entry point for `shirabe pr-body-hook`. Always returns
+/// `ExitCode::SUCCESS`: the adapter is fail-safe and must never abort the
+/// tool call with a non-zero code — a block is expressed as a `deny` decision
+/// in the emitted hook JSON, not as a process exit code.
+pub fn run() -> ExitCode {
+    if disabled() {
+        return ExitCode::SUCCESS;
+    }
+    let input = read_stdin();
+    if let Some(reason) = evaluate(&input) {
+        emit_deny(&reason);
+    }
+    ExitCode::SUCCESS
+}
+
+/// The kill switch: `PR_BODY_HOOK_DISABLE=1` (any non-empty value other than
+/// `0`/`false`) turns the adapter into an unconditional allow.
+fn disabled() -> bool {
+    match std::env::var("PR_BODY_HOOK_DISABLE") {
+        Ok(v) => !v.is_empty() && v != "0" && v != "false",
+        Err(_) => false,
+    }
+}
+
+fn read_stdin() -> String {
+    let mut s = String::new();
+    let _ = std::io::stdin().read_to_string(&mut s);
+    s
+}
+
+/// Core logic, split out for testability: given the raw PreToolUse hook JSON,
+/// return `Some(reason)` when the command should be **denied** (the reason
+/// lists the PB findings) or `None` when it should be **allowed**.
+///
+/// Every failure path returns `None` (fail-open, DESIGN D9).
+fn evaluate(input: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(input).ok()?;
+    let command = v
+        .get("tool_input")
+        .and_then(|t| t.get("command"))
+        .and_then(|c| c.as_str())?;
+
+    let (_action, tokens) = find_gh_pr_command(command)?;
+    let extracted = extract_fields(&tokens);
+
+    let findings: Vec<PrBodyFinding> = match (extracted.body, extracted.title) {
+        // A body is present: run the full body-level checks (PB2/PB3) plus the
+        // title check (PB1) when a title is also present. This covers a
+        // `gh pr create` (both) and a `gh pr edit --body` (body only).
+        (Some(body), title) => check_pr_body(&body, title.as_deref()),
+        // Title only (e.g. `gh pr edit --title`): run PB1 alone. Passing an
+        // empty body to `check_pr_body` would spuriously fire PB2, so the
+        // title-only path uses the dedicated title check.
+        (None, Some(title)) => check_pr_title(&title).into_iter().collect(),
+        // Nothing extractable to check (e.g. `gh pr edit 12 --add-label x`,
+        // or `--fill`): allow.
+        (None, None) => return None,
+    };
+
+    if findings.is_empty() {
+        None
+    } else {
+        Some(render_reason(&findings))
+    }
+}
+
+/// The action word of a recognized `gh pr` command.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PrAction {
+    Create,
+    Edit,
+}
+
+/// Locate a `gh ... pr create|edit` invocation in a (possibly compound)
+/// command and return its action plus the argv tokens **after** the action
+/// word (from which the option values are read).
+///
+/// The command is split into per-command token lists by [`tokenize_segments`]
+/// (quote-aware, so a multi-line inline `--body` stays one token). `gh` is
+/// matched only in **command-head** position — the first token that is not a
+/// leading `NAME=value` env-assignment — so `echo gh pr create ...` is not
+/// mistaken for a real invocation. Within that command, `pr` then
+/// `create`/`edit` are matched as bare tokens. Returns `None` when the command
+/// does not tokenize (unbalanced quote) or contains no such invocation —
+/// fail-open.
+fn find_gh_pr_command(cmd: &str) -> Option<(PrAction, Vec<String>)> {
+    let segments = tokenize_segments(cmd)?;
+    for seg in &segments {
+        // The command head is the first token that is not a leading
+        // `NAME=value` env-assignment; it must be exactly `gh`.
+        let head = match seg.iter().position(|t| !is_env_assignment(t)) {
+            Some(i) => i,
+            None => continue,
+        };
+        if seg[head] != "gh" {
+            continue;
+        }
+        // Within this command, require `pr` then `create`/`edit` as bare
+        // tokens; return the argv tokens that follow the action word.
+        let rest = &seg[head + 1..];
+        let pr_i = match rest.iter().position(|t| t == "pr") {
+            Some(i) => i,
+            None => continue,
+        };
+        let action = rest[pr_i + 1..]
+            .iter()
+            .enumerate()
+            .find_map(|(k, t)| match t.as_str() {
+                "create" => Some((k, PrAction::Create)),
+                "edit" => Some((k, PrAction::Edit)),
+                _ => None,
+            });
+        if let Some((off, action)) = action {
+            let after_action = pr_i + 1 + off + 1;
+            return Some((action, rest[after_action..].to_vec()));
+        }
+    }
+    None
+}
+
+/// True when `t` is a shell env-assignment token `NAME=value` with `NAME` a
+/// valid identifier (so a leading `GH_TOKEN=x` before `gh` is skipped, while a
+/// real first word such as `echo` or `gh` is not).
+fn is_env_assignment(t: &str) -> bool {
+    match t.split_once('=') {
+        Some((name, _)) => {
+            !name.is_empty()
+                && name
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+                && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        }
+        None => false,
+    }
+}
+
+/// Conservative shell-ish tokenizer that splits a (possibly compound) command
+/// into per-command token lists. Unquoted whitespace ends a token; the unquoted
+/// command separators `;` `|` `&` end the current command and start a new one,
+/// so `gh` is only ever matched in command-head position (`cd x && gh pr
+/// create ...` yields two commands). Single- and double-quoted spans are taken
+/// literally — including any newlines — since this adapter never expands or
+/// evaluates; a backslash outside quotes escapes the next character. Returns
+/// `None` on an unterminated quote, so the caller fails open.
+///
+/// Not a full shell parser: it performs no variable or command substitution.
+/// Bodies relying on `$(...)`, backticks, or heredocs surface as opaque tokens
+/// and are rejected at extraction time (see [`resolve_body_value`] /
+/// [`read_body_file`]).
+fn tokenize_segments(input: &str) -> Option<Vec<Vec<String>>> {
+    let mut segments: Vec<Vec<String>> = Vec::new();
+    let mut seg: Vec<String> = Vec::new();
+    let mut cur = String::new();
+    let mut in_token = false;
+    let mut chars = input.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '\'' => {
+                in_token = true;
+                loop {
+                    match chars.next() {
+                        Some('\'') => break,
+                        Some(ch) => cur.push(ch),
+                        None => return None, // unterminated single quote
+                    }
+                }
+            }
+            '"' => {
+                in_token = true;
+                loop {
+                    match chars.next() {
+                        Some('"') => break,
+                        Some('\\') => {
+                            // Inside double quotes a backslash escapes only a
+                            // small set; keep it literal otherwise.
+                            match chars.next() {
+                                Some(n @ ('"' | '\\' | '$' | '`')) => cur.push(n),
+                                Some(n) => {
+                                    cur.push('\\');
+                                    cur.push(n);
+                                }
+                                None => return None,
+                            }
+                        }
+                        Some(ch) => cur.push(ch),
+                        None => return None, // unterminated double quote
+                    }
+                }
+            }
+            '\\' => {
+                in_token = true;
+                match chars.next() {
+                    Some(n) => cur.push(n),
+                    None => return None,
+                }
+            }
+            // Command separators end the current token AND the current command.
+            ';' | '|' | '&' => {
+                if in_token {
+                    seg.push(std::mem::take(&mut cur));
+                    in_token = false;
+                }
+                if !seg.is_empty() {
+                    segments.push(std::mem::take(&mut seg));
+                }
+            }
+            c if c.is_whitespace() => {
+                if in_token {
+                    seg.push(std::mem::take(&mut cur));
+                    in_token = false;
+                }
+            }
+            _ => {
+                in_token = true;
+                cur.push(c);
+            }
+        }
+    }
+    if in_token {
+        seg.push(cur);
+    }
+    if !seg.is_empty() {
+        segments.push(seg);
+    }
+    Some(segments)
+}
+
+/// The title/body fields pulled out of a `gh pr create|edit` argv.
+#[derive(Default, Debug)]
+struct Fields {
+    title: Option<String>,
+    body: Option<String>,
+}
+
+/// Read the `--title`/`-t`, `--body`/`-b`, and `--body-file`/`-F` option values
+/// out of the argv tokens. `--flag=value` and `--flag value` forms are both
+/// accepted. `--fill`, `--fill-first`, `--web`, an inline body carrying a
+/// command substitution, and a `--body-file` that is `-` or unreadable each
+/// leave `body` as `None` (nothing confidently extractable → allow).
+fn extract_fields(tokens: &[String]) -> Fields {
+    let mut fields = Fields::default();
+    let mut body_file: Option<String> = None;
+    let mut i = 0;
+    while i < tokens.len() {
+        let t = tokens[i].as_str();
+        // Split `--flag=value` (an option token only — a bare `a=b` is not a
+        // flag) into (flag, inline-value); otherwise the value is the next
+        // token, consumed by advancing `i`.
+        let (flag, inline) = match t.split_once('=') {
+            Some((f, v)) if f.starts_with('-') => (f, Some(v.to_string())),
+            _ => (t, None),
+        };
+        let slot = match flag {
+            "--title" | "-t" => Some(&mut fields.title),
+            "--body" | "-b" => Some(&mut fields.body),
+            "--body-file" | "-F" => Some(&mut body_file),
+            _ => None,
+        };
+        if let Some(slot) = slot {
+            if let Some(v) = inline {
+                *slot = Some(v);
+            } else if i + 1 < tokens.len() {
+                *slot = Some(tokens[i + 1].clone());
+                i += 1;
+            }
+        }
+        i += 1;
+    }
+
+    // Resolve the inline body: reject a command-substitution body (unresolvable
+    // statically) so we do not check a literal `$(...)` string.
+    if let Some(b) = fields.body.take() {
+        fields.body = resolve_body_value(b);
+    }
+    // A `--body-file` overrides only when we have no inline body. Read it from
+    // disk; any failure leaves the body `None` (fail-open).
+    if fields.body.is_none() {
+        if let Some(path) = body_file {
+            fields.body = read_body_file(&path);
+        }
+    }
+    fields
+}
+
+/// Accept an inline `--body` value unless it looks like an unresolved shell
+/// expansion (command substitution), which this adapter cannot evaluate — in
+/// that case return `None` so the command is allowed and the CI gate checks it.
+fn resolve_body_value(body: String) -> Option<String> {
+    if body.contains("$(") || body.contains('`') {
+        return None;
+    }
+    Some(body)
+}
+
+/// Read a `--body-file` path. Returns `None` for stdin (`-`), a path carrying a
+/// process/command substitution, or any I/O failure — every one is treated as
+/// "no confidently extractable body" (fail-open, DESIGN D9).
+fn read_body_file(path: &str) -> Option<String> {
+    if path == "-" || path.contains("$(") || path.contains('`') || path.starts_with("<(") {
+        return None;
+    }
+    std::fs::read_to_string(path).ok()
+}
+
+/// Render the deny reason from the findings: a fixed prefix line the agent can
+/// recognize, then one `- <message>` line per finding.
+fn render_reason(findings: &[PrBodyFinding]) -> String {
+    let mut out =
+        String::from("PR body check failed (references/pr-body-conformance.md). Fix and re-run:");
+    for f in findings {
+        out.push_str("\n- ");
+        out.push_str(&f.message);
+    }
+    out
+}
+
+/// Print the PreToolUse `deny` hook JSON. The reason is placed in a
+/// `serde_json` string value, so an attacker-influenceable title/body can never
+/// break out of the JSON string or inject a terminal control sequence. Matches
+/// the shape the existing `gate-online` PreToolUse hook emits.
+fn emit_deny(reason: &str) {
+    let value = serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": reason,
+        }
+    });
+    if let Ok(s) = serde_json::to_string(&value) {
+        println!("{s}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a PreToolUse hook JSON with `command` as the Bash tool input.
+    fn hook(command: &str) -> String {
+        serde_json::json!({
+            "session_id": "s1",
+            "tool_name": "Bash",
+            "tool_input": { "command": command },
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn clean_create_is_allowed() {
+        let cmd = "gh pr create --title 'feat: add mode' --body 'Adds the mode.
+
+---
+
+Fixes #1'";
+        assert_eq!(evaluate(&hook(cmd)), None);
+    }
+
+    #[test]
+    fn non_conventional_title_is_denied() {
+        let cmd = "gh pr create --title 'Add the mode' --body 'Body.
+
+---
+
+Fixes #1'";
+        let reason = evaluate(&hook(cmd)).expect("should deny");
+        assert!(reason.contains("not Conventional Commits"), "got: {reason}");
+    }
+
+    #[test]
+    fn missing_separator_is_denied() {
+        let cmd = "gh pr create --title 'fix: thing' --body 'One part only, no separator.'";
+        let reason = evaluate(&hook(cmd)).expect("should deny");
+        assert!(reason.contains("no `---` separator"), "got: {reason}");
+    }
+
+    #[test]
+    fn attribution_footer_is_denied() {
+        let cmd = "gh pr create -t 'fix: thing' -b 'Real change.
+
+---
+
+Context.
+
+Co-Authored-By: Claude <noreply@anthropic.com>'";
+        let reason = evaluate(&hook(cmd)).expect("should deny");
+        assert!(reason.contains("AI-attribution"), "got: {reason}");
+    }
+
+    #[test]
+    fn flag_equals_value_form_is_parsed() {
+        let cmd = "gh pr create --title=Add --body='b\n\n---\n\nx'";
+        // `--title=Add` is not Conventional Commits -> deny naming the title.
+        let reason = evaluate(&hook(cmd)).expect("should deny");
+        assert!(reason.contains("not Conventional Commits"), "got: {reason}");
+    }
+
+    #[test]
+    fn edit_title_only_runs_pb1_only() {
+        // A title-only edit must run PB1 and NOT trip PB2 (no body/separator).
+        let bad = "gh pr edit 12 --title 'Not conventional'";
+        assert!(evaluate(&hook(bad))
+            .expect("should deny")
+            .contains("not Conventional Commits"));
+        let good = "gh pr edit 12 --title 'feat: good title'";
+        assert_eq!(evaluate(&hook(good)), None, "clean title-only edit allowed");
+    }
+
+    #[test]
+    fn edit_body_only_runs_body_checks() {
+        let cmd = "gh pr edit 12 --body 'No separator body.'";
+        let reason = evaluate(&hook(cmd)).expect("should deny");
+        assert!(reason.contains("no `---` separator"), "got: {reason}");
+    }
+
+    #[test]
+    fn edit_without_title_or_body_is_allowed() {
+        let cmd = "gh pr edit 12 --add-label needs-review";
+        assert_eq!(evaluate(&hook(cmd)), None);
+    }
+
+    #[test]
+    fn non_gh_command_is_allowed() {
+        assert_eq!(evaluate(&hook("echo gh pr create --title bad")), None);
+        assert_eq!(evaluate(&hook("git commit -m 'not a pr'")), None);
+    }
+
+    #[test]
+    fn fill_and_web_are_allowed() {
+        assert_eq!(evaluate(&hook("gh pr create --fill")), None);
+        assert_eq!(
+            evaluate(&hook("gh pr create --title 'feat: x' --web")),
+            None,
+            "no body to check, title is fine"
+        );
+    }
+
+    #[test]
+    fn command_substitution_body_is_allowed() {
+        // We cannot evaluate `$(...)`; fail open and let CI check the real body.
+        let cmd = "gh pr create --title 'feat: x' --body \"$(cat body.txt)\"";
+        assert_eq!(evaluate(&hook(cmd)), None);
+    }
+
+    #[test]
+    fn body_file_is_read_and_checked() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("shirabe-hook-test-{}.md", std::process::id()));
+        std::fs::write(&path, "One-part body, no separator.\n").unwrap();
+        let cmd = format!(
+            "gh pr create --title 'fix: thing' --body-file {}",
+            path.display()
+        );
+        let reason = evaluate(&hook(&cmd)).expect("should deny");
+        assert!(reason.contains("no `---` separator"), "got: {reason}");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn body_file_clean_is_allowed() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("shirabe-hook-ok-{}.md", std::process::id()));
+        std::fs::write(&path, "Real change.\n\n---\n\nFixes #2\n").unwrap();
+        let cmd = format!(
+            "gh pr create --title 'fix: real' --body-file {}",
+            path.display()
+        );
+        assert_eq!(evaluate(&hook(&cmd)), None);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn unreadable_body_file_is_allowed() {
+        let cmd = "gh pr create --title 'fix: thing' --body-file /nonexistent/nope.md";
+        assert_eq!(evaluate(&hook(cmd)), None);
+    }
+
+    #[test]
+    fn body_file_dash_stdin_is_allowed() {
+        let cmd = "gh pr create --title 'fix: thing' --body-file -";
+        assert_eq!(evaluate(&hook(cmd)), None);
+    }
+
+    #[test]
+    fn malformed_stdin_is_allowed() {
+        assert_eq!(evaluate("not json at all"), None);
+        assert_eq!(evaluate("{}"), None);
+        assert_eq!(evaluate(""), None);
+    }
+
+    #[test]
+    fn env_assignment_prefix_is_stripped() {
+        let cmd = "GH_TOKEN=abc gh pr create --title 'bad title' --body 'b\n\n---\n\nx'";
+        let reason = evaluate(&hook(cmd)).expect("should deny");
+        assert!(reason.contains("not Conventional Commits"), "got: {reason}");
+    }
+
+    #[test]
+    fn compound_command_finds_the_gh_segment() {
+        let cmd = "cd /tmp && gh pr create --title 'bad' --body 'b\n\n---\n\nx'";
+        let reason = evaluate(&hook(cmd)).expect("should deny");
+        assert!(reason.contains("not Conventional Commits"), "got: {reason}");
+    }
+
+    #[test]
+    fn unterminated_quote_segment_is_allowed() {
+        // A segment we cannot tokenize is skipped (fail-open).
+        let cmd = "gh pr create --title 'unterminated --body 'b\n\n---\n\nx'";
+        // Depending on how quotes pair this may or may not parse; the contract
+        // is only that it never panics and returns a decision.
+        let _ = evaluate(&hook(cmd));
+    }
+
+    #[test]
+    fn deny_reason_is_json_safe() {
+        // A crafted title with quotes/newlines must not break the JSON.
+        let cmd = "gh pr create --title 'evil\" }] title' --body 'Real.\n\n---\n\nx'";
+        if let Some(reason) = evaluate(&hook(cmd)) {
+            let value = serde_json::json!({
+                "hookSpecificOutput": { "permissionDecisionReason": reason }
+            });
+            let s = serde_json::to_string(&value).unwrap();
+            // Round-trips cleanly: the reason is a proper JSON string value.
+            let back: serde_json::Value = serde_json::from_str(&s).unwrap();
+            assert!(back["hookSpecificOutput"]["permissionDecisionReason"].is_string());
+        }
+    }
+
+    #[test]
+    fn disable_env_short_circuits() {
+        // The kill switch is checked in `run`; here we assert the predicate.
+        std::env::set_var("PR_BODY_HOOK_DISABLE", "1");
+        assert!(disabled());
+        std::env::set_var("PR_BODY_HOOK_DISABLE", "0");
+        assert!(!disabled());
+        std::env::remove_var("PR_BODY_HOOK_DISABLE");
+        assert!(!disabled());
+    }
+}

--- a/docs/briefs/BRIEF-pr-template-gate.md
+++ b/docs/briefs/BRIEF-pr-template-gate.md
@@ -132,6 +132,19 @@ check confirms a Conventional Commits `docs:` title, exactly one separator,
 a non-empty Part 1, and no attribution footer, and it never second-guesses
 the sparse Part 2. A correct minimal PR is not a false positive.
 
+### A contributor is stopped before opening a malformed PR
+
+A contributor — or a dispatched worker — runs `gh pr create` by hand with a
+body that has no `---` separator and a title of `Update the validator`. Before
+the command runs, an authoring-time check reads the title and body, finds the
+same mechanical violations the CI gate would, and stops the command with a
+message naming them. The contributor fixes the title and adds the separator,
+re-runs the command, and the PR opens clean on the first try. The malformed PR
+never reaches GitHub, so no CI run and no reviewer attention is spent on a
+defect a machine could name at the keystroke. This authoring-time surface
+reuses the same rule the CI gate enforces; it is a faster feedback path, not a
+different standard.
+
 ### A maintainer reads a failing check
 
 A maintainer looks at a red conformance check on someone else's PR. The
@@ -158,6 +171,11 @@ mechanical (fix the body) rather than a judgment call.
 - Path-independence as the acceptance property: the gate must catch a
   manual or dispatched PR, not only a skill-authored one, and must not
   fail a legitimate minimal PR.
+- A second, authoring-time enforcement surface — a client-side hook that runs
+  the same mechanical rule against a `gh pr create` / `gh pr edit` command
+  before it executes — so the defect is caught in any checkout, even one with
+  no CI wired. This was originally deferred (see below) and is now committed as
+  a follow-on increment; the downstream PRD and DESIGN own its exact shape.
 
 ### OUT of scope
 
@@ -169,10 +187,12 @@ mechanical (fix the body) rather than a judgment call.
 - Modifying the downstream consumer's PR-creation skill. The mechanical
   logic is migrated into shirabe so shirabe is self-authoritative; the
   downstream skill is left untouched rather than extended with new checks.
-- The exact enforcement surfaces beyond the CI gate — an optional local
-  pre-PR hook, and closing the dispatch gap so dispatched PR-opening work
-  routes through a template-applying skill — are secondary mechanisms the
-  downstream PRD and DESIGN decide on, not commitments of this framing.
+- The local pre-PR hook was originally deferred here as a secondary
+  mechanism; it is now committed (see IN scope) and specified by the
+  downstream PRD (R13–R16) and DESIGN. Closing the dispatch gap — routing
+  dispatched PR-opening work through a template-applying skill — remains out
+  of scope: it is an orthogonal workflow-authoring change, not part of this
+  enforcement work.
 - Requirements articulation and interface shape — the precise check set,
   the validator mode's flags, the CI trigger events — belong to the
   downstream PRD and DESIGN, one altitude down from this framing.

--- a/docs/designs/current/DESIGN-pr-template-gate.md
+++ b/docs/designs/current/DESIGN-pr-template-gate.md
@@ -14,6 +14,10 @@ decision: |
   mode implements and the skills cite, replacing the dangling cross-plugin
   pointer. Wire a reusable `pr-body` CI workflow plus a self-caller on
   `pull_request` that fetches the PR title/body via `gh` and runs the mode.
+  Add a second, authoring-time enforcement surface — a `shirabe pr-body-hook`
+  PreToolUse adapter (the fail-safe analog of `work-summary capture`) that
+  reuses the same `check_pr_body` engine to gate `gh pr create` / `gh pr edit`
+  before the PR is opened, with the hook registration delegated to dot-niwa.
 rationale: |
   A validate mode is the established single-source shape for a
   path-independent check (`--coordination-body` static, `--merge-gate` live);
@@ -36,6 +40,17 @@ checks R2–R4, nothing more), and the interface by which the title and body
 reach the mode (`--pr-body <file>` for the body, an optional `--pr-title
 <string>` companion for the title). The downstream PLAN owns the atomic
 issue decomposition.
+
+This design was extended with a second enforcement increment after the CI
+gate shipped. The CI gate is path-independent but strictly *reactive*: it
+fires only once a PR exists, so a malformed body is created, then flagged.
+The increment adds an authoring-time surface — a client-side PreToolUse hook
+that runs the same `check_pr_body` engine against a `gh pr create` /
+`gh pr edit` command before it executes — so a malformed PR is caught at the
+keystroke, in any checkout, even one with no GitHub Actions workflow. The two
+surfaces share one engine and one reference; the CI gate stays the
+authoritative backstop. The client-side material below is labelled as the
+increment; the CI-gate decision is unchanged.
 
 ## Context and Problem Statement
 
@@ -96,6 +111,18 @@ of which path opened the PR (PRD goals; R7, R8).
   `lifecycle.yml` / `validate-docs.yml` pattern: build the binary from source
   at the called workflow's ref, SHA-pin every action, request least
   privilege.
+- **D8 — Authoring-time feedback (increment).** The CI gate is reactive: the
+  malformed PR is created, then a red check appears. Catching the same defect
+  *before* the PR exists — at the `gh pr create` keystroke, in any checkout,
+  independent of whether a GHA workflow is wired — needs a client-side hook
+  that intercepts the command. This is a convenience layer over the same
+  rule, not a second rule.
+- **D9 — Fail-safe ambient behavior (increment).** A client hook runs on
+  every Bash command in the session. It must never trap a legitimate flow or
+  break when it cannot understand its input: an unparseable command, an
+  unreadable `--body-file`, a `--fill`/`--web` create, or a missing binary
+  must degrade to "allow", exactly as shirabe's `work-summary` hooks degrade
+  to "no output". The CI gate is the backstop that makes fail-open safe.
 
 ## Considered Options
 
@@ -151,6 +178,56 @@ always covers all three checks. The title arrives as a value argument (argv,
 never shell-evaluated), and the workflow passes it through an environment
 variable rather than direct expression interpolation (D6).
 
+### Client-side surface: PreToolUse hook vs shell wrapper vs git hook (increment)
+
+The authoring-time surface (D8) needs to see the `gh pr create` / `gh pr edit`
+invocation and its `--body`/`--body-file`/`--title` arguments before the
+command runs. Three shapes were considered.
+
+A **git `pre-push` / `commit-msg` hook** was rejected: it sees commits, not
+the PR title/body, which are supplied to `gh` at PR-open time and never touch
+git. It cannot check the two-part body at all.
+
+A **shell alias/wrapper around `gh`** was rejected against portability and
+D9: it only fires in an interactive shell that sourced the wrapper, misses
+non-interactive and agent-driven `gh` calls, and has no clean fail-safe
+contract.
+
+The **chosen surface** is a **Claude Code PreToolUse hook matching the Bash
+tool**, the same mechanism shirabe's `work-summary` (PostToolUse) and the
+existing `gate-online` (PreToolUse) hooks already use. It receives the exact
+command string in the hook JSON before execution, fires for every Bash
+invocation regardless of how it was issued, and has a defined
+allow/ask/deny response contract. The logic lives in the on-PATH `shirabe`
+binary (a new `shirabe pr-body-hook` subcommand); the hook script is a thin
+pass-through, exactly like `work-summary-capture.sh`.
+
+### Hook response: block vs warn-only (increment)
+
+A PreToolUse hook can **deny** (abort the tool call with a reason the agent
+sees), **ask** (prompt a human), or **allow** — optionally attaching
+`additionalContext`. The design must pick what happens when the parsed body
+or title produces PB findings.
+
+**Warn-only** (allow + `additionalContext` naming the findings) was
+considered and rejected as the primary behavior: it does not stop the
+malformed PR from being created, so the client surface would be redundant
+with the CI gate rather than additive — the whole point of D8 is to catch the
+defect *before* the PR exists. **Ask** was rejected because the session runs
+under `bypassPermissions` and dispatched/headless agents have no human to
+prompt; an `ask` there stalls the turn.
+
+The **chosen response is deny, fail-open** (D9). When the hook can confidently
+extract a title/body and `check_pr_body` returns findings, it denies the
+`gh pr create` / `gh pr edit` call and returns the PB1–PB3 findings as the
+`permissionDecisionReason`, so the agent reads exactly what to fix and
+re-issues a corrected command. In every ambiguous case — the command is not a
+recognized create/edit, no title and no body can be extracted, a
+`--body-file` cannot be read, `--fill`/`--web`/`--body-file -` is used, or
+the parse is uncertain — the hook **allows** (emits nothing). This mirrors
+`gate-online`'s deny-known-bad / allow-otherwise shape and `work-summary`'s
+fail-safe posture, and the CI gate catches anything the hook fails open on.
+
 ## Decision Outcome
 
 Add `shirabe validate --pr-body <file> [--pr-title <string>]`: an offline
@@ -202,6 +279,50 @@ self-caller `.github/workflows/validate-pr-body.yml` invokes it on this
 repo's PRs on `pull_request` with `types: [opened, edited, reopened,
 synchronize, ready_for_review]` and no `paths:` filter. Permissions are
 `contents: read` + `pull-requests: read`.
+
+### Client-side PreToolUse hook (increment)
+
+A new `shirabe pr-body-hook` subcommand is the PreToolUse adapter. It is a
+fail-safe hook adapter in the shape of `work-summary capture`, **not** a
+`validate` mode: it reads a Claude Code hook JSON on stdin, and its output
+contract is hook JSON with a permission decision (and it always exits 0),
+which is the opposite of `validate`'s `ValidateOutcome` exit-code contract.
+It adds no rule — it reuses `check_pr_body` from `shirabe-validate`, the same
+engine `--pr-body` calls, so PB1–PB3 are stated once and consumed by CI, the
+skills, and the hook alike.
+
+The adapter:
+
+1. reads the hook JSON on stdin and extracts `tool_input.command` (the Bash
+   command about to run); on any parse failure it emits nothing (allow);
+2. detects a `gh ... pr create` or `gh ... pr edit` invocation using the same
+   shell-boundary / env-assignment / quote-stripping argv scan `work-summary`
+   already uses for `is_pr_create`, extended to also recognize `edit` and to
+   read the `--title`, `--body`, and `--body-file <path>` option values from
+   the argv tokens (never by shell-evaluating the command);
+3. resolves the body: `--body <str>` inline, or `--body-file <path>` read from
+   disk. A `--body-file -` (stdin), a heredoc/process-substitution body, a
+   `--fill`/`--web` create, or an unreadable file yields "no confidently
+   extractable body" → allow;
+4. when a title and/or body is extractable, runs `check_pr_body(body,
+   title)`. Empty findings → allow (emit nothing). Non-empty findings → emit a
+   PreToolUse hook JSON with `permissionDecision: "deny"` and a
+   `permissionDecisionReason` listing the PB findings (one per line, prefixed
+   so the agent sees "PR body check: …"). Output is terminal-safe: the
+   attacker-influenceable title/body reaches the reason only inside a
+   `serde_json` string value, never concatenated into a control sequence.
+
+Because a `gh pr edit` may set only a title or only a body, the hook checks
+whatever it can extract: a title-only edit runs PB1; a body-only edit runs
+PB2–PB3; a create with both runs all three. When neither is present (e.g.
+`gh pr edit 123 --add-label foo`) it allows.
+
+The hook registration is **delegated to dot-niwa** (see Solution
+Architecture), exactly as the `work-summary` hooks were wired via
+`tsukumogami/dot-niwa#4`: shirabe owns the binary subcommand and the rule;
+dot-niwa owns the `.niwa/hooks/pre_tool_use/` pass-through script and the
+`workspace.toml` registration that `niwa apply` projects into each repo's
+Claude settings.
 
 ## Solution Architecture
 
@@ -291,10 +412,90 @@ The PR number is a safe integer from the event payload; the title never
 enters the run script as an expression — it is read from the environment,
 closing the script-injection vector (D6).
 
+### Client-side hook adapter: `shirabe pr-body-hook` (increment)
+
+`crates/shirabe/src/main.rs` gains a `PrBodyHook` subcommand dispatched to a
+new `crates/shirabe/src/pr_body_hook.rs` module, structured like
+`work_summary`:
+
+```
+shirabe pr-body-hook          # PreToolUse adapter; reads hook JSON on stdin,
+                              # emits hook JSON on stdout, ALWAYS exits 0
+```
+
+The module reuses the `work_summary` primitives rather than duplicating them:
+`read_stdin` + `serde_json::from_str` for the hook JSON, and the
+shell-boundary/env-assignment/quote-stripping argv scan behind `is_pr_create`
+(generalized to a small `PrCommand` classifier that returns
+`Some(Create | Edit)` and the surviving argv tokens). From the tokens it
+reads the option values:
+
+```
+--title <STR>          -> title
+--body  <STR>          -> body (inline)
+--body-file <PATH>     -> body (read from PATH; unreadable or "-" => none)
+--fill | --web         -> no extractable body => allow
+```
+
+It then calls `shirabe_validate::check_pr_body(body, title.as_deref())` and
+maps the result:
+
+```
+findings.is_empty()  -> print nothing            (allow)
+!findings.is_empty() -> print deny hook JSON      (block, reason = findings)
+any error / ambiguity-> print nothing            (allow, fail-open)
+```
+
+The deny JSON matches the `gate-online` PreToolUse shape:
+
+```
+{"hookSpecificOutput":{"hookEventName":"PreToolUse",
+ "permissionDecision":"deny",
+ "permissionDecisionReason":"PR body check failed:\n- <PB finding>\n- <…>"}}
+```
+
+built with `serde_json::json!` so the title/body text is always a JSON string
+value. Env seam `PR_BODY_HOOK_DISABLE=1` short-circuits to allow, giving an
+operator a kill switch without unwiring the hook (mirrors the `WS_*` seams).
+Like `work-summary`, `run()` returns `ExitCode::SUCCESS` unconditionally.
+
+### Hook wiring: dot-niwa handoff (increment)
+
+shirabe ships the subcommand and a reference pass-through script under
+`references/` or documents the one-liner; it does **not** register the hook
+in any repo. Registration is dot-niwa's job, following the `work-summary`
+precedent (`tsukumogami/dot-niwa#4`):
+
+- add `dot-niwa/.niwa/hooks/pre_tool_use/pr-body-guard.sh`, a thin
+  pass-through in the spirit of `work-summary-capture.sh`, with one
+  PreToolUse-specific difference: it must **not** `exec` the binary. A
+  PostToolUse hook can `exec` because a non-zero exit there is harmless, but a
+  PreToolUse hook that exits non-zero *blocks* the tool call. Since the hook
+  matches every Bash command, an outdated `shirabe` that predates the
+  `pr-body-hook` subcommand (clap exits non-zero on an unknown subcommand)
+  would otherwise block every command. The script therefore guards the exit:
+  `command -v shirabe >/dev/null 2>&1 || exit 0` then `shirabe pr-body-hook
+  2>/dev/null || exit 0` (fall back to allow). The current binary always exits
+  0, so the guard only ever fires against a stale install;
+- register it in `dot-niwa/.niwa/workspace.toml` as a second
+  `[[claude.hooks.pre_tool_use]]` entry with `matcher = "Bash"` and
+  `scripts = ["hooks/pre_tool_use/pr-body-guard.sh"]` (Claude Code runs
+  multiple PreToolUse Bash hooks; it composes with the existing
+  `gate-online.sh` entry).
+
+`niwa apply` then projects the script into each repo's
+`.claude/hooks/pre_tool_use/…local.sh` and adds the PreToolUse registration to
+`.claude/settings.local.json`, exactly as it already does for the
+`work-summary` hooks. The handoff boundary is clean: a shirabe release makes
+the subcommand available on PATH; a dot-niwa change turns it on across the
+workspace. This design's PR opens the dot-niwa issue/PR that carries the
+wiring; the shirabe side does not depend on it to build or test.
+
 ## Implementation Approach
 
-Three batches, sequenced so each is independently reviewable and the gate is
-never half-wired:
+Four batches, sequenced so each is independently reviewable and the gate is
+never half-wired. Batches 1–3 shipped the CI gate; Batch 4 is the
+authoring-time increment and depends only on Batch 1:
 
 - **Batch 1 — validator mode.** `pr_body.rs` (`check_pr_body` + fence-strip
   helper + PB1/PB2/PB3), the `lib.rs` re-export, the `main.rs` args, guards,
@@ -314,6 +515,20 @@ never half-wired:
   `lifecycle.yml`/`validate-lifecycle.yml`. Lands last so the gate goes live
   once the mode and reference exist; the PR shipping this design self-tests
   the gate on its own body.
+- **Batch 4 — client-side PreToolUse hook (increment).** The
+  `shirabe pr-body-hook` subcommand (`pr_body_hook.rs`), the `main.rs`
+  dispatch, and unit tests: a `gh pr create` with a clean body/title (allow,
+  no output); a create with a non-conventional title (deny, reason names the
+  title); a create with no separator (deny); a `--body-file` pointing at a
+  clean and a malformed file; a `gh pr edit --title` (PB1 only); a
+  `gh pr edit --add-label` (allow, nothing to check); a non-`gh` command
+  (allow); a `--fill`/`--web` create and an unreadable `--body-file` (allow,
+  fail-open); a malformed stdin (allow). Depends on Batch 1 for
+  `check_pr_body`. The dot-niwa registration (a thin pass-through script plus
+  a `workspace.toml` entry) is handed off as `tsukumogami/dot-niwa#<N>`,
+  landing independently once a shirabe release carries the subcommand — the
+  same shirabe-owns-binary / dot-niwa-owns-wiring split as
+  `tsukumogami/dot-niwa#4`.
 
 ## Security Considerations
 
@@ -335,6 +550,17 @@ never half-wired:
   no network or `gh` call; the validator's output is a pure function of its
   file and title inputs, so it cannot be steered by anything but the PR
   content it is handed.
+- **Hook adapter, untrusted stdin and argv (increment, D6/D9).** The PreToolUse
+  adapter treats the command string, title, and body as attacker-controlled.
+  It never shell-evaluates the command — it scans argv tokens with the same
+  quote-aware splitter `work-summary` uses — so a body containing `$(…)` or a
+  `;` cannot cause execution. The deny reason is assembled with `serde_json`,
+  so the title/body is always a JSON string value, never concatenated into a
+  terminal control sequence. The adapter reads a `--body-file` path but writes
+  nothing and runs no subprocess. It always exits 0 and fails open on any
+  ambiguity (D9), so it can neither trap a legitimate `gh` call nor be turned
+  into a denial vector by a body it cannot parse; the CI gate remains the
+  authoritative check.
 - **Denial-of-input false positives.** The code-fence-exclusion in PB2/PB3 is
   a correctness-and-safety measure: without it, a PR whose Part 2 shows a
   YAML `---` or discusses a `Co-Authored-By:` line (as this very design does)
@@ -360,6 +586,11 @@ never half-wired:
   CLI concepts for a maintainer to learn.
 - A downstream repo can adopt the gate by calling the reusable workflow, the
   same way `lifecycle.yml` is consumed.
+- *(Increment)* The client-side hook catches the malformed PR at the
+  `gh pr create` keystroke, before it exists, in any checkout — including one
+  with no GitHub Actions — turning a CI red into instant, actionable local
+  feedback while reusing the one `check_pr_body` engine, so no rule is
+  duplicated across the two surfaces.
 
 **Negative, with mitigations.**
 
@@ -394,3 +625,13 @@ never half-wired:
 - `skills/execute/koto-templates/execute.md` — the `pr_finalization` state
   carrying the inline mechanical rule and the dangling
   `skills/pr-creation/SKILL.md` pointer this design single-sources.
+- `crates/shirabe/src/work_summary.rs` — the fail-safe hook-adapter precedent
+  the client-side increment mirrors: reads a Claude Code hook JSON on stdin,
+  scans a `gh` command out of `tool_input.command` (`is_pr_create`), emits
+  hook JSON built with `serde_json`, and always exits 0. `pr_body_hook.rs`
+  reuses its stdin and argv-scan primitives.
+- `.niwa/hooks/pre_tool_use/gate-online.sh` and
+  `.niwa/hooks/post_tool_use/work-summary-capture.sh` (in `tsukumogami/dot-niwa`)
+  — the existing PreToolUse deny-shape and the thin pass-through pattern the
+  `pr-body-guard.sh` wiring copies; `tsukumogami/dot-niwa#4` is the
+  work-summary wiring PR this handoff parallels.

--- a/docs/prds/PRD-pr-template-gate.md
+++ b/docs/prds/PRD-pr-template-gate.md
@@ -82,6 +82,10 @@ that:
   cross-plugin reference is replaced with the shirabe authority.
 - Subjective judgment — which Part 2 sections a change needs — stays with
   the author and is never gated. A legitimate minimal PR does not fail.
+- *(Increment)* The same mechanical rule is also enforced at authoring time
+  by an optional client-side hook, so a malformed PR is caught before it is
+  created — in any checkout, even one with no CI wired — turning a reactive
+  CI red into instant local feedback without a second copy of the rule.
 
 ## User Stories
 
@@ -191,6 +195,43 @@ Part 1 (fail R3); an AI-attribution footer (fail R4); and the docs-only
 minimal Part 2 (pass, R10). Skill-reference single-sourcing SHALL be covered
 by the relevant skill evals.
 
+### Client-side enforcement (increment)
+
+Added after the CI gate (R1–R12) shipped. These requirements bring the local
+PreToolUse hook — originally deferred in Out of Scope — into scope as a second
+enforcement surface that reuses the R1 engine.
+
+**R13.** shirabe SHALL provide a **PreToolUse hook adapter** that reuses the
+R2–R4 checks (the `check_pr_body` engine, NOT a reimplementation) to evaluate
+a `gh pr create` / `gh pr edit` command before it runs. The adapter SHALL be
+a fail-safe binary entrypoint (following the `work-summary` hook precedent):
+it reads a Claude Code hook JSON on stdin, always exits 0, and never aborts a
+turn with a non-zero code. It performs no network or `gh` call.
+
+**R14.** The adapter SHALL extract the submitted title and body from the
+command's argv — `--title`, `--body`, and `--body-file <path>` — by scanning
+argv tokens, never by shell-evaluating the command. A `--body-file` path is
+read from disk; `--fill`, `--web`, `--body-file -`, an unreadable file, or a
+command that is not a recognized `gh pr create`/`edit` SHALL be treated as
+"nothing to check" and allowed.
+
+**R15.** When a title and/or body is extractable and the R2–R4 checks return
+findings, the adapter SHALL **deny** the tool call and return the findings as
+the decision reason, so the agent sees what to fix and can re-issue a
+corrected command. When the checks are clean, or in any ambiguous case in
+R14, the adapter SHALL **allow** (fail-open). The choice of deny over
+advisory-warn, and of fail-open on ambiguity, SHALL be recorded in the
+DESIGN. The attacker-controlled title/body SHALL reach the decision reason
+only as a structured (JSON-encoded) value, never string-concatenated.
+
+**R16.** The hook **registration** (the settings wiring that installs the
+PreToolUse hook) SHALL be **delegated to `tsukumogami/dot-niwa`**, following
+the `work-summary` wiring precedent (`tsukumogami/dot-niwa#4`): shirabe owns
+the binary subcommand and the rule; dot-niwa owns the pass-through hook script
+and the `workspace.toml` registration that `niwa apply` projects into each
+repo. This PRD's implementation opens the dot-niwa issue/PR; the shirabe side
+builds and tests without it.
+
 ## Acceptance Criteria
 
 - [ ] `shirabe validate --pr-body <file>` exists, is offline, and is
@@ -223,6 +264,17 @@ by the relevant skill evals.
   cases.
 - [ ] All edits are public-visibility clean and use no banned writing-style
   words.
+- [ ] *(Increment)* A `shirabe pr-body-hook` PreToolUse adapter exists, reads
+  hook JSON on stdin, always exits 0, and reuses `check_pr_body` (no second
+  copy of PB1–PB3).
+- [ ] *(Increment)* A `gh pr create` with a malformed title or body is denied
+  with a reason naming the finding; a clean one is allowed with no output.
+- [ ] *(Increment)* A `gh pr edit` setting only a title runs PB1; setting only
+  a body runs PB2–PB3; a `gh pr edit` that changes neither is allowed.
+- [ ] *(Increment)* `--fill`/`--web`, an unreadable or `-` `--body-file`, a
+  non-`gh` command, and malformed stdin all fail open (allow, no output).
+- [ ] *(Increment)* The hook registration is delegated to `tsukumogami/dot-niwa`
+  via an opened issue/PR; the shirabe change builds and tests independently.
 
 ## Out of Scope
 
@@ -234,9 +286,11 @@ by the relevant skill evals.
   gate never inspects Part 2 section choice.
 - Modifying the downstream consumer's PR-creation skill. The mechanical
   logic is migrated into shirabe; the downstream skill is left untouched.
-- The optional local PreToolUse hook matching `gh pr create` / `gh pr edit`.
-  It is a convenience that turns a CI red into instant local feedback but is
-  not required for the path-independent gate; it can be a follow-up.
+- ~~The optional local PreToolUse hook matching `gh pr create` / `gh pr edit`.~~
+  **Now in scope** as the R13–R16 increment: the hook was originally deferred
+  here as a follow-up, and this PRD was extended to specify it once the CI
+  gate had shipped. It remains a convenience layer over the same rule, not a
+  replacement for the path-independent CI gate.
 - Closing the dispatch gap (routing dispatched PR-opening work through a
   template-applying skill or loading the PR-creation guidance in the brief).
   This is a workflow-authoring change orthogonal to the gate.

--- a/references/pr-body-conformance.md
+++ b/references/pr-body-conformance.md
@@ -100,3 +100,9 @@ example.
 - **`/execute`** (`pr_finalization`) and **`/work-on`** (PR phase) cite this
   reference for the mechanical rule while authoring the title and two-part
   body, so the body they produce and the rule CI enforces come from one source.
+- **The client-side PreToolUse hook** (`shirabe pr-body-hook`, wired via
+  `tsukumogami/dot-niwa`) runs the same `check_pr_body` engine against a
+  `gh pr create` / `gh pr edit` command before it executes, catching a
+  malformed PR at authoring time in any checkout. It reuses this rule, adding
+  no checks of its own — PB1–PB3 are stated here once and enforced by CI, the
+  skills, and the hook alike.


### PR DESCRIPTION
Extend the `pr-template-gate` chain with a second, authoring-time enforcement surface and implement it in the `shirabe` binary. The CI gate shipped by PR #222 is path-independent but strictly reactive: a malformed PR is created, then flagged. This adds a client-side PreToolUse hook that runs the same `check_pr_body` engine against a `gh pr create` / `gh pr edit` command before it executes, so a malformed PR is caught at the keystroke, in any checkout, even one with no GitHub Actions.

The new `shirabe pr-body-hook` subcommand is a fail-safe hook adapter in the shape of `work-summary capture` (reads hook JSON on stdin, emits a PreToolUse decision, always exits 0). It reuses `check_pr_body` / a new `check_pr_title` exposed from `shirabe-validate` — it adds no rule, so PB1-PB3 stay stated once in `references/pr-body-conformance.md`. On findings it denies the command with the findings as the reason; in every ambiguous case (non-`gh` command, unreadable `--body-file`, `--fill`/`--web`, command-substitution body, malformed stdin) it fails open. The design chain (BRIEF, PRD, DESIGN) and the reference are amended to specify the surface, the warn-vs-block decision, and the dot-niwa wiring handoff.

---

## What this accomplishes

- New `shirabe pr-body-hook` PreToolUse adapter (`crates/shirabe/src/pr_body_hook.rs`) with a quote-aware, segment-aware argv scanner that extracts `--title`/`--body`/`--body-file` without shell-evaluating the command.
- `check_pr_title` exposed from `shirabe-validate` so a title-only `gh pr edit` runs PB1 alone without spuriously firing PB2.
- Amended `docs/briefs/BRIEF-pr-template-gate.md`, `docs/prds/PRD-pr-template-gate.md` (new R13-R16), `docs/designs/current/DESIGN-pr-template-gate.md` (D8/D9, the block-fail-open decision, the dot-niwa handoff), and `references/pr-body-conformance.md` (the hook as a third consumer of the one rule).

## Warn vs block

The hook **denies** on findings (fail-open on ambiguity), not warn-only: a warn would not stop the malformed PR from being created, making the client surface redundant with CI. The rationale is recorded in the DESIGN ("Hook response" option).

## Wiring handoff

Hook registration is delegated to `tsukumogami/dot-niwa`, following the `tsukumogami/dot-niwa#4` work-summary precedent: shirabe owns the binary and the rule; dot-niwa owns the pass-through script and the `workspace.toml` registration. The companion dot-niwa PR carries the wiring and depends on a shirabe release that ships this subcommand.

## Testing

- `cargo test` passes; `crates/shirabe/src/pr_body_hook.rs` adds 21 unit tests (clean/malformed create, title-only and body-only edit, non-`gh`, `--fill`/`--web`, `--body-file` read, unreadable/`-` body-file, command-substitution body, env-assignment prefix, compound command, malformed stdin, JSON-safety of the deny reason).
- End-to-end: piping a malformed `gh pr create` hook JSON to `shirabe pr-body-hook` emits a deny decision; a clean one and a non-`gh` command emit nothing; garbage stdin exits 0.
- The three amended docs pass `shirabe validate`.
