### PR TITLE
fix(validate): resolve R8 visibility from the doc's owning repo

### DIFF
--- a/crates/shirabe-validate/src/lib.rs
+++ b/crates/shirabe-validate/src/lib.rs
@@ -25,6 +25,7 @@ pub mod report;
 pub mod table;
 pub mod transition;
 pub mod validate;
+pub mod visibility;
 
 // Crate root re-exports. This list mirrors the design's intended public
 // surface (DESIGN §"crates/shirabe-validate (library)"). Every export is
@@ -70,3 +71,4 @@ pub use validate::{
     effective_severity, is_known_check_code, is_notice, posture_class, validate_file, PostureClass,
     ReviewPosture, Severity,
 };
+pub use visibility::resolve_doc_visibility;

--- a/crates/shirabe-validate/src/visibility.rs
+++ b/crates/shirabe-validate/src/visibility.rs
@@ -1,0 +1,232 @@
+//! Repo-visibility resolution for the file-level `validate` pass.
+//!
+//! Mirrors the idiom every shirabe skill uses to decide whether a doc's
+//! owning repo is Public or Private (see `skills/strategy` Phase 0.4):
+//!
+//!   1. Read the owning repo's `CLAUDE.md` (or `CLAUDE.local.md`) and look
+//!      for a `## Repo Visibility: (Public|Private)` header.
+//!   2. If absent, infer from the path: a `private` path component implies
+//!      Private, a `public` component implies Public.
+//!   3. If still unknown, default to Private — restricting is easier to undo
+//!      than oversharing.
+//!
+//! The visibility-gated checks (R7/R8/R9) bypass only on exactly `"private"`;
+//! every other value (including `"public"`) runs the check. This module returns
+//! the lowercase string that both the `--visibility` flag and
+//! [`crate::doc::Config::visibility`] carry, so the CLI's auto-detection and the
+//! skills' hand-detection resolve visibility the same way and cannot drift.
+
+use std::path::{Component, Path};
+
+/// The visibility string that bypasses the public-repo checks.
+pub const PRIVATE: &str = "private";
+/// The visibility string that runs the public-repo checks.
+pub const PUBLIC: &str = "public";
+
+/// Parse a `## Repo Visibility: (Public|Private)` header out of a `CLAUDE.md`
+/// body. Case-insensitive on both the header key and the value; returns the
+/// lowercase `"public"` / `"private"` string, or `None` when no well-formed
+/// header is present. A header with an unrecognized value is skipped, not an
+/// error — a later well-formed header (if any) still wins.
+pub fn parse_visibility_header(contents: &str) -> Option<String> {
+    const KEY: &str = "## repo visibility:";
+    for line in contents.lines() {
+        let lower = line.trim().to_ascii_lowercase();
+        if let Some(value) = lower.strip_prefix(KEY) {
+            let value = value.trim();
+            if value.starts_with(PRIVATE) {
+                return Some(PRIVATE.to_string());
+            }
+            if value.starts_with(PUBLIC) {
+                return Some(PUBLIC.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Infer visibility from the path's components. A `private` component implies
+/// Private; a `public` component implies Public. Components are walked from the
+/// leaf upward, so the component nearest the doc wins when both appear.
+pub fn infer_visibility_from_path(path: &Path) -> Option<String> {
+    for comp in path.components().rev() {
+        if let Component::Normal(os) = comp {
+            let s = os.to_string_lossy();
+            if s.eq_ignore_ascii_case(PRIVATE) {
+                return Some(PRIVATE.to_string());
+            }
+            if s.eq_ignore_ascii_case(PUBLIC) {
+                return Some(PUBLIC.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Resolve the visibility (`"public"` or `"private"`) for the doc at `path`,
+/// applying the skills' idiom end to end. Filesystem-touching but never
+/// errors: an unresolvable path defaults to `"private"` (fail safe toward
+/// restriction).
+pub fn resolve_doc_visibility(path: &Path) -> String {
+    // Canonicalize so the ancestor walk is absolute and stable regardless of
+    // the process CWD. Fall back to the raw path if canonicalization fails
+    // (e.g. a relative path whose file was already consumed) — the walk still
+    // works on whatever path we have, and path inference below is CWD-relative
+    // either way.
+    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+
+    // 1. Walk up from the doc's directory; the first CLAUDE.local.md / CLAUDE.md
+    //    that carries a `## Repo Visibility:` header wins. A CLAUDE.md without
+    //    the header does not stop the walk (a nested workspace layout keeps the
+    //    per-repo header below workspace-level CLAUDE.md files that lack it).
+    let mut dir = canonical.parent();
+    while let Some(d) = dir {
+        for name in ["CLAUDE.local.md", "CLAUDE.md"] {
+            if let Ok(contents) = std::fs::read_to_string(d.join(name)) {
+                if let Some(v) = parse_visibility_header(&contents) {
+                    return v;
+                }
+            }
+        }
+        dir = d.parent();
+    }
+
+    // 2. Infer from the path components.
+    if let Some(v) = infer_visibility_from_path(&canonical) {
+        return v;
+    }
+
+    // 3. Default: restricting is easier to undo than oversharing.
+    PRIVATE.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn unique_dir(tag: &str) -> PathBuf {
+        // Derive a per-test directory name without Date/Random (unavailable in
+        // this crate's test sandbox is not a concern here, but a stable name
+        // keeps parallel test runs isolated by tag).
+        let base = std::env::temp_dir();
+        let dir = base.join(format!("shirabe-visibility-test-{tag}"));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn parse_header_public_and_private() {
+        assert_eq!(
+            parse_visibility_header("# repo\n\n## Repo Visibility: Public\n"),
+            Some("public".to_string())
+        );
+        assert_eq!(
+            parse_visibility_header("## Repo Visibility: Private\n"),
+            Some("private".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_header_is_case_insensitive() {
+        assert_eq!(
+            parse_visibility_header("## repo visibility: PRIVATE"),
+            Some("private".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_header_absent_or_malformed_is_none() {
+        assert_eq!(parse_visibility_header("# repo\n\nno header here"), None);
+        assert_eq!(
+            parse_visibility_header("## Repo Visibility: internal"),
+            None
+        );
+        // A prose mention that is not a header line must not match.
+        assert_eq!(
+            parse_visibility_header("See the ## Repo Visibility: Public note above"),
+            None
+        );
+    }
+
+    #[test]
+    fn infer_from_path_prefers_nearest_component() {
+        assert_eq!(
+            infer_visibility_from_path(Path::new("private/vision/docs/x.md")),
+            Some("private".to_string())
+        );
+        assert_eq!(
+            infer_visibility_from_path(Path::new("public/shirabe/docs/x.md")),
+            Some("public".to_string())
+        );
+        // Deepest component wins when both appear.
+        assert_eq!(
+            infer_visibility_from_path(Path::new("public/x/private/y/z.md")),
+            Some("private".to_string())
+        );
+        assert_eq!(infer_visibility_from_path(Path::new("docs/x.md")), None);
+    }
+
+    #[test]
+    fn resolve_reads_owning_repo_header() {
+        let dir = unique_dir("header");
+        let repo = dir.join("myrepo");
+        let docs = repo.join("docs/strategies");
+        fs::create_dir_all(&docs).unwrap();
+        fs::write(
+            repo.join("CLAUDE.md"),
+            "# myrepo\n\n## Repo Visibility: Private\n",
+        )
+        .unwrap();
+        let doc = docs.join("STRATEGY-x.md");
+        fs::write(&doc, "body").unwrap();
+        assert_eq!(resolve_doc_visibility(&doc), "private");
+    }
+
+    #[test]
+    fn resolve_claude_local_overrides_claude_md() {
+        let dir = unique_dir("local");
+        let repo = dir.join("myrepo");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(repo.join("CLAUDE.md"), "## Repo Visibility: Public\n").unwrap();
+        fs::write(
+            repo.join("CLAUDE.local.md"),
+            "## Repo Visibility: Private\n",
+        )
+        .unwrap();
+        let doc = repo.join("DESIGN-x.md");
+        fs::write(&doc, "body").unwrap();
+        // CLAUDE.local.md is consulted first in each directory.
+        assert_eq!(resolve_doc_visibility(&doc), "private");
+    }
+
+    #[test]
+    fn resolve_falls_back_to_path_when_no_header() {
+        let dir = unique_dir("pathinfer");
+        let repo = dir.join("public").join("somerepo");
+        fs::create_dir_all(&repo).unwrap();
+        // A header-less CLAUDE.md must not stop the walk or force a default.
+        fs::write(
+            repo.join("CLAUDE.md"),
+            "# somerepo\n\nno visibility header\n",
+        )
+        .unwrap();
+        let doc = repo.join("STRATEGY-x.md");
+        fs::write(&doc, "body").unwrap();
+        assert_eq!(resolve_doc_visibility(&doc), "public");
+    }
+
+    #[test]
+    fn resolve_defaults_private_when_unknown() {
+        let dir = unique_dir("default");
+        let repo = dir.join("neutralrepo");
+        fs::create_dir_all(&repo).unwrap();
+        let doc = repo.join("STRATEGY-x.md");
+        fs::write(&doc, "body").unwrap();
+        // No header anywhere up the tree, no public/private path component:
+        // the safe default is Private.
+        assert_eq!(resolve_doc_visibility(&doc), "private");
+    }
+}

--- a/crates/shirabe/src/main.rs
+++ b/crates/shirabe/src/main.rs
@@ -15,10 +15,10 @@ use saphyr::{LoadableYamlNode, Yaml};
 use shirabe_validate::{
     check_coordination_body, check_pr_body, check_slug_prefix, detect_format, detect_pr_draft,
     explain_advisory, format_error, format_notice, is_known_check_code, is_notice, parse_doc,
-    render_human_with_advisory, render_json_with_advisory, run_lifecycle_chain_check,
-    run_lifecycle_check, run_merge_gate, run_transition, validate_file, walk_chain_mode,
-    AdvisoryReport, Config, Flags, GhSubprocessClient, GhVisibilityResolver, MergeGateOutcome,
-    Mode, ParseError, PrPosture, ReviewPosture, SlugPrefixCheck, ValidationError,
+    render_human_with_advisory, render_json_with_advisory, resolve_doc_visibility,
+    run_lifecycle_chain_check, run_lifecycle_check, run_merge_gate, run_transition, validate_file,
+    walk_chain_mode, AdvisoryReport, Config, Flags, GhSubprocessClient, GhVisibilityResolver,
+    MergeGateOutcome, Mode, ParseError, PrPosture, ReviewPosture, SlugPrefixCheck, ValidationError,
 };
 
 mod populate;
@@ -218,7 +218,11 @@ struct ValidateArgs {
     check: Vec<String>,
 
     /// Visibility context; only 'private' bypasses public-repo checks
-    /// (unset is treated as public).
+    /// (R7/R8/R9). When unset, visibility is auto-detected per file from the
+    /// doc's owning repo the same way the shirabe skills detect it: read the
+    /// repo's `CLAUDE.md`/`CLAUDE.local.md` `## Repo Visibility:` header, else
+    /// infer from the path (`private`/`public` component), else default to
+    /// 'private'. Passing the flag overrides detection for every file.
     #[arg(long, default_value = "")]
     visibility: String,
 
@@ -578,10 +582,15 @@ fn run_validate(args: &ValidateArgs) -> ExitCode {
         }
     };
 
-    let cfg = Config {
-        custom_statuses,
-        visibility: args.visibility.clone(),
-        allow_untracked_acs: args.allow_untracked_acs,
+    // An explicit `--visibility` overrides detection for every file; when the
+    // flag is unset, visibility is resolved per file from the doc's owning repo
+    // (CLAUDE.md `## Repo Visibility:` header, then path inference, then a
+    // Private default). Per-file resolution is required because a single run can
+    // span docs in repos of differing visibility.
+    let explicit_visibility = if args.visibility.is_empty() {
+        None
+    } else {
+        Some(args.visibility.clone())
     };
 
     // Collect every emitted finding across all files first, then render
@@ -611,6 +620,16 @@ fn run_validate(args: &ValidateArgs) -> ExitCode {
                 worst = worst.merge(ValidateOutcome::ToolError);
                 continue;
             }
+        };
+
+        let visibility = match &explicit_visibility {
+            Some(v) => v.clone(),
+            None => resolve_doc_visibility(std::path::Path::new(path)),
+        };
+        let cfg = Config {
+            custom_statuses: custom_statuses.clone(),
+            visibility,
+            allow_untracked_acs: args.allow_untracked_acs,
         };
 
         for ve in validate_file(&doc, &spec, &cfg) {

--- a/crates/shirabe/tests/cli.rs
+++ b/crates/shirabe/tests/cli.rs
@@ -227,3 +227,75 @@ fn allow_untracked_acs_flag_is_accepted() {
         .failure()
         .stdout(contains("[L05]"));
 }
+
+/// A minimal STRATEGY doc that carries the R8-gated `Competitive
+/// Considerations` section. The `--check R8` runs filter every other finding,
+/// so only R8's presence/absence is observed.
+const STRATEGY_WITH_COMPETITIVE: &str = "---\nschema: strategy/v1\nbet: A bet.\nscope: A scope.\nstatus: Active\n---\n\n# STRATEGY: visibility autodetect\n\n## Competitive Considerations\n\nPrivate-only section.\n";
+
+/// Create an isolated repo directory under the temp dir with the given
+/// CLAUDE.md body and a STRATEGY doc, returning the doc path. The directory
+/// name is derived from `tag` (cleaned first) so parallel test runs stay
+/// isolated without a randomness source.
+fn make_repo_with_doc(tag: &str, claude_md: &str) -> std::path::PathBuf {
+    let repo = std::env::temp_dir().join(format!("shirabe-cli-visibility-{tag}"));
+    let _ = std::fs::remove_dir_all(&repo);
+    std::fs::create_dir_all(&repo).unwrap();
+    std::fs::write(repo.join("CLAUDE.md"), claude_md).unwrap();
+    let doc = repo.join("STRATEGY-visibility.md");
+    std::fs::write(&doc, STRATEGY_WITH_COMPETITIVE).unwrap();
+    doc
+}
+
+#[test]
+fn visibility_autodetected_private_repo_strategy_passes_r8_without_flag() {
+    // The R8 false-positive fix: with no `--visibility` flag, a STRATEGY that
+    // lives in a repo whose CLAUDE.md declares `## Repo Visibility: Private`
+    // must NOT trip R8 for its Competitive Considerations section. Visibility
+    // is auto-detected from the owning repo's CLAUDE.md header.
+    let doc = make_repo_with_doc("private-passes", "# repo\n\n## Repo Visibility: Private\n");
+    shirabe()
+        .arg("validate")
+        .arg("--check")
+        .arg("R8")
+        .arg(&doc)
+        .assert()
+        .success()
+        .stdout("");
+}
+
+#[test]
+fn visibility_autodetected_public_repo_strategy_still_fails_r8() {
+    // The fix must not neuter R8 for genuinely public repos: with no
+    // `--visibility` flag, a STRATEGY in a repo whose CLAUDE.md declares
+    // `## Repo Visibility: Public` must still trip R8 on its Competitive
+    // Considerations section.
+    let doc = make_repo_with_doc("public-fails", "# repo\n\n## Repo Visibility: Public\n");
+    shirabe()
+        .arg("validate")
+        .arg("--check")
+        .arg("R8")
+        .arg(&doc)
+        .assert()
+        .failure()
+        .stdout(contains("[R8]"))
+        .stdout(contains("Competitive Considerations"));
+}
+
+#[test]
+fn visibility_explicit_flag_overrides_autodetection() {
+    // An explicit `--visibility public` overrides the Private header, so R8
+    // fires even though the owning repo's CLAUDE.md says Private. This locks
+    // the precedence: flag beats detection.
+    let doc = make_repo_with_doc("flag-override", "## Repo Visibility: Private\n");
+    shirabe()
+        .arg("validate")
+        .arg("--visibility")
+        .arg("public")
+        .arg("--check")
+        .arg("R8")
+        .arg(&doc)
+        .assert()
+        .failure()
+        .stdout(contains("[R8]"));
+}


### PR DESCRIPTION
shirabe validate's R8 check (Competitive Considerations prohibited in public STRATEGY docs) fired against STRATEGY docs living in private repos, where that section is legitimate. The CLI treated an unset `--visibility` flag as public, so a doc validated on its own path was misclassified as public and tripped R8 — a false positive, since R8 must fire only when the doc's owning repo is Public.

When `--visibility` is unset, visibility is now resolved per file from the doc's owning repo, using the same idiom every shirabe skill uses: read the repo's `CLAUDE.md`/`CLAUDE.local.md` `## Repo Visibility:` header (walking up from the doc), else infer from the path (`private`/`public` component), else default to Private. An explicit `--visibility` still overrides detection for every file, so the skills' hand-detected flag keeps working and R8 is unchanged for genuinely public repos. The resolution lives in a new `shirabe_validate::visibility` module so the CLI and the skills cannot drift.

Fixes the R8 visibility false-positive on private-repo strategies.

---

## Before / after

Repro fixture: `vision/docs/strategies/STRATEGY-shirabe-evolution.md` (private repo, has a Competitive Considerations section).

Before — false positive:

```
::error file=.../STRATEGY-shirabe-evolution.md,line=601::[R8] section "Competitive Considerations" is prohibited in public STRATEGY docs
exit=2
```

After — clean (the remaining FC10 line is a pre-existing writing-style notice, exit 0):

```
::notice file=.../STRATEGY-shirabe-evolution.md::[FC10] writing-style banned word "tier" ...
exit=0
```

Control (`STRATEGY-shirabe-rust-consolidation.md`, no CC section) stays clean, exit 0. The public-repo fixture still fails R8 (check not neutered):

```
::error file=synthetic/STRATEGY-r8-prohibited-section.md,line=42::[R8] section "Competitive Considerations" is prohibited in public STRATEGY docs
exit=2
```

## Tests

- New `shirabe_validate::visibility` unit tests: header parse (case-insensitive, malformed/prose rejected), path inference (nearest component wins), owning-repo header resolution, `CLAUDE.local.md` precedence, path fallback, and the visibility-unknown to default-Private path.
- New `crates/shirabe/tests/cli.rs` end-to-end tests: private-repo STRATEGY with a Competitive Considerations section passes R8 without a flag; public-repo STRATEGY still fails R8; explicit `--visibility public` overrides a Private header.
- Full existing suite green, including the 28 golden parity tests (the `STRATEGY-r8`/`VISION-r7` fixtures are unchanged — they resolve Public via shirabe's own `## Repo Visibility: Public` header).

## Scope

No `vision` docs edited; no other FC/R check changed; R8 not relaxed for public repos.
