### PR TITLE
ci: make lifecycle coordination gate a no-op for non-coordination PRs

### DIFF
--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -6,9 +6,20 @@ name: Lifecycle Check
 # on:
 #   pull_request:
 #     types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
+# permissions:
+#   contents: read
+#   pull-requests: read
 # jobs:
 #   lifecycle:
 #     uses: tsukumogami/shirabe/.github/workflows/lifecycle.yml@v0.10.0
+#
+# The caller must grant `pull-requests: read` (as above): a reusable workflow
+# cannot request a permission the caller lacks, and the coordination merge-last
+# gate below needs it for its live `gh` queries on a coordination PR. A
+# single-repo consumer that never opens a coordination PR can grant only
+# `contents: read` — the gate detects the non-coordination case from the event
+# payload and skips before touching the API (see that step's comment). This
+# mirrors how validate-pr-body.yml documents the caller-permissions contract.
 #
 # The reusable workflow runs the chain-aware passing-state check
 # (`shirabe validate --lifecycle .`) against the caller repo's working
@@ -31,6 +42,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Needed only by the coordination merge-last gate's live `gh` queries on
+      # a genuine coordination PR. Declared here so the scope is not downscoped
+      # away for coordination callers; the non-coordination skip path never
+      # exercises it (it detects from the event payload). A caller that grants
+      # only `contents: read` still runs the skip path cleanly.
+      pull-requests: read
     steps:
       - name: Check PR context
         # Non-PR triggers (workflow_dispatch, etc.) have no pull_request
@@ -137,19 +154,36 @@ jobs:
         # workflow skill from the template in references/coordination-strategy.md)
         # carries a fixed declaration line — the blockquote "This is a
         # **coordination PR** for a coordinated multi-repo effort." We grep the
-        # live PR body for that marker rather than relying on a label, so the
-        # signal travels with the durable skill-authored body. A PR without the
-        # marker is not a coordination PR and the gate is skipped (a no-op for
-        # ordinary lifecycle PRs).
+        # PR body for that marker rather than relying on a label, so the signal
+        # travels with the durable skill-authored body. A PR without the marker
+        # is not a coordination PR and the gate is skipped (a no-op for ordinary
+        # lifecycle PRs).
+        #
+        # Detection reads the body from the EVENT PAYLOAD (the PR_BODY env var),
+        # not a live `gh pr view`. That is the fix for the merge-gate hard-fail:
+        # the skip path for an ordinary PR must never shell out to the API, or a
+        # downstream single-repo consumer that grants no `pull-requests` scope
+        # dies at `gh pr view` under `set -e` before its own skip guard can run.
+        # Reading the event payload lets the non-coordination case exit 0 with
+        # zero API calls and zero PR permission. The body is passed through env
+        # (never interpolated inline into the script) so an untrusted PR body
+        # cannot reach the shell as code — the same injection-safe posture the
+        # pr-body.yml author-login guard uses.
         #
         # F4: status is recomputed live by `shirabe validate --merge-gate` from
         # `gh`, never from the (editable) PR body — the body supplies only the
         # list of refs the step passes in. Fail closed: any unresolvable
         # PR/upstream blocks.
         env:
-          # `gh` reads the PR body via the API; the token is consumed by the
-          # subprocess only, never held by the validator process (gh.rs model).
+          # `gh` reads live PR/upstream status via the API on the coordination
+          # path; the token is consumed by the subprocess only, never held by
+          # the validator process (gh.rs model).
           GH_TOKEN: ${{ github.token }}
+          # Coordination detection reads the PR body from the event payload
+          # through this env var (never interpolated inline — injection surface).
+          # The skip path for an ordinary PR consults only this and makes no API
+          # call, so it needs no `pull-requests` scope.
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           # Only ready PRs run the gate (strict-mode pinned, mirrors the check
           # above). A draft PR is not mergeable, so the gate is moot there.
@@ -158,15 +192,25 @@ jobs:
             exit 0
           fi
 
-          # Detect a coordination PR by the fixed declaration line in its body.
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-          BODY="$(gh pr view "$PR_NUMBER" --json body --jq '.body')"
-          if ! printf '%s' "$BODY" | grep -qF 'This is a **coordination PR**'; then
+          # Detect a coordination PR by the fixed declaration line in the
+          # event-payload body. No `gh` here: an ordinary PR must skip without
+          # any API call (see this step's comment). `printf | grep` inside the
+          # `if !` condition is exempt from `set -e`, so a non-match (grep exit
+          # 1) drives the skip branch instead of aborting the step.
+          if ! printf '%s' "$PR_BODY" | grep -qF 'This is a **coordination PR**'; then
             echo "Not a coordination PR (no declaration marker); skipping merge-last gate."
             exit 0
           fi
 
           echo "Coordination PR detected and ready; running the merge-last gate."
