### PR TITLE
docs: align /plan Output section with /roadmap populate ownership

### DIFF
--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -454,11 +454,13 @@ Final artifacts depend on execution mode:
 - Source design doc status updated to "Planned"
 
 **multi-pr mode (roadmap input):**
-- Roadmap enriched directly -- Implementation Issues table and Dependency Graph
-  written into the roadmap's reserved sections (no separate PLAN doc)
-- GitHub milestone + per-feature planning issues with `needs-*` labels
-- Table uses `Feature | Issues | Dependencies | Status` format from `roadmap-format.md`
-- Roadmap stays Active (no status transition)
+- Populating the roadmap's reserved Implementation Issues and Dependency Graph
+  sections is owned by `/roadmap populate` (the `shirabe roadmap populate`
+  subcommand), not by this workflow
+- `/plan` on a roadmap produces the conventional PLAN artifact for a
+  roadmap-scoped slice (`docs/plans/PLAN-<topic>.md`, plus GitHub milestone and
+  issues), per `references/phases/phase-7-creation.md`; it no longer rewrites
+  the roadmap document itself
 
 **single-pr mode:**
 - `docs/plans/PLAN-<topic>.md` with status Draft


### PR DESCRIPTION
Correct the stale multi-pr roadmap-input entry in the `/plan` skill's Output section. It still claimed `/plan` enriches a roadmap directly by writing the reserved Implementation Issues table and Dependency Graph into the roadmap document, creating per-feature planning issues, and leaving no separate PLAN doc. That contradicted the same skill's own ownership statement and the phase-7 creation reference, which hand roadmap population to `/roadmap populate` and keep the `/plan` roadmap branch only for producing a PLAN doc over a roadmap-scoped slice.

The Output entry now states that populating the roadmap's reserved sections is owned by `/roadmap populate` (the `shirabe roadmap populate` subcommand), not by this workflow, and that `/plan` on a roadmap produces the conventional PLAN artifact for a roadmap-scoped slice, no longer rewriting the roadmap document itself. This is a documentation-only change with no behavioral impact.

---

## What changed

`skills/plan/SKILL.md`, Output section, `multi-pr mode (roadmap input)` block.

Before:

```
**multi-pr mode (roadmap input):**
- Roadmap enriched directly -- Implementation Issues table and Dependency Graph
  written into the roadmap's reserved sections (no separate PLAN doc)
- GitHub milestone + per-feature planning issues with `needs-*` labels
- Table uses `Feature | Issues | Dependencies | Status` format from `roadmap-format.md`
- Roadmap stays Active (no status transition)
```

After:

```
**multi-pr mode (roadmap input):**
- Populating the roadmap's reserved Implementation Issues and Dependency Graph
  sections is owned by `/roadmap populate` (the `shirabe roadmap populate`
  subcommand), not by this workflow
- `/plan` on a roadmap produces the conventional PLAN artifact for a
  roadmap-scoped slice (`docs/plans/PLAN-<topic>.md`, plus GitHub milestone and
  issues), per `references/phases/phase-7-creation.md`; it no longer rewrites
  the roadmap document itself
```

## Why this is consistent

- `skills/plan/SKILL.md:357-362` already states population "is owned by `/roadmap populate` (which calls the `shirabe roadmap populate` subcommand), not by this workflow ... it no longer rewrites the roadmap document itself." The Output entry now matches this.
- `skills/plan/references/phases/phase-7-creation.md:5-17` states the prose-substitution path "is retired" and the `input_type: roadmap` branch "remains only for the case where a PLAN document is being produced from a roadmap upstream ... It no longer rewrites the roadmap document itself." The Output entry now matches this.

## Verification

- `grep -rn "reserved" skills/plan/`: remaining hits are the ownership statement (line 357), the rewritten Output entry (line 457), `evals/evals.json:118` (which asserts the transcript points at `/roadmap populate`), and `references/phases/phase-7-creation.md`. No spot in the plan skill still claims `/plan` fills the roadmap's reserved sections.
- CI coverage: none of `check-templates.yml`, `check-template-consistency.yml`, `check-plan-docs.yml`, `check-plan-scripts.yml` are path-triggered by `skills/plan/SKILL.md` (their filters are `koto-templates/**`, `docs/plans/PLAN-*.md`, and `skills/plan/scripts/**`). Ran the plan-skill scripts they do invoke anyway: `validate-plan_test.sh` (11 passed, 0 failed), `plan-to-tasks_test.sh` (67 passed, 0 failed), `validate-template-mermaid.sh` (all templates valid).

Fixes #234
