### PR TITLE
docs: rewire pr-body client hook to niwa default injection

### DIFF
--- a/docs/designs/current/DESIGN-pr-template-gate.md
+++ b/docs/designs/current/DESIGN-pr-template-gate.md
@@ -17,7 +17,9 @@ decision: |
   Add a second, authoring-time enforcement surface — a `shirabe pr-body-hook`
   PreToolUse adapter (the fail-safe analog of `work-summary capture`) that
   reuses the same `check_pr_body` engine to gate `gh pr create` / `gh pr edit`
-  before the PR is opened, with the hook registration delegated to dot-niwa.
+  before the PR is opened, with the hook injected by niwa as a built-in default
+  for shirabe adopters (the same default-injection path as the work-summary
+  hooks).
 rationale: |
   A validate mode is the established single-source shape for a
   path-independent check (`--coordination-body` static, `--merge-gate` live);
@@ -317,12 +319,12 @@ whatever it can extract: a title-only edit runs PB1; a body-only edit runs
 PB2–PB3; a create with both runs all three. When neither is present (e.g.
 `gh pr edit 123 --add-label foo`) it allows.
 
-The hook registration is **delegated to dot-niwa** (see Solution
-Architecture), exactly as the `work-summary` hooks were wired via
-`tsukumogami/dot-niwa#4`: shirabe owns the binary subcommand and the rule;
-dot-niwa owns the `.niwa/hooks/pre_tool_use/` pass-through script and the
-`workspace.toml` registration that `niwa apply` projects into each repo's
-Claude settings.
+The hook registration is a **niwa built-in default** (see Solution
+Architecture), exactly as the `work-summary` hooks are injected by
+`tsukumogami/niwa#188`: shirabe owns the binary subcommand and the rule; niwa
+injects the inline PreToolUse pass-through into each shirabe-adopting repo's
+Claude settings during `niwa apply`, gated on the shirabe plugin and bounded by
+a `pr_body_hook` off switch.
 
 ## Solution Architecture
 
@@ -459,37 +461,41 @@ value. Env seam `PR_BODY_HOOK_DISABLE=1` short-circuits to allow, giving an
 operator a kill switch without unwiring the hook (mirrors the `WS_*` seams).
 Like `work-summary`, `run()` returns `ExitCode::SUCCESS` unconditionally.
 
-### Hook wiring: dot-niwa handoff (increment)
+### Hook wiring: niwa default injection (increment)
 
-shirabe ships the subcommand and a reference pass-through script under
-`references/` or documents the one-liner; it does **not** register the hook
-in any repo. Registration is dot-niwa's job, following the `work-summary`
-precedent (`tsukumogami/dot-niwa#4`):
+shirabe owns the subcommand and the rule; it does **not** register the hook in
+any repo. Registration is niwa's job, injected as a **built-in default** for
+shirabe adopters, following the `work-summary` default-injection precedent
+(`tsukumogami/niwa#188`):
 
-- add `dot-niwa/.niwa/hooks/pre_tool_use/pr-body-guard.sh`, a thin
-  pass-through in the spirit of `work-summary-capture.sh`, with one
-  PreToolUse-specific difference: it must **not** `exec` the binary. A
-  PostToolUse hook can `exec` because a non-zero exit there is harmless, but a
-  PreToolUse hook that exits non-zero *blocks* the tool call. Since the hook
-  matches every Bash command, an outdated `shirabe` that predates the
-  `pr-body-hook` subcommand (clap exits non-zero on an unknown subcommand)
-  would otherwise block every command. The script therefore guards the exit:
-  `command -v shirabe >/dev/null 2>&1 || exit 0` then `shirabe pr-body-hook
+- niwa's per-repo `SettingsMaterializer` injects a Bash-matched PreToolUse hook
+  into every provisioned instance that installs the shirabe plugin. It is an
+  inline pass-through — **no carried script file** — to the on-PATH
+  `shirabe pr-body-hook`, exactly like the work-summary hooks niwa injects.
+- One PreToolUse-specific difference from the work-summary PostToolUse
+  pass-through: the command must **not** `exec` the binary. A PostToolUse hook
+  can `exec` because a non-zero exit there is harmless, but a PreToolUse hook
+  that exits non-zero *blocks* the tool call. Since the hook matches every Bash
+  command, an outdated `shirabe` that predates the `pr-body-hook` subcommand
+  (clap exits non-zero on an unknown subcommand) would otherwise block every
+  command. The injected command therefore guards the exit:
+  `command -v shirabe >/dev/null 2>&1 || exit 0; shirabe pr-body-hook
   2>/dev/null || exit 0` (fall back to allow). The current binary always exits
-  0, so the guard only ever fires against a stale install;
-- register it in `dot-niwa/.niwa/workspace.toml` as a second
-  `[[claude.hooks.pre_tool_use]]` entry with `matcher = "Bash"` and
-  `scripts = ["hooks/pre_tool_use/pr-body-guard.sh"]` (Claude Code runs
-  multiple PreToolUse Bash hooks; it composes with the existing
-  `gate-online.sh` entry).
+  0, so the guard only ever fires against a stale install.
+- Injection is gated on the shirabe plugin, bounded by a
+  `[claude] pr_body_hook = false` off switch (default on), and deduped against
+  any pr-body hook a workspace still declares itself, so it never
+  double-registers. It is appended to the PreToolUse block, composing with an
+  existing `gate-online` entry (Claude Code runs multiple PreToolUse Bash
+  hooks).
 
-`niwa apply` then projects the script into each repo's
-`.claude/hooks/pre_tool_use/…local.sh` and adds the PreToolUse registration to
-`.claude/settings.local.json`, exactly as it already does for the
-`work-summary` hooks. The handoff boundary is clean: a shirabe release makes
-the subcommand available on PATH; a dot-niwa change turns it on across the
-workspace. This design's PR opens the dot-niwa issue/PR that carries the
-wiring; the shirabe side does not depend on it to build or test.
+The boundary is clean: a shirabe release makes the subcommand available on
+PATH; niwa's default injection turns it on across every shirabe-using workspace
+on the next `niwa apply`, with no per-workspace declaration. The trust anchor
+is the installed `shirabe` binary, never a working-tree script. This replaces
+the earlier dot-niwa `workspace.toml` / `pr-body-guard.sh` handoff — the same
+shirabe-owns-binary / niwa-owns-wiring split as `tsukumogami/niwa#188`. The
+shirabe side does not depend on the niwa change to build or test.
 
 ## Implementation Approach
 