+
+          # A genuine coordination PR: re-read the body LIVE for ref extraction.
+          # The index may have been edited after the triggering event, and this
+          # path (unlike detection) is entitled to the API — a coordination PR
+          # is fail-closed, so a missing `pull-requests` scope here SHOULD abort
+          # the step (gh fails, command substitution non-zero, `set -e` exits).
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          BODY="$(gh pr view "$PR_NUMBER" --json body --jq '.body')"
 
           # The coordination PR body's PR-index lines carry the durable list of
           # `owner/repo:path#number` refs. Extract them as the index ONLY —


### PR DESCRIPTION
The reusable lifecycle.yml "Coordination merge-last gate" step hard-failed on every ready (non-draft) PR in downstream consumers. The job granted only contents: read, but the step ran `gh pr view` for coordination detection under `bash -e -o pipefail`, so the failed command substitution aborted the step before its own "not a coordination PR, skip" guard could run. Single-repo consumers, which never open a coordination PR, were fully blocked even though the whole-tree `shirabe validate --lifecycle .` check itself passed.

This moves coordination detection to the event payload. The PR body arrives through a `PR_BODY` env var (never interpolated inline, so an untrusted body cannot reach the shell as code) and the skip path greps that variable instead of shelling out to `gh`. An ordinary PR now exits 0 with zero API calls and needs no pull-requests permission, so a single-repo consumer that grants only contents: read is no longer blocked. The job also declares pull-requests: read so the genuine coordination path, which still re-reads the live body for ref extraction and runs live `gh` queries inside `shirabe validate --merge-gate`, keeps that scope instead of having it downscoped away; the example-caller comment now documents that callers must grant it too, mirroring validate-pr-body.yml. The gate stays fail-closed for real coordination PRs: an empty PR-index still blocks, and a blocked merge-gate still fails under --mode=ready. The documented invariants are preserved unchanged: the draft-posture skip, the fail-closed empty index, and the F4 live recompute.

---

## Fixes

Fixes #231

## set -e execution-path walkthrough

The step runs under `bash --noprofile --norc -e -o pipefail`.

Ready, non-coordination PR in a permissions-restricted downstream (caller grants only contents: read, so the token has no pull-requests scope):

1. The runner sets `PR_BODY` from `github.event.pull_request.body` — an env assignment, not a command; it cannot fail.
2. `if [ "<draft>" != "false" ]` — a ready PR has draft == false, so the test is false and `[` exits 0; the draft-skip branch is not taken. No error.
3. `if ! printf '%s' "$PR_BODY" | grep -qF 'This is a **coordination PR**'` — printf exits 0, grep finds no marker and exits 1, so the pipeline exits 1 and `!` negates it to true. Because this runs as an `if` condition, set -e is suppressed for it (a command whose status is tested), so the non-zero pipeline does not abort the step. The branch is taken: `echo` then `exit 0`. The step succeeds having invoked no `gh` command, so no pull-requests permission is required.

Ready coordination PR (caller granted pull-requests: read):

1-2. Same as above.
3. grep finds the marker and exits 0, so the pipeline exits 0 and `!` negates it to false; the skip branch is not taken. Execution continues.
4. `BODY="$(gh pr view ... )"` — with the scope granted, `gh` succeeds and the substitution exits 0. If the scope were missing, `gh` would fail, the substitution would be non-zero, and set -e would abort the step (fail-closed, which is correct for a coordination PR).
5. `mapfile` extracts the ref index. An empty index hits `echo "::error::..."` then `exit 1` (fail-closed).
6. Otherwise `shirabe validate --merge-gate --mode=ready ...` runs; its exit code is the step's, so a blocked gate fails the check (the F4 live recompute / merge-last backstop).

So the gate is a genuine no-op (exit 0 with no failing command, no API call) for a ready non-coordination PR, and remains fail-closed for a ready coordination PR.

## actionlint

Ran actionlint 1.7.12 (downloaded via `gh release download -R rhysd/actionlint`) on `.github/workflows/lifecycle.yml`. The only two findings — `property "workflow_repository" is not defined` and `property "workflow_sha" is not defined` — are pre-existing on origin/main in the untouched "Checkout shirabe" step (this actionlint version does not yet know those `job` context fields). They appear identically on the base file and on this branch, so this change introduces zero new actionlint findings.

## Out of scope

The issue's trailing "Note (possibly separate)" about standalone `shirabe validate --merge-gate --mode=ready` (no --pr-index) reporting BLOCKED and exiting 2 is a CLI-behavior question in the Rust binary, downstream of this workflow bug. It is not touched here; the workflow only reaches the merge-gate on a detected coordination PR and always passes an explicit ref index (or fails closed on an empty one).
