### PR TITLE
ci: exempt bot-authored PRs from the pr-body conformance gate

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -8,7 +8,12 @@ name: PR-body Conformance
 #     types: [opened, edited, reopened, synchronize, ready_for_review]
 # jobs:
 #   pr-body:
-#     uses: tsukumogami/shirabe/.github/workflows/pr-body.yml@v0.13.0
+#     uses: tsukumogami/shirabe/.github/workflows/pr-body.yml@main
+#
+# The tsukumogami adopters pin `@main` so the gate always runs the current
+# engine without per-release pin bumps, matching the validate-docs.yml
+# adoption. A consumer outside the org that wants a reproducible pin can use a
+# release tag (`@vX.Y.Z`) instead.
 #
 # The reusable workflow runs `shirabe validate --pr-body` against the PR's
 # title and body — the mechanical, path-independent gate for PR-template
@@ -17,9 +22,25 @@ name: PR-body Conformance
 # of which code path opened it, so a manual `gh pr create` or a dispatched
 # worker is checked the same as a skill-authored PR. The rule it enforces is
 # single-sourced in references/pr-body-conformance.md.
+#
+# Machine-authored PRs are exempt: a bot (dependabot, renovate, the Actions
+# bot) produces a fixed body shape that cannot follow the two-part `---`
+# convention, so the gate would false-positive every such PR into a red check.
+# The built-in exempt set is dependabot[bot], renovate[bot], and
+# github-actions[bot]; a caller adds more via the `exempt_authors` input.
 
 on:
   workflow_call:
+    inputs:
+      exempt_authors:
+        description: >-
+          Extra PR-author logins to exempt from the check, beyond the built-in
+          bots (dependabot[bot], renovate[bot], github-actions[bot]). Space- or
+          comma-separated. For machine-generated PRs whose bodies cannot follow
+          the two-part convention.
+        required: false
+        type: string
+        default: ""
 
 jobs:
   pr-body:
@@ -28,19 +49,47 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - name: Check PR context
-        # The check only makes sense on a pull_request event; a non-PR
-        # trigger has no PR number to read a title/body from. Skip cleanly.
+      - name: Determine whether to run
+        id: guard
+        # The check runs only for a human-authored PR. Two cases short-circuit
+        # to a clean skip (leaving the job green, so the check stays safe as a
+        # required status check): a non-PR trigger with no PR number, and a
+        # machine author whose fixed body shape cannot follow the two-part
+        # convention. The author login arrives via the environment (never
+        # interpolated into the script body) and bot logins are constrained, so
+        # there is no injection surface.
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          EXTRA_EXEMPT: ${{ inputs.exempt_authors }}
         run: |
-          if [ -z "${{ github.event.pull_request.number }}" ]; then
+          # Disable pathname expansion: bot logins such as `dependabot[bot]`
+          # contain glob metacharacters (`[bot]` is a character class), and the
+          # unquoted `for` word-split below would otherwise try to expand them
+          # against the working tree.
+          set -f
+          if [ -z "$PR_NUMBER" ]; then
             echo "::notice::Skipping PR-body check: requires a PR context (no pull_request number)"
+            echo "run=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          # Built-in bot exempt set, plus any caller-supplied logins. Commas in
+          # the input are normalized to spaces so both separators work.
+          EXEMPT="dependabot[bot] renovate[bot] github-actions[bot] ${EXTRA_EXEMPT//,/ }"
+          for a in $EXEMPT; do
+            if [ "$a" = "$PR_AUTHOR" ]; then
+              echo "::notice::Skipping PR-body check: author '$PR_AUTHOR' is exempt (machine-authored PR)"
+              echo "run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+          echo "run=true" >> "$GITHUB_OUTPUT"
 
       - name: Checkout caller repo
         # The pr-body check does not read the working tree (it reads the PR
         # title/body via gh), but the checkout mirrors the sibling workflows
         # for consistency and gives gh a repo context.
+        if: steps.guard.outputs.run == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Checkout shirabe
@@ -50,6 +99,7 @@ jobs:
         # picks up shirabe at the called ref so the binary matches the workflow
         # contract. For the local self-caller (`uses: ./...`) it resolves to
         # this repo at the PR's head, which is what we want.
+        if: steps.guard.outputs.run == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: ${{ job.workflow_repository }}
@@ -58,9 +108,11 @@ jobs:
 
       - name: Install Rust toolchain
         # Reads .shirabe-src/rust-toolchain.toml and installs the pinned channel.
+        if: steps.guard.outputs.run == 'true'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Cache Cargo
+        if: steps.guard.outputs.run == 'true'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
         with:
           path: |