@@ -524,11 +530,12 @@ authoring-time increment and depends only on Batch 1:
   `gh pr edit --add-label` (allow, nothing to check); a non-`gh` command
   (allow); a `--fill`/`--web` create and an unreadable `--body-file` (allow,
   fail-open); a malformed stdin (allow). Depends on Batch 1 for
-  `check_pr_body`. The dot-niwa registration (a thin pass-through script plus
-  a `workspace.toml` entry) is handed off as `tsukumogami/dot-niwa#<N>`,
-  landing independently once a shirabe release carries the subcommand — the
-  same shirabe-owns-binary / dot-niwa-owns-wiring split as
-  `tsukumogami/dot-niwa#4`.
+  `check_pr_body`. The registration is a niwa built-in default (the
+  `SettingsMaterializer` injects the inline PreToolUse pass-through for shirabe
+  adopters, `tsukumogami/niwa#189`), landing independently once a shirabe
+  release carries the subcommand — the same shirabe-owns-binary /
+  niwa-owns-wiring split as the work-summary default injection
+  (`tsukumogami/niwa#188`).
 
 ## Security Considerations
 
@@ -630,8 +637,10 @@ authoring-time increment and depends only on Batch 1:
   scans a `gh` command out of `tool_input.command` (`is_pr_create`), emits
   hook JSON built with `serde_json`, and always exits 0. `pr_body_hook.rs`
   reuses its stdin and argv-scan primitives.
-- `.niwa/hooks/pre_tool_use/gate-online.sh` and
-  `.niwa/hooks/post_tool_use/work-summary-capture.sh` (in `tsukumogami/dot-niwa`)
-  — the existing PreToolUse deny-shape and the thin pass-through pattern the
-  `pr-body-guard.sh` wiring copies; `tsukumogami/dot-niwa#4` is the
-  work-summary wiring PR this handoff parallels.
+- `internal/workspace/materialize.go` (in `tsukumogami/niwa`) — the
+  `SettingsMaterializer` default-injection path. `tsukumogami/niwa#188` made the
+  work-summary hooks a niwa built-in default for shirabe adopters; the pr-body
+  PreToolUse hook is injected the same way (`tsukumogami/niwa#189`), with the
+  PreToolUse-safe non-exec guard. The injected hook composes with the existing
+  `gate-online` PreToolUse entry (Claude Code runs multiple PreToolUse Bash
+  hooks).

