### PR TITLE
fix(transition): recognize strategy-derived prefix feature headings

### DIFF
--- a/crates/shirabe-validate/src/features.rs
+++ b/crates/shirabe-validate/src/features.rs
@@ -19,10 +19,16 @@
 //! <one or more lines of description prose>
 //! ```
 //!
+//! The heading also accepts the strategy-derived prefix form
+//! `### <PREFIX><N>: <label>` (e.g. `### ED1:`, `### SE2:`), where `<PREFIX>`
+//! is a short alphabetic tag immediately followed by the feature number. Both
+//! forms number features positionally, so a `Feature M` dependency edge still
+//! resolves against a prefixed roadmap.
+//!
 //! Order matters only for the heading line; the three bolded annotation
 //! lines and the description are matched by their leading marker, not by
 //! position, so an author writing them in a different order still parses.
-//! The label captures everything after `### Feature N: ` up to end-of-line
+//! The label captures everything after the heading's colon up to end-of-line
 //! and may include an inline issue link (e.g. `... — [#42](url)`); the
 //! caller strips the link for downstream uses where the bare label is
 //! wanted.
@@ -37,7 +43,8 @@ pub struct Feature {
     /// against; `Feature 1` in a Dependencies cell means the feature with
     /// `id == 1`.
     pub id: usize,
-    /// The full label text from the heading after `### Feature N: `.
+    /// The full label text from the heading, after the `### Feature N: ` (or
+    /// `### <PREFIX><N>: `) prefix and colon.
     /// May contain trailing decoration (an em-dash plus an issue link),
     /// which the caller is expected to strip when a bare label is wanted.
     pub label: String,
@@ -61,7 +68,8 @@ pub struct Feature {
 
 /// Parse the `## Features` section of `doc` into an ordered list of
 /// [`Feature`]s. Returns an empty vector when the section is missing or
-/// contains no `### Feature N:` headings.
+/// contains no feature headings (neither `### Feature N:` nor the
+/// strategy-derived `### <PREFIX><N>:` form).
 pub fn parse_features(doc: &Doc) -> Vec<Feature> {
     let Some((start_idx, end_idx, _heading_line)) = find_features_section(doc) else {
         return Vec::new();
@@ -272,26 +280,65 @@ fn absolute_line(doc: &Doc, body_idx: usize) -> usize {
     features_heading + body_idx.saturating_sub(features_body_idx)
 }
 
-/// Recognize `### Feature N: <label>` and return the label.
+/// Recognize a feature heading and return its label. Two forms are accepted:
+///
+/// - `### Feature <N>: <label>` -- the classic numbered form.
+/// - `### <PREFIX><N>: <label>` -- the strategy-derived prefix form, where
+///   `<PREFIX>` is a short alphabetic tag (e.g. `ED`, `SE`, `SR`, `NW`)
+///   immediately followed by the feature number with no space between them.
+///
+/// In both forms the returned label is everything after the colon, trimmed.
 fn parse_feature_heading(line: &str) -> Option<String> {
-    let rest = line.strip_prefix("### Feature ")?;
-    // Read decimal digits, then ":", then optional whitespace, then label.
-    let mut chars = rest.char_indices();
-    let mut last_digit_end: Option<usize> = None;
-    while let Some((idx, c)) = chars.next() {
-        if c.is_ascii_digit() {
-            last_digit_end = Some(idx + c.len_utf8());
+    let rest = line.strip_prefix("### ")?;
+
+    // Classic form: the literal word `Feature`, a space, then `<N>: <label>`.
+    if let Some(after) = rest.strip_prefix("Feature ") {
+        return parse_number_colon_label(after);
+    }
+
+    // Prefix form: an alphabetic tag immediately followed by the number, then
+    // `: <label>`. Require at least one leading ASCII-alphabetic character so
+    // a tag-less `### 1: x` is not mistaken for a feature.
+    let mut alpha_end = 0;
+    for (idx, c) in rest.char_indices() {
+        if c.is_ascii_alphabetic() {
+            alpha_end = idx + c.len_utf8();
         } else {
             break;
         }
     }
-    let digit_end = last_digit_end?;
+    if alpha_end == 0 {
+        return None;
+    }
+    parse_number_colon_label(&rest[alpha_end..])
+}
+
+/// Given text positioned at `<N>: <label>`, read the decimal number, require
+/// the `:` delimiter, and return the trimmed label. `None` if the number or
+/// colon is missing.
+fn parse_number_colon_label(s: &str) -> Option<String> {
+    let mut digit_end = 0;
+    for (idx, c) in s.char_indices() {
+        if c.is_ascii_digit() {
+            digit_end = idx + c.len_utf8();
+        } else {
+            break;
+        }
+    }
     if digit_end == 0 {
         return None;
     }
-    let after_digits = &rest[digit_end..];
-    let after_colon = after_digits.strip_prefix(':')?;
+    let after_colon = s[digit_end..].strip_prefix(':')?;
     Some(after_colon.trim().to_string())
+}
+
+/// True when `line` is a feature heading recognized by [`parse_features`]:
+/// either the classic `### Feature <N>:` form or the strategy-derived
+/// `### <PREFIX><N>:` prefix form. `shirabe transition` uses this to count
+/// features with the same prefix grammar the parser applies, so a roadmap
+/// that activates is also one the parser can read.
+pub fn is_feature_heading(line: &str) -> bool {
+    parse_feature_heading(line).is_some()
 }
 
 /// If `line` begins with the bold marker (e.g. `**Needs:**`), return the
@@ -434,6 +481,62 @@ mod tests {
         assert_eq!(strip_label_decoration("Foo -- [#1](url)"), "Foo");
         assert_eq!(strip_label_decoration("Foo — [#1](url)"), "Foo");
         assert_eq!(strip_label_decoration("Foo [#1](url)"), "Foo");
+    }
+
+    #[test]
+    fn parse_features_accepts_strategy_derived_prefix_headings() {
+        // The strategy-derived roadmap variant names features with a short
+        // alphabetic prefix + number (`### ED1:`, `### ED2:`) instead of the
+        // classic `### Feature N:`. The parser must recognize them, number
+        // them positionally, and capture the label after the colon.
+        let body = vec![
+            "## Features",
+            "",
+            "### ED1: Dispatch event bus",
+            "**Needs:** `needs-design`",
+            "**Dependencies:** None",
+            "**Status:** Not started",
+            "",
+            "The event bus.",
+            "",
+            "### ED2: Worker pool",
+            "**Needs:** None",
+            "**Dependencies:** Feature 1",
+            "**Status:** Not started",
+            "",
+            "Runs workers.",
+            "",
+            "## Sequencing Rationale",
+        ];
+        let doc = make_doc(body, vec![("Features", 1), ("Sequencing Rationale", 17)]);
+        let features = parse_features(&doc);
+        assert_eq!(features.len(), 2);
+        assert_eq!(features[0].id, 1);
+        assert_eq!(features[0].label, "Dispatch event bus");
+        assert_eq!(features[0].status, "Not started");
+        assert_eq!(features[0].description, "The event bus.");
+        assert_eq!(features[1].id, 2);
+        assert_eq!(features[1].label, "Worker pool");
+    }
+
+    #[test]
+    fn is_feature_heading_recognizes_both_forms() {
+        // Classic numbered form.
+        assert!(is_feature_heading("### Feature 1: Foundation"));
+        assert!(is_feature_heading("### Feature 12: Caching"));
+        // Strategy-derived prefix form (short alpha tag + number, no space).
+        assert!(is_feature_heading("### ED1: Dispatch"));
+        assert!(is_feature_heading("### SE2: Skills"));
+        assert!(is_feature_heading("### SR10: Consolidation"));
+        assert!(is_feature_heading("### NW1: Networking"));
+        assert!(is_feature_heading("### A1: Single-letter tag"));
+        // Non-headings and near-misses.
+        assert!(!is_feature_heading("### Feature A")); // no number/colon
+        assert!(!is_feature_heading("### Milestone: Foo")); // no number
+        assert!(!is_feature_heading("### 1: No tag")); // no alpha prefix
+        assert!(!is_feature_heading("### ED1 Dispatch")); // no colon
+        assert!(!is_feature_heading("### Sequencing Rationale"));
+        assert!(!is_feature_heading("## Features")); // wrong heading level
     }
 
     #[test]

--- a/crates/shirabe-validate/src/transition.rs
+++ b/crates/shirabe-validate/src/transition.rs
@@ -113,7 +113,8 @@ pub enum Precondition {
     None,
     /// Open Questions must be resolved (vision/strategy Draft -> Accepted).
     OpenQuestionsResolved,
-    /// At least N `### Feature` headings (roadmap Draft -> Active, N = 2).
+    /// At least N feature headings -- classic `### Feature N:` or the
+    /// strategy-derived `### <PREFIX><N>:` form (roadmap Draft -> Active, N = 2).
     MinFeatures(usize),
 }
 
@@ -936,14 +937,20 @@ fn validate_open_questions_resolved(doc: &crate::Doc) -> Result<(), TransitionEr
     Ok(())
 }
 
-/// Port of the scripts' `validate_features_count`: count `### Feature` headings
-/// (lines starting with `### Feature`); fewer than `min` is exit 2 with the
-/// script's `Found <count>.` message.
+/// Port of the scripts' `validate_features_count`: count feature headings;
+/// fewer than `min` is exit 2 with the script's `Found <count>.` message.
+///
+/// A heading counts when it is either the classic `### Feature` form (matched
+/// leniently, as the original shell script did) or the strategy-derived
+/// `### <PREFIX><N>:` prefix form (e.g. `### ED1:`, `### SE2:`). The prefix
+/// form is recognized with the same grammar the feature parser uses
+/// ([`crate::features::is_feature_heading`]) so a roadmap that activates is
+/// also one `roadmap populate` can parse.
 fn validate_features_count(doc: &crate::Doc, min: usize) -> Result<(), TransitionError> {
     let count = doc
         .body
         .iter()
-        .filter(|l| l.starts_with("### Feature"))
+        .filter(|l| l.starts_with("### Feature") || crate::features::is_feature_heading(l))
         .count();
 
     if count < min {
@@ -1856,6 +1863,33 @@ mod tests {
         let path = write_doc("ROADMAP-twofeat.md", doc);
         let outcome = run_transition(&path, "Active", &Flags::default()).expect("ok");
         assert_eq!(outcome.new_status, "Active");
+    }
+
+    #[test]
+    fn roadmap_draft_to_active_passes_with_prefix_convention_features() {
+        // Strategy-derived roadmaps name features `### ED1:`, `### ED2:`, ...
+        // instead of `### Feature N:`. Draft -> Active must recognize them so
+        // the count gate does not wrongly report "Found 0".
+        let doc = "---\nstatus: Draft\n---\n\n## Status\n\nDraft\n\n## Features\n\n### ED1: Dispatch event bus\n### ED2: Worker pool\n";
+        let path = write_doc("ROADMAP-prefix.md", doc);
+        let outcome = run_transition(&path, "Active", &Flags::default()).expect("ok");
+        assert_eq!(outcome.new_status, "Active");
+    }
+
+    #[test]
+    fn roadmap_draft_to_active_blocked_with_one_prefix_feature() {
+        // A single prefixed feature is still too few: the negative case must
+        // fail exactly as the classic form does.
+        let doc =
+            "---\nstatus: Draft\n---\n\n## Status\n\nDraft\n\n## Features\n\n### SE1: Only one\n";
+        let path = write_doc("ROADMAP-oneprefix.md", doc);
+        let err = run_transition(&path, "Active", &Flags::default()).expect_err("err");
+        assert_eq!(err.code, 2);
+        assert_eq!(
+            err.message,
+            "Draft -> Active requires at least 2 ### Feature headings in the Features \
+             section. Found 1."
+        );
     }
 
     // ---- idempotent no-op skips graph + preconditions (Issue 2) ----

--- a/skills/roadmap/references/roadmap-format.md
+++ b/skills/roadmap/references/roadmap-format.md
@@ -113,6 +113,25 @@ The `Needs` annotation is optional. Features without it are treated
 as ready for direct implementation. When present, it determines which
 `needs-*` label gets applied during issue creation.
 
+#### Heading forms
+
+A feature heading uses one of two forms:
+
+- **Classic:** `### Feature <N>: <label>` -- the default, where `<N>`
+  is the 1-based feature number.
+- **Strategy-derived prefix:** `### <PREFIX><N>: <label>` -- a short
+  alphabetic tag immediately followed by the feature number, no space
+  between them (e.g. `### ED1:`, `### SE2:`, `### SR10:`, `### NW1:`).
+  This variant fits product-spanning roadmaps derived from a strategy,
+  where a per-direction prefix keeps features grouped by their strategic
+  building block.
+
+Both forms are equivalent to the tooling: features are numbered
+positionally in source order regardless of the tag, so a
+`**Dependencies:** Feature 1` edge resolves against the first feature
+whether it is written `### Feature 1:` or `### ED1:`. Pick one form per
+roadmap and use it consistently.
+
 ## Reserved Sections
 
 Two sections follow Progress. They're structurally part of the


### PR DESCRIPTION
`shirabe transition <roadmap> Active` counted 0 features and refused to activate any roadmap whose Features section used the strategy-derived prefix heading convention (a short per-direction alphabetic tag plus a number, e.g. ED1, SE1, SR1, NW1) instead of the classic numbered form.

The transition count and the shared feature parser now both accept the prefix form in addition to the classic form. The prefix form is a short alphabetic tag immediately followed by the feature number. Recognition is applied consistently at both points so they agree on what a feature heading is: the transition count keeps its lenient classic behavior and additionally recognizes the prefix form via the shared parser, and the feature parser reused by `shirabe roadmap populate` now parses both. Features stay numbered positionally, so a `Feature M` dependency edge still resolves whether headings use the classic or the prefix form.

The classic form's behavior and the too-few-features negative case are unchanged. The prefix convention is documented in the roadmap-format reference.

Closes #238

---

## What

`shirabe transition <roadmap> Active` refused to activate any roadmap whose
Features section uses the strategy-derived prefix heading convention
(`### ED1:`, `### SE1:`, `### SR1:`, `### NW1:`, ...) instead of the classic
`### Feature N:` form. The Draft -> Active precondition counted **0** feature
headings and errored:

```json
{"success":false,"error":"Draft -> Active requires at least 2 ### Feature headings in the Features section. Found 0.","code":2}
```

## Why

The prefix convention is real and documented for strategy-derived,
product-spanning roadmaps (a short per-direction tag plus a number). The fix
broadens shirabe's recognition rather than forcing the classic form.

## How

Accept `### <PREFIX><N>: <label>` -- a short alphabetic tag immediately
followed by the feature number, no space -- in addition to the classic
`### Feature <N>: <label>`. Applied at both recognition points:

- **`transition.rs::validate_features_count`** keeps its lenient classic count
  (unchanged behavior for existing roadmaps) and additionally recognizes the
  prefix form via the shared `features::is_feature_heading`.
- **`features.rs::parse_feature_heading`** (reused by `shirabe roadmap
  populate`) now parses both forms. Features stay numbered positionally, so a
  `**Dependencies:** Feature M` edge still resolves whether headings are
  written `### Feature 1:` or `### ED1:`.

`skills/roadmap/references/roadmap-format.md` documents the prefix form.

## Scope / not in scope

- The classic `### Feature N:` form's behavior and the too-few-features
  negative case are unchanged.
- Dependency *cell* references stay positional (`Feature 1`, `Feature 2`).
  Prefix-token dependency references (e.g. `**Dependencies:** ED1`) are a
  distinct grammar and are not addressed here.

## Tests

- `features.rs`: `parse_features` extracts prefixed features (`### ED1:` /
  `### ED2:`); `is_feature_heading` unit-covers both forms and near-misses
  (no number, no colon, no tag, wrong heading level).
- `transition.rs`: Draft -> Active succeeds with two prefixed features;
  a single prefixed feature still fails with the existing `Found 1.` message.
- `cargo test --workspace` green; `cargo clippy` clean on the changed files.

### End-to-end verification (debug binary)

| Case | Result |
|------|--------|
| `transition` on `### ED1:`/`### ED2:` roadmap | `success: true`, status -> Active |
| `transition` on classic `### Feature 1:`/`### Feature 2:` | `success: true` (unchanged) |
| `transition` on single `### SE1:` | `code: 2`, `Found 1.` (blocked, as before) |
| `roadmap populate --no-issues` on prefixed roadmap | parses `F1`/`F2`, resolves `F1 --> F2` |