@@ -72,6 +124,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Build shirabe
+        if: steps.guard.outputs.run == 'true'
         run: |
           cargo build --release --bin shirabe --manifest-path .shirabe-src/Cargo.toml
           install -m 0755 .shirabe-src/target/release/shirabe /usr/local/bin/shirabe
@@ -84,6 +137,7 @@ jobs:
         # (never eval-ed) and the body only as a file path. A non-zero exit
         # (violations) fails the check; each finding surfaces as a fileless
         # `::error::` annotation.
+        if: steps.guard.outputs.run == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/validate-pr-body.yml
+++ b/.github/workflows/validate-pr-body.yml
@@ -2,8 +2,8 @@ name: Validate shirabe PR body
 
 # Self-caller: exercises the reusable pr-body.yml against shirabe's own PRs,
 # so the PR that ships the gate has CI signal on its own body. Downstream
-# repos use `tsukumogami/shirabe/.github/workflows/pr-body.yml@v0.13.0` (or
-# whichever release tag they pin). This self-caller uses the local relative
+# repos pin `tsukumogami/shirabe/.github/workflows/pr-body.yml@main` (matching
+# the validate-docs.yml adoption). This self-caller uses the local relative
 # path so the PR exercises its own pre-release code.
 #
 # No `paths:` filter — the gate is path-independent by design. A malformed PR

--- a/references/pr-body-conformance.md
+++ b/references/pr-body-conformance.md
@@ -96,7 +96,12 @@ example.
 
 - **CI** runs the mode on `pull_request` (`.github/workflows/pr-body.yml` and
   its self-caller), fetching the title and body via `gh` — the path-independent
-  gate.
+  gate. Machine-authored PRs are exempt: a bot (dependabot, renovate, the
+  Actions bot) emits a fixed body shape that cannot carry the two-part `---`
+  convention, so gating it would false-positive every such PR. The reusable
+  workflow skips the built-in bot set and any author a caller adds through its
+  `exempt_authors` input; the rule itself (PB1–PB3) is unchanged — only the set
+  of PRs the CI surface applies it to.
 - **`/execute`** (`pr_finalization`) and **`/work-on`** (PR phase) cite this
   reference for the mechanical rule while authoring the title and two-part
   body, so the body they produce and the rule CI enforces come from one source.


### PR DESCRIPTION
Exempt machine-authored PRs from the reusable pr-body conformance gate. A bot (dependabot, renovate, the Actions bot) produces a fixed body shape that cannot carry the two-part `---` convention, so the gate would false-positive every such PR into a red check. The reusable workflow now runs an author guard that skips a built-in bot set (`dependabot[bot]`, `renovate[bot]`, `github-actions[bot]`) plus any login a caller adds through a new `exempt_authors` input, and the build/check steps are gated on it so an exempt PR leaves the job green rather than skipped. The mechanical rule (PB1-PB3) is unchanged; only the set of PRs the CI surface applies it to. The `@v0.13.0` pin examples in both workflow comments are aligned to `@main` to match the actual adoption pattern.

---

## Why

tsuku runs active dependabot. Its grouped-update PRs have no `---` separator (fails PB2) and some carry bare `Bump ...` titles (fails PB1), so adopting the gate there would red-check every future dependabot PR — and dependabot bodies structurally cannot be made conforming. Exempting bots at the shared-workflow layer keeps the rule single-sourced: every adopter inherits the exemption for free instead of restating a bot `if:` in each caller.

## What changed

- `.github/workflows/pr-body.yml`: a `Determine whether to run` guard step reads the PR author from the environment and sets a `run` output; the checkout/build/run steps are `if: steps.guard.outputs.run == 'true'`. New `exempt_authors` `workflow_call` input lets a caller extend the set. `set -f` disables glob expansion so the `[bot]` logins are matched literally.
- `.github/workflows/validate-pr-body.yml`, `.github/workflows/pr-body.yml`: pin examples `@v0.13.0` -> `@main`.
- `references/pr-body-conformance.md`: the Consumers/CI bullet records the exemption.

## Safety

The author login arrives via an env var, never interpolated into the run script; bot logins are constrained, so there is no injection surface. The job stays green (not skipped) for exempt PRs, so the check is safe to make a required status check.

## Testing

- `pr-body.yml` parses as valid YAML; the guard shell logic was exercised against dependabot/renovate/gha-bot/human/extra-bot/no-PR inputs and exempts only the intended authors.
- This PR dogfoods the gate via the self-caller.

Decided with the maintainer as part of the PR-body gate rollout (which repos adopt, `@main` pin, bot handling).