--- a/docs/prds/PRD-pr-template-gate.md
+++ b/docs/prds/PRD-pr-template-gate.md
@@ -225,12 +225,13 @@ DESIGN. The attacker-controlled title/body SHALL reach the decision reason
 only as a structured (JSON-encoded) value, never string-concatenated.
 
 **R16.** The hook **registration** (the settings wiring that installs the
-PreToolUse hook) SHALL be **delegated to `tsukumogami/dot-niwa`**, following
-the `work-summary` wiring precedent (`tsukumogami/dot-niwa#4`): shirabe owns
-the binary subcommand and the rule; dot-niwa owns the pass-through hook script
-and the `workspace.toml` registration that `niwa apply` projects into each
-repo. This PRD's implementation opens the dot-niwa issue/PR; the shirabe side
-builds and tests without it.
+PreToolUse hook) SHALL be a **`tsukumogami/niwa` built-in default** for shirabe
+adopters, following the `work-summary` default-injection precedent
+(`tsukumogami/niwa#188`): shirabe owns the binary subcommand and the rule; niwa
+injects the inline PreToolUse pass-through during `niwa apply`, gated on the
+shirabe plugin and bounded by a `pr_body_hook` off switch. This PRD's
+implementation opens the niwa issue/PR; the shirabe side builds and tests
+without it.
 
 ## Acceptance Criteria
 
@@ -273,8 +274,9 @@ builds and tests without it.
   a body runs PB2–PB3; a `gh pr edit` that changes neither is allowed.
 - [ ] *(Increment)* `--fill`/`--web`, an unreadable or `-` `--body-file`, a
   non-`gh` command, and malformed stdin all fail open (allow, no output).
-- [ ] *(Increment)* The hook registration is delegated to `tsukumogami/dot-niwa`
-  via an opened issue/PR; the shirabe change builds and tests independently.
+- [ ] *(Increment)* The hook registration is a `tsukumogami/niwa` built-in
+  default (injected for shirabe adopters) via an opened issue/PR; the shirabe
+  change builds and tests independently.
 
 ## Out of Scope
 

--- a/references/pr-body-conformance.md
+++ b/references/pr-body-conformance.md
@@ -105,9 +105,9 @@ example.
 - **`/execute`** (`pr_finalization`) and **`/work-on`** (PR phase) cite this
   reference for the mechanical rule while authoring the title and two-part
   body, so the body they produce and the rule CI enforces come from one source.
-- **The client-side PreToolUse hook** (`shirabe pr-body-hook`, wired via
-  `tsukumogami/dot-niwa`) runs the same `check_pr_body` engine against a
-  `gh pr create` / `gh pr edit` command before it executes, catching a
-  malformed PR at authoring time in any checkout. It reuses this rule, adding
-  no checks of its own — PB1–PB3 are stated here once and enforced by CI, the
-  skills, and the hook alike.
+- **The client-side PreToolUse hook** (`shirabe pr-body-hook`, injected by niwa
+  as a built-in default for shirabe adopters) runs the same `check_pr_body`
+  engine against a `gh pr create` / `gh pr edit` command before it executes,
+  catching a malformed PR at authoring time in any checkout. It reuses this
+  rule, adding no checks of its own — PB1–PB3 are stated here once and enforced
+  by CI, the skills, and the hook alike.


### PR DESCRIPTION
Update the pr-template-gate scoping docs so the client-side pr-body PreToolUse hook is described as a `tsukumogami/niwa` built-in default for shirabe adopters, rather than a per-workspace `dot-niwa` `workspace.toml` declaration plus a carried `pr-body-guard.sh` script. This mirrors the work-summary default-injection precedent (`tsukumogami/niwa#188`). The mechanical rule (PB1-PB3) and the `shirabe pr-body-hook` subcommand are unchanged; only the registration mechanism moves.

---

## Why

We decided to wire the client hook the same way niwa #188 wired the work-summary hooks: niwa's `SettingsMaterializer` injects the hook as a built-in default for any instance that installs the shirabe plugin, gated + off-switchable, with no per-workspace declaration and no working-tree script. That supersedes the dot-niwa handoff the design originally specified (dot-niwa #6, now closed). The niwa side is implemented in `tsukumogami/niwa#189`.

## What changed

- `docs/designs/current/DESIGN-pr-template-gate.md` — the decision summary, the Solution Architecture handoff paragraph, the "Hook wiring" section (retitled to "niwa default injection"), the Batch 4 note, and the References entry now describe the niwa built-in default. The PreToolUse-safe contract is preserved verbatim: the injected command must **not** `exec` and swallows a non-zero exit (`command -v shirabe ... || exit 0; shirabe pr-body-hook 2>/dev/null || exit 0`) because a non-zero PreToolUse exit blocks the tool call.
- `docs/prds/PRD-pr-template-gate.md` — R16 and its acceptance criterion now name the niwa built-in default instead of the dot-niwa delegation.
- `references/pr-body-conformance.md` — the client-hook consumer bullet says "injected by niwa as a built-in default for shirabe adopters."

## Testing

- Docs-only; the mechanical rule and the binary are untouched. The `validate-docs` gate checks frontmatter/structure, which is preserved.

Companion to `tsukumogami/niwa#189` (the implementation); `tsukumogami/dot-niwa#6` is closed in favor of the niwa default.
