### PR TITLE
fix(release): remove finalize/binaries race in prepare-release

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: number
         default: 5
+      wait-timeout-seconds:
+        description: 'Max seconds to wait for the release object and its assets to appear'
+        required: false
+        type: number
+        default: 1800
     secrets:
       token:
         description: 'Token with release edit permission (falls back to GITHUB_TOKEN)'
@@ -20,6 +25,9 @@ on:
 jobs:
   finalize:
     runs-on: ubuntu-latest
+    # Backstop for the bounded poll below; keeps a stuck wait from running for
+    # the 6h GitHub default.
+    timeout-minutes: 45
     steps:
       - name: Determine effective token
         id: token
@@ -37,37 +45,61 @@ jobs:
             exit 1
           fi
 
-      - name: Verify draft release exists
+      # The release object and its assets are created asynchronously by the
+      # tag-triggered Release Binaries workflow, which builds four binaries
+      # before it creates the draft and uploads the five assets. finalize only
+      # `needs: release` (the tag-push job), so it can start minutes before the
+      # release object exists. Poll instead of failing on the first miss, so a
+      # fresh dispatch finalizes without a manual rerun -- whether or not a draft
+      # was pre-created. Waits for the release to exist AND to reach the expected
+      # asset count, bounded by wait-timeout-seconds.
+      - name: Wait for release and assets
+        id: wait
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
-          DRAFT=$(gh release view "${{ inputs.tag }}" --repo "${{ github.repository }}" --json isDraft --jq '.isDraft' 2>/dev/null || echo "not_found")
-          if [ "$DRAFT" = "not_found" ]; then
-            echo "::error::No release found for tag ${{ inputs.tag }}"
-            echo "Create one: gh release create ${{ inputs.tag }} --draft --title '${{ inputs.tag }}'"
-            exit 1
-          fi
-          if [ "$DRAFT" != "true" ]; then
-            echo "Release ${{ inputs.tag }} is already published. Nothing to do."
-            exit 0
-          fi
-
-      - name: Verify asset count
-        if: ${{ inputs.expected-assets > 0 }}
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
-        run: |
-          ACTUAL=$(gh release view "${{ inputs.tag }}" --repo "${{ github.repository }}" --json assets --jq '.assets | length')
+          TAG="${{ inputs.tag }}"
+          REPO="${{ github.repository }}"
           EXPECTED=${{ inputs.expected-assets }}
-          if [ "$ACTUAL" -lt "$EXPECTED" ]; then
-            echo "::error::Expected at least $EXPECTED assets, found $ACTUAL"
-            echo "Assets present:"
-            gh release view "${{ inputs.tag }}" --repo "${{ github.repository }}" --json assets --jq '.assets[].name'
-            exit 1
-          fi
-          echo "Asset count OK: $ACTUAL >= $EXPECTED"
+          TIMEOUT=${{ inputs.wait-timeout-seconds }}
+          INTERVAL=15
+          ELAPSED=0
+          while true; do
+            INFO=$(gh release view "$TAG" --repo "$REPO" --json isDraft,assets 2>/dev/null || echo "")
+            if [ -n "$INFO" ]; then
+              IS_DRAFT=$(echo "$INFO" | jq -r '.isDraft')
+              ACTUAL=$(echo "$INFO" | jq -r '.assets | length')
+              if [ "$IS_DRAFT" != "true" ]; then
+                echo "Release $TAG is already published (assets: $ACTUAL). Nothing to promote."
+                echo "already-published=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              if [ "$EXPECTED" -le 0 ] || [ "$ACTUAL" -ge "$EXPECTED" ]; then
+                echo "Release $TAG ready: draft with $ACTUAL asset(s) (expected >= $EXPECTED)."
+                echo "already-published=false" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              echo "Waiting: draft $TAG has $ACTUAL/$EXPECTED assets... (${ELAPSED}s/${TIMEOUT}s)"
+            else
+              echo "Waiting: release $TAG not created yet... (${ELAPSED}s/${TIMEOUT}s)"
+            fi
+            if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+              if [ -z "$INFO" ]; then
+                echo "::error::Timed out after ${TIMEOUT}s: no release object for $TAG."
+                echo "Check the Release Binaries workflow triggered by the tag push."
+              else
+                echo "::error::Timed out after ${TIMEOUT}s waiting for >= $EXPECTED assets on $TAG (found $ACTUAL)."
+                echo "Assets present:"
+                echo "$INFO" | jq -r '.assets[].name'
+              fi
+              exit 1
+            fi
+            sleep "$INTERVAL"
+            ELAPSED=$((ELAPSED + INTERVAL))
+          done
 
       - name: Promote draft to published
+        if: ${{ steps.wait.outputs.already-published != 'true' }}
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |


### PR DESCRIPTION
`prepare-release.yml` runs `release` (calls `release.yml`) then `finalize` (calls `finalize-release.yml`, `needs: release`). But the GitHub release object and its five assets are created by neither of those jobs — they are created by `release-binaries.yml`, a separate workflow triggered by the tag push (`on: push tags: v*`). `release.yml` only stamps the version and pushes the tag (fast git ops), so `finalize` starts almost immediately, while `release-binaries.yml` spends minutes building four binaries before it creates the draft and uploads assets. With no ordering between them, `finalize` ran first and its `gh release view` returned nothing, failing hard on "No release found for tag vX.Y.Z" and forcing a manual `gh run rerun --failed`. Even with a pre-created draft, `finalize` could still race the asset upload and fail the asset-count check.

This makes `finalize-release.yml` tolerant of that async ordering: the two first-miss verification steps ("Verify draft release exists", "Verify asset count") are replaced by a single bounded poll that waits for the release object to exist AND reach the expected asset count, then promotes. A `wait-timeout-seconds` input (default 1800) bounds the wait, backed by a `timeout-minutes: 45` job cap. It works whether or not a draft was pre-created; an already-published release exits the poll early and skips promotion.

---

## Chosen option and why

Brief's option 1 (make finalize tolerant), over option 2 (create the release object up front) and option 3 (pull the binaries build into a `needs`-chain):

- Works with AND without a pre-created draft — the poll waits out the not-found window while `release-binaries.yml` creates the draft and uploads assets; a pre-created draft just shortens the wait.
- Minimal blast radius — no pipeline restructure, no change to `release.yml` / `release-binaries.yml` / versioning / the PR-body gate. Options 2 and 3 touch more surface and risk double-builds for no benefit over polling.
- Preserves the already-published rerun path: the poll exits early and skips promote; the post-release hook still runs, as before.
- Bounded, legible failure: on timeout it reports whether the release object never appeared or the assets never completed, and lists what was present.

## Verification

A real release can't be cut here (v0.15.0 is already published; out of scope), so verified by:

- `actionlint` clean on the changed workflow; YAML parses.
- Extracted the exact poll body and drove it through a mocked `gh` for all four race states:
  1. release appears late, assets grow 0, 2, 5 -> promotes (`already-published=false`)
  2. already published -> early success, skips promote (`already-published=true`)
  3. release object never created -> bounded timeout, exit 1 with a clear message
  4. draft stuck below asset count -> bounded timeout, exit 1, lists present assets

## Out of scope

No real release cut. No changes to versioning, unrelated release behavior, or the PR-body gate.
