### PR TITLE
fix(validate): accept the revert Conventional Commits type in PB1

### DIFF
--- a/crates/shirabe-validate/src/pr_body.rs
+++ b/crates/shirabe-validate/src/pr_body.rs
@@ -39,7 +39,7 @@ pub struct PrBodyFinding {
 /// The Conventional Commits types accepted in a PR title (PB1). Mirrors the
 /// set the PR-creation guidance lists.
 const CONVENTIONAL_TYPES: &[&str] = &[
-    "feat", "fix", "docs", "style", "refactor", "perf", "test", "chore", "ci", "build",
+    "feat", "fix", "docs", "style", "refactor", "perf", "test", "chore", "ci", "build", "revert",
 ];
 
 /// Statically check an authored PR `body` and optional `title`, offline.
@@ -145,7 +145,7 @@ fn check_title(title: &str) -> Option<String> {
         format!(
             "PR title {:?} is not Conventional Commits. Use `<type>[optional scope]: \
              <description>` with <type> one of feat|fix|docs|style|refactor|perf|test|chore|\
-             ci|build; see references/pr-body-conformance.md.",
+             ci|build|revert; see references/pr-body-conformance.md.",
             title
         )
     };
@@ -317,6 +317,14 @@ Fixes #221
     fn unknown_type_fails() {
         let findings = check_pr_body(GOOD_BODY, Some("feet: add a mode"));
         assert!(messages(&findings).contains("not Conventional Commits"));
+    }
+
+    #[test]
+    fn revert_type_passes() {
+        // `revert` is a Conventional Commits type; a PR that reverts an earlier
+        // change titled `revert: ...` must pass PB1.
+        let findings = check_pr_body(GOOD_BODY, Some("revert: undo the pr-body mode"));
+        assert!(findings.is_empty(), "expected clean, got: {:?}", findings);
     }
 
     #[test]

--- a/references/pr-body-conformance.md
+++ b/references/pr-body-conformance.md
@@ -40,7 +40,7 @@ enforces them offline (no `gh`, no network).
 - **PB1 — Conventional Commits title** (checked when a title is supplied). The
   title is `<type>[optional scope][!]: <description>` where:
   - `<type>` is one of `feat`, `fix`, `docs`, `style`, `refactor`, `perf`,
-    `test`, `chore`, `ci`, `build`;
+    `test`, `chore`, `ci`, `build`, `revert`;
   - the description after `: ` is non-empty;
   - the optional scope is not an **issue-number scope**. Issue numbers are
     never a scope — `docs(issue-8):`, `chore(#8):`, and `fix(8):` all fail.


### PR DESCRIPTION
Accept `revert` as a Conventional Commits type in the PB1 title check. A GitHub-style revert PR carries the title `revert: <original subject>`, but `revert` was missing from the accepted type set, so the pr-body gate flagged every such PR as "not Conventional Commits". Add `revert` to `CONVENTIONAL_TYPES`, to the PB1 error-message hint, and to the single-source type list in `references/pr-body-conformance.md`, with a unit test asserting a `revert:` title passes.

---

## Why

`revert` is a standard Conventional Commits type. The gate's job is to accept well-formed titles and reject malformed ones; rejecting a legitimate `revert:` title was a false positive that would force a reviewer to reword a mechanically-correct revert. Surfaced while landing the PR-body conformance gate.

## What changed

- `crates/shirabe-validate/src/pr_body.rs` — `revert` added to `CONVENTIONAL_TYPES` and to the `check_title` error hint; new `revert_type_passes` test.
- `references/pr-body-conformance.md` — the PB1 `<type>` list (the single source the check mirrors) now includes `revert`.

## Testing

- `cargo test -p shirabe-validate pr_body` — 15 pass, including the new `revert_type_passes`.
- Single-source preserved: a repo-wide grep confirms the type list is stated only in the reference and the validator, both updated; no consumer restates it.
