### PR TITLE
fix(templates): gate CI on check buckets so skipped checks stop failing

### DIFF
--- a/.github/workflows/check-template-consistency.yml
+++ b/.github/workflows/check-template-consistency.yml
@@ -6,6 +6,9 @@ on:
       - 'skills/*/koto-templates/**'
       - 'skills/*/koto-templates/*.mermaid.md'
       - 'scripts/validate-template-mermaid.sh'
+      - 'scripts/validate-template-mermaid_test.sh'
+      - 'scripts/ci-gate-expression_test.sh'
+      - '.github/workflows/check-template-consistency.yml'
 
 jobs:
   check-template-consistency:
@@ -13,5 +16,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
       - name: Validate koto template consistency
         run: bash scripts/validate-template-mermaid.sh
+
+      - name: Test the validator
+        run: bash scripts/validate-template-mermaid_test.sh
+
+      - name: Test the CI gate expression
+        run: bash scripts/ci-gate-expression_test.sh

--- a/.github/workflows/check-template-consistency.yml
+++ b/.github/workflows/check-template-consistency.yml
@@ -8,6 +8,7 @@ on:
       - 'scripts/validate-template-mermaid.sh'
       - 'scripts/validate-template-mermaid_test.sh'
       - 'scripts/ci-gate-expression_test.sh'
+      - 'scripts/lib/koto-gates.sh'
       - '.github/workflows/check-template-consistency.yml'
 
 jobs:
@@ -15,9 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install jq
-        run: sudo apt-get install -y jq
 
       - name: Validate koto template consistency
         run: bash scripts/validate-template-mermaid.sh

--- a/docs/designs/current/DESIGN-shirabe-pattern-v1-workflow-friction.md
+++ b/docs/designs/current/DESIGN-shirabe-pattern-v1-workflow-friction.md
@@ -545,6 +545,12 @@ Edit `skills/work-on/koto-templates/work-on-plan.md` `ci_monitor`
 state (lines 84-111) to add a second gate that checks merge state
 before evaluating check-runs. The new gate logic:
 
+> Note: the `ci_passing` command shown below is the one this design
+> proposed. Issue #244 later replaced the `--json state` filter with a
+> `--json bucket` one, because the state filter counted every SKIPPED
+> check as a failure. Read the templates, not this snippet, for the
+> current command.
+
 ```yaml
 ci_monitor:
   gates:

--- a/scripts/ci-gate-expression_test.sh
+++ b/scripts/ci-gate-expression_test.sh
@@ -1,75 +1,65 @@
 #!/usr/bin/env bash
 # Tests for the ci_passing gate expression carried by the koto templates.
 #
-# The gate decides whether a pull request's checks are green. It is a shell
+# The gate decides whether a pull request's checks are green. It's a shell
 # pipeline embedded in a YAML string, so nothing else in the repo exercises it.
 # This test pulls the live command out of each template and drives its jq filter
-# against synthetic `gh pr checks` payloads.
+# against synthetic `gh pr checks` payloads, so it can't drift from what ships.
 #
-# The fixtures carry only the fields the command actually asks `gh` for, so a
-# command that requests one field and filters on another fails here rather than
-# in production.
+# The payloads carry only the fields the command actually asks gh for. That's
+# what catches a command that requests one field and filters on another.
+#
+# The bucket values below come from gh's own aggregation, which folds the check
+# states into five buckets (cli/cli v2.97.0, pkg/cmd/pr/checks/aggregate.go:73-87):
+#
+#   pass      SUCCESS
+#   skipping  SKIPPED, NEUTRAL
+#   fail      ERROR, FAILURE, TIMED_OUT, ACTION_REQUIRED
+#   cancel    CANCELLED
+#   pending   everything else, including EXPECTED, REQUESTED, WAITING, QUEUED,
+#             PENDING, IN_PROGRESS and STALE
+#
+# The gate asks for `bucket` rather than `state` precisely so that the last row
+# holds: a state gh has never heard of arrives as `pending` and gates, instead of
+# slipping through. That means the states above are documentation of gh's
+# behavior, not inputs to these assertions -- the assertions run per bucket.
 #
 # Usage: bash scripts/ci-gate-expression_test.sh
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=lib/koto-gates.sh
+. "$SCRIPT_DIR/lib/koto-gates.sh"
+
 PASS=0
 FAIL=0
 
+# Every koto template carrying a ci_passing gate belongs here. The validator's
+# check 4 holds them all to the same command, so a template added there and
+# forgotten here would be gated but never exercised.
 TEMPLATES=(
     "skills/work-on/koto-templates/work-on.md"
     "skills/execute/koto-templates/execute.md"
 )
 
 # ---------------------------------------------------------------------------
-# Extraction: pull the ci_passing gate command out of a template
+# Pulling the pieces out of the gate command
 # ---------------------------------------------------------------------------
-
-# Prints the raw YAML scalar for the ci_passing gate's `command:` field.
-extract_gate_command() {
-    local template="$1"
-    awk '
-        /^    gates:[[:space:]]*$/ { in_gates = 1; gate = ""; next }
-        in_gates && /^      [a-z_][a-z_0-9]*:[[:space:]]*$/ {
-            gate = $0
-            sub(/:.*/, "", gate)
-            sub(/^[[:space:]]+/, "", gate)
-            next
-        }
-        in_gates && gate == "ci_passing" && /^        command:/ {
-            line = $0
-            sub(/^        command:[[:space:]]*/, "", line)
-            print line
-            exit
-        }
-        /^  [a-z_]/ { in_gates = 0 }
-    ' "$template"
-}
-
-# Strips the surrounding double quotes and unescapes the YAML string, so the
-# result is the command as the shell would receive it.
-unquote_yaml_scalar() {
-    local raw="$1"
-    raw="${raw#\"}"
-    raw="${raw%\"}"
-    printf '%s' "${raw//\\\"/\"}"
-}
 
 # Prints the comma-separated field list passed to `gh pr checks --json`.
 # The command also runs `gh pr list --json number`, so take the last --json:
-# that is the one belonging to the checks call.
+# that's the one belonging to the checks call.
 extract_json_fields() {
-    local cmd="$1"
-    printf '%s' "$cmd" | grep -oE '\-\-json [a-zA-Z,]+' | tail -1 | sed 's/^--json //'
+    printf '%s' "$1" | grep -oE '\-\-json [a-zA-Z,]+' | tail -1 | sed 's/^--json //'
 }
 
 # Prints the jq filter that classifies the checks. The command carries two --jq
-# flags; the classifying one is the last.
+# flags and the classifying one is the last, for the same reason.
 extract_jq_filter() {
-    local cmd="$1"
-    local rest="$cmd" last="" head
+    local rest="$1" last="" head
     while [[ "$rest" == *"--jq '"* ]]; do
         rest="${rest#*--jq \'}"
         head="${rest%%\'*}"
@@ -81,24 +71,23 @@ extract_jq_filter() {
 }
 
 # ---------------------------------------------------------------------------
-# Fixtures: build a `gh pr checks --json <fields>` payload
+# Fixtures
 # ---------------------------------------------------------------------------
 
-# Builds a JSON array from "STATE:BUCKET" pairs, emitting only the fields the
-# command asked for. Usage: build_payload "<fields>" SUCCESS:pass SKIPPED:skipping
+# Builds a `gh pr checks --json <fields>` payload from a list of bucket values,
+# emitting only the fields the command asked for.
+# Usage: build_payload "<fields>" pass skipping
 build_payload() {
     local fields="$1"
     shift
     local out="[" first=1
-    local pair state bucket obj f value
-    for pair in "$@"; do
-        state="${pair%%:*}"
-        bucket="${pair##*:}"
+    local bucket obj f value
+    for bucket in "$@"; do
         obj=""
         while IFS= read -r f; do
             case "$f" in
-                state)  value="$state" ;;
                 bucket) value="$bucket" ;;
+                state)  value="UNCHECKED_STATE" ;;
                 name)   value="some check" ;;
                 *)      value="" ;;
             esac
@@ -116,7 +105,7 @@ build_payload() {
 # Assertions
 # ---------------------------------------------------------------------------
 
-# assert_gate <label> <expected true|false> <name> <fields> <filter> <pairs...>
+# assert_gate <label> <expected true|false> <name> <fields> <filter> <buckets...>
 assert_gate() {
     local label="$1" expected="$2" name="$3" fields="$4" filter="$5"
     shift 5
@@ -140,14 +129,6 @@ assert_gate() {
     fi
 }
 
-# 42 SUCCESS and 5 SKIPPED: the shape measured on a real pull request whose
-# checks were all green but which the pre-fix gate rejected.
-real_world_pairs() {
-    local i
-    for i in $(seq 1 42); do printf 'SUCCESS:pass\n'; done
-    for i in $(seq 1 5); do printf 'SKIPPED:skipping\n'; done
-}
-
 # ---------------------------------------------------------------------------
 # Run the fixture set against every template's live expression
 # ---------------------------------------------------------------------------
@@ -162,62 +143,76 @@ for template in "${TEMPLATES[@]}"; do
         continue
     fi
 
-    raw=$(extract_gate_command "$path")
+    raw=$(koto_gate_command "$path" ci_passing)
     if [[ -z "$raw" ]]; then
-        echo "FAIL: [$label] no ci_passing gate command found"
+        echo "FAIL: [$label] no readable ci_passing gate command found."
+        echo "       Either the gate was renamed or scripts/lib/koto-gates.sh no"
+        echo "       longer matches koto's template layout."
         FAIL=$((FAIL + 1))
         continue
     fi
 
-    cmd=$(unquote_yaml_scalar "$raw")
+    cmd=$(koto_unquote_scalar "$raw")
     fields=$(extract_json_fields "$cmd")
     filter=$(extract_jq_filter "$cmd")
 
     if [[ -z "$fields" || -z "$filter" ]]; then
-        echo "FAIL: [$label] could not extract --json fields or jq filter from: $cmd"
+        echo "FAIL: [$label] extract_json_fields or extract_jq_filter came back empty."
+        echo "       Command was: $cmd"
+        FAIL=$((FAIL + 1))
+        continue
+    fi
+
+    # Both extractors assume the classifying --json and --jq are the last of
+    # their kind on the line. If a future edit reorders them, they would silently
+    # return the pull-request-number filter instead and every assertion below
+    # would fail for a reason that has nothing to do with the gate's semantics.
+    if [[ "$filter" != *"$fields"* ]]; then
+        echo "FAIL: [$label] the extracted filter does not mention the requested field."
+        echo "       Requested: $fields"
+        echo "       Filter:    $filter"
+        echo "       Look at extract_json_fields and extract_jq_filter in this file:"
+        echo "       they take the last --json and --jq on the line."
         FAIL=$((FAIL + 1))
         continue
     fi
 
     # Green: nothing failed and nothing is still running.
-    assert_gate "$label" true "all checks succeed" \
-        "$fields" "$filter" SUCCESS:pass SUCCESS:pass SUCCESS:pass
-    assert_gate "$label" true "success plus skipped passes" \
-        "$fields" "$filter" SUCCESS:pass SKIPPED:skipping
-    assert_gate "$label" true "success plus neutral passes" \
-        "$fields" "$filter" SUCCESS:pass NEUTRAL:skipping
-    assert_gate "$label" true "every check skipped passes" \
-        "$fields" "$filter" SKIPPED:skipping SKIPPED:skipping
-    # shellcheck disable=SC2046
-    assert_gate "$label" true "42 success and 5 skipped passes" \
-        "$fields" "$filter" $(real_world_pairs)
+    assert_gate "$label" true "all checks pass" \
+        "$fields" "$filter" pass pass pass
+    assert_gate "$label" true "pass plus skipping passes (#244)" \
+        "$fields" "$filter" pass skipping
+    assert_gate "$label" true "every check skipping passes" \
+        "$fields" "$filter" skipping skipping
 
     # Red: a real failure must still gate.
-    assert_gate "$label" false "a failure gates" \
-        "$fields" "$filter" SUCCESS:pass FAILURE:fail
-    assert_gate "$label" false "an error gates" \
-        "$fields" "$filter" SUCCESS:pass ERROR:fail
-    assert_gate "$label" false "a timeout gates" \
-        "$fields" "$filter" SUCCESS:pass TIMED_OUT:fail
-    assert_gate "$label" false "action_required gates" \
-        "$fields" "$filter" SUCCESS:pass ACTION_REQUIRED:fail
-    assert_gate "$label" false "a failure alongside a skip still gates" \
-        "$fields" "$filter" SKIPPED:skipping FAILURE:fail
+    assert_gate "$label" false "fail gates" \
+        "$fields" "$filter" pass fail
+    assert_gate "$label" false "fail alongside skipping still gates" \
+        "$fields" "$filter" skipping fail
 
-    # Cancelled produced no verdict, so it is not green.
-    assert_gate "$label" false "cancelled gates" \
-        "$fields" "$filter" SUCCESS:pass CANCELLED:cancel
+    # Cancelled produced no verdict, so it isn't green.
+    assert_gate "$label" false "cancel gates" \
+        "$fields" "$filter" pass cancel
 
-    # Still-running checks are not green either. Loosening the gate to "nothing
-    # has failed" would break these four.
+    # A check that's still running isn't green either. Loosening the gate to
+    # "nothing is in the fail bucket" would break this one case and nothing else,
+    # which is why it's called out here and in the template comment.
     assert_gate "$label" false "pending gates" \
-        "$fields" "$filter" SUCCESS:pass PENDING:pending
-    assert_gate "$label" false "in_progress gates" \
-        "$fields" "$filter" SUCCESS:pass IN_PROGRESS:pending
-    assert_gate "$label" false "queued gates" \
-        "$fields" "$filter" SUCCESS:pass QUEUED:pending
-    assert_gate "$label" false "stale gates" \
-        "$fields" "$filter" SUCCESS:pass STALE:pending
+        "$fields" "$filter" pass pending
+
+    # An unrecognized bucket must gate rather than slip through, which is what
+    # makes the filter safe against gh growing a sixth bucket.
+    assert_gate "$label" false "an unknown bucket gates" \
+        "$fields" "$filter" pass something_new
+
+    # A pull request with no checks reported at all satisfies `length == 0` and
+    # so reads as green. This is long-standing behavior, not something #244
+    # introduced, and it's the silent-success surface that execute.md's
+    # merge_state_clean gate exists to cover. Asserted so the next person sees
+    # it stated rather than discovering it.
+    assert_gate "$label" true "no checks at all reads as green (pre-existing surface)" \
+        "$fields" "$filter"
 done
 
 # ---------------------------------------------------------------------------

--- a/scripts/ci-gate-expression_test.sh
+++ b/scripts/ci-gate-expression_test.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Tests for the ci_passing gate expression carried by the koto templates.
+#
+# The gate decides whether a pull request's checks are green. It is a shell
+# pipeline embedded in a YAML string, so nothing else in the repo exercises it.
+# This test pulls the live command out of each template and drives its jq filter
+# against synthetic `gh pr checks` payloads.
+#
+# The fixtures carry only the fields the command actually asks `gh` for, so a
+# command that requests one field and filters on another fails here rather than
+# in production.
+#
+# Usage: bash scripts/ci-gate-expression_test.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+TEMPLATES=(
+    "skills/work-on/koto-templates/work-on.md"
+    "skills/execute/koto-templates/execute.md"
+)
+
+# ---------------------------------------------------------------------------
+# Extraction: pull the ci_passing gate command out of a template
+# ---------------------------------------------------------------------------
+
+# Prints the raw YAML scalar for the ci_passing gate's `command:` field.
+extract_gate_command() {
+    local template="$1"
+    awk '
+        /^    gates:[[:space:]]*$/ { in_gates = 1; gate = ""; next }
+        in_gates && /^      [a-z_][a-z_0-9]*:[[:space:]]*$/ {
+            gate = $0
+            sub(/:.*/, "", gate)
+            sub(/^[[:space:]]+/, "", gate)
+            next
+        }
+        in_gates && gate == "ci_passing" && /^        command:/ {
+            line = $0
+            sub(/^        command:[[:space:]]*/, "", line)
+            print line
+            exit
+        }
+        /^  [a-z_]/ { in_gates = 0 }
+    ' "$template"
+}
+
+# Strips the surrounding double quotes and unescapes the YAML string, so the
+# result is the command as the shell would receive it.
+unquote_yaml_scalar() {
+    local raw="$1"
+    raw="${raw#\"}"
+    raw="${raw%\"}"
+    printf '%s' "${raw//\\\"/\"}"
+}
+
+# Prints the comma-separated field list passed to `gh pr checks --json`.
+# The command also runs `gh pr list --json number`, so take the last --json:
+# that is the one belonging to the checks call.
+extract_json_fields() {
+    local cmd="$1"
+    printf '%s' "$cmd" | grep -oE '\-\-json [a-zA-Z,]+' | tail -1 | sed 's/^--json //'
+}
+
+# Prints the jq filter that classifies the checks. The command carries two --jq
+# flags; the classifying one is the last.
+extract_jq_filter() {
+    local cmd="$1"
+    local rest="$cmd" last="" head
+    while [[ "$rest" == *"--jq '"* ]]; do
+        rest="${rest#*--jq \'}"
+        head="${rest%%\'*}"
+        [[ "$head" == "$rest" ]] && break
+        last="$head"
+        rest="${rest#*\'}"
+    done
+    printf '%s' "$last"
+}
+
+# ---------------------------------------------------------------------------
+# Fixtures: build a `gh pr checks --json <fields>` payload
+# ---------------------------------------------------------------------------
+
+# Builds a JSON array from "STATE:BUCKET" pairs, emitting only the fields the
+# command asked for. Usage: build_payload "<fields>" SUCCESS:pass SKIPPED:skipping
+build_payload() {
+    local fields="$1"
+    shift
+    local out="[" first=1
+    local pair state bucket obj f value
+    for pair in "$@"; do
+        state="${pair%%:*}"
+        bucket="${pair##*:}"
+        obj=""
+        while IFS= read -r f; do
+            case "$f" in
+                state)  value="$state" ;;
+                bucket) value="$bucket" ;;
+                name)   value="some check" ;;
+                *)      value="" ;;
+            esac
+            [[ -n "$obj" ]] && obj="${obj},"
+            obj="${obj}\"${f}\":\"${value}\""
+        done < <(printf '%s\n' "$fields" | tr ',' '\n')
+        [[ $first -eq 0 ]] && out="${out},"
+        first=0
+        out="${out}{${obj}}"
+    done
+    printf '%s]' "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Assertions
+# ---------------------------------------------------------------------------
+
+# assert_gate <label> <expected true|false> <name> <fields> <filter> <pairs...>
+assert_gate() {
+    local label="$1" expected="$2" name="$3" fields="$4" filter="$5"
+    shift 5
+
+    local payload actual
+    payload=$(build_payload "$fields" "$@")
+
+    if ! actual=$(printf '%s' "$payload" | jq -r "$filter" 2>&1); then
+        echo "FAIL: [$label] $name (jq error: $actual)"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+
+    if [[ "$actual" == "$expected" ]]; then
+        echo "PASS: [$label] $name"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: [$label] $name (expected $expected, got $actual)"
+        echo "       payload: $payload"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# 42 SUCCESS and 5 SKIPPED: the shape measured on a real pull request whose
+# checks were all green but which the pre-fix gate rejected.
+real_world_pairs() {
+    local i
+    for i in $(seq 1 42); do printf 'SUCCESS:pass\n'; done
+    for i in $(seq 1 5); do printf 'SKIPPED:skipping\n'; done
+}
+
+# ---------------------------------------------------------------------------
+# Run the fixture set against every template's live expression
+# ---------------------------------------------------------------------------
+
+for template in "${TEMPLATES[@]}"; do
+    label="$(basename "$template")"
+    path="$REPO_ROOT/$template"
+
+    if [[ ! -f "$path" ]]; then
+        echo "FAIL: [$label] template not found at $path"
+        FAIL=$((FAIL + 1))
+        continue
+    fi
+
+    raw=$(extract_gate_command "$path")
+    if [[ -z "$raw" ]]; then
+        echo "FAIL: [$label] no ci_passing gate command found"
+        FAIL=$((FAIL + 1))
+        continue
+    fi
+
+    cmd=$(unquote_yaml_scalar "$raw")
+    fields=$(extract_json_fields "$cmd")
+    filter=$(extract_jq_filter "$cmd")
+
+    if [[ -z "$fields" || -z "$filter" ]]; then
+        echo "FAIL: [$label] could not extract --json fields or jq filter from: $cmd"
+        FAIL=$((FAIL + 1))
+        continue
+    fi
+
+    # Green: nothing failed and nothing is still running.
+    assert_gate "$label" true "all checks succeed" \
+        "$fields" "$filter" SUCCESS:pass SUCCESS:pass SUCCESS:pass
+    assert_gate "$label" true "success plus skipped passes" \
+        "$fields" "$filter" SUCCESS:pass SKIPPED:skipping
+    assert_gate "$label" true "success plus neutral passes" \
+        "$fields" "$filter" SUCCESS:pass NEUTRAL:skipping
+    assert_gate "$label" true "every check skipped passes" \
+        "$fields" "$filter" SKIPPED:skipping SKIPPED:skipping
+    # shellcheck disable=SC2046
+    assert_gate "$label" true "42 success and 5 skipped passes" \
+        "$fields" "$filter" $(real_world_pairs)
+
+    # Red: a real failure must still gate.
+    assert_gate "$label" false "a failure gates" \
+        "$fields" "$filter" SUCCESS:pass FAILURE:fail
+    assert_gate "$label" false "an error gates" \
+        "$fields" "$filter" SUCCESS:pass ERROR:fail
+    assert_gate "$label" false "a timeout gates" \
+        "$fields" "$filter" SUCCESS:pass TIMED_OUT:fail
+    assert_gate "$label" false "action_required gates" \
+        "$fields" "$filter" SUCCESS:pass ACTION_REQUIRED:fail
+    assert_gate "$label" false "a failure alongside a skip still gates" \
+        "$fields" "$filter" SKIPPED:skipping FAILURE:fail
+
+    # Cancelled produced no verdict, so it is not green.
+    assert_gate "$label" false "cancelled gates" \
+        "$fields" "$filter" SUCCESS:pass CANCELLED:cancel
+
+    # Still-running checks are not green either. Loosening the gate to "nothing
+    # has failed" would break these four.
+    assert_gate "$label" false "pending gates" \
+        "$fields" "$filter" SUCCESS:pass PENDING:pending
+    assert_gate "$label" false "in_progress gates" \
+        "$fields" "$filter" SUCCESS:pass IN_PROGRESS:pending
+    assert_gate "$label" false "queued gates" \
+        "$fields" "$filter" SUCCESS:pass QUEUED:pending
+    assert_gate "$label" false "stale gates" \
+        "$fields" "$filter" SUCCESS:pass STALE:pending
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/scripts/lib/koto-gates.sh
+++ b/scripts/lib/koto-gates.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Shared reader for the gate commands in a koto template.
+#
+# Sourced by scripts/validate-template-mermaid.sh (which compares gate commands
+# across templates) and scripts/ci-gate-expression_test.sh (which executes one).
+# It lives here because both need to know koto's gate layout, and two copies of
+# that knowledge is the thing the drift check exists to prevent.
+#
+# koto's layout inside a template's YAML frontmatter:
+#
+#   states:
+#     <state>:            2 spaces
+#       gates:            4 spaces
+#         <gate-name>:    6 spaces
+#           command: ...  8 spaces
+#
+# Only the single-line `command: "..."` form can be read. A YAML block scalar
+# (`command: >` or `command: |`) puts the body on following lines, and reporting
+# an empty body as if it were the command would let two different commands look
+# identical. Callers are told so explicitly rather than handed a blank.
+
+# koto_gate_rows <template>
+#
+# Prints one tab-separated row per gate that declares a command:
+#
+#   COMMAND<TAB><gate-name><TAB><raw-yaml-scalar>
+#   UNREADABLE<TAB><gate-name><TAB>
+#
+# The scalar is printed as it appears in the file, still quoted and escaped.
+koto_gate_rows() {
+    local template="$1"
+    awk '
+        /^    gates:[[:space:]]*$/ { in_gates = 1; gate = ""; next }
+        in_gates && /^      [a-z_][a-z_0-9]*:[[:space:]]*$/ {
+            gate = $0
+            sub(/:.*/, "", gate)
+            sub(/^[[:space:]]+/, "", gate)
+            next
+        }
+        in_gates && gate != "" && /^        command:/ {
+            cmd = $0
+            sub(/^        command:[[:space:]]*/, "", cmd)
+            if (cmd ~ /^[|>][0-9+-]*[[:space:]]*$/ || cmd == "") {
+                print "UNREADABLE\t" gate "\t"
+            } else {
+                print "COMMAND\t" gate "\t" cmd
+            }
+            next
+        }
+        /^  [a-z_]/ { in_gates = 0 }
+    ' "$template"
+}
+
+# koto_gate_command <template> <gate-name>
+#
+# Prints the raw YAML scalar for one named gate, or nothing when the gate is
+# absent or unreadable.
+koto_gate_command() {
+    local template="$1" gate="$2"
+    koto_gate_rows "$template" \
+        | awk -F'\t' -v g="$gate" '$1 == "COMMAND" && $2 == g { print $3; exit }'
+}
+
+# koto_unquote_scalar <raw-scalar>
+#
+# Turns the double-quoted YAML scalar into the string the shell would receive.
+# Handles the `\"` escape, which is the only one these templates use.
+koto_unquote_scalar() {
+    local raw="$1"
+    raw="${raw#\"}"
+    raw="${raw%\"}"
+    printf '%s' "${raw//\\\"/\"}"
+}

--- a/scripts/validate-template-mermaid.sh
+++ b/scripts/validate-template-mermaid.sh
@@ -6,6 +6,8 @@
 #      (skipped if no .mermaid.md companion exists)
 #   2. default_template: references point to existing files
 #   3. No hardcoded workflow names in koto next calls (use {{SESSION_NAME}})
+#   4. A gate name used by more than one template carries the same command in
+#      all of them (only meaningful when several templates are validated at once)
 #
 # Usage:
 #   validate-template-mermaid.sh [file ...]
@@ -149,6 +151,98 @@ check_hardcoded_names() {
 }
 
 # ---------------------------------------------------------------------------
+# Check 4: gate commands shared across templates stay identical
+#
+# Some templates are near-copies of one another and carry the same gate under
+# the same name. When one copy is fixed and the other is not, the workflows
+# silently disagree about what a gate means -- that is how issue #244 got two
+# templates gating CI on the same wrong expression. This check makes the
+# duplication mechanical rather than a matter of remembering.
+# ---------------------------------------------------------------------------
+
+# Emits one "<gate-name>\t<command>" line per gate that defines a command.
+#
+# Only the single-line `command: "..."` form is understood, which is the form
+# every gate in this repo uses. A YAML block scalar (`command: >` or `command: |`)
+# would put the body on following lines where this cannot see it, and comparing
+# the empty remainders would make two different commands look identical. So a
+# block scalar is reported as its own error rather than quietly compared: the
+# whole point of this check is that it must not pass on something it did not read.
+extract_gate_commands() {
+    local template="$1"
+    awk '
+        /^    gates:[[:space:]]*$/ { in_gates = 1; gate = ""; next }
+        in_gates && /^      [a-z_][a-z_0-9]*:[[:space:]]*$/ {
+            gate = $0
+            sub(/:.*/, "", gate)
+            sub(/^[[:space:]]+/, "", gate)
+            next
+        }
+        in_gates && gate != "" && /^        command:/ {
+            cmd = $0
+            sub(/^        command:[[:space:]]*/, "", cmd)
+            if (cmd ~ /^[|>][0-9+-]*[[:space:]]*$/ || cmd == "") {
+                print "UNREADABLE\t" gate "\t"
+            } else {
+                print "COMMAND\t" gate "\t" cmd
+            }
+            next
+        }
+        /^  [a-z_]/ { in_gates = 0 }
+    ' "$template"
+}
+
+check_shared_gate_commands() {
+    local templates=("$@")
+
+    # Fewer than two templates means there is nothing to compare against.
+    if [[ ${#templates[@]} -lt 2 ]]; then
+        return 0
+    fi
+
+    # Each row is "<template>\t<kind>\t<gate>\t<command>", where kind is COMMAND
+    # for a gate this can read and UNREADABLE for one it cannot.
+    local rows=""
+    local t line
+    for t in "${templates[@]}"; do
+        while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            rows+="${t}"$'\t'"${line}"$'\n'
+        done < <(extract_gate_commands "$t")
+    done
+
+    [[ -z "$rows" ]] && return 0
+
+    # A gate whose command could not be read cannot be compared, so say so
+    # rather than treating it as agreeing with everything.
+    local unreadable
+    unreadable=$(printf '%s' "$rows" | awk -F'\t' '$2 == "UNREADABLE" { print "  " $1 ": " $3 }' | sort -u)
+    if [[ -n "$unreadable" ]]; then
+        echo "ERROR: gate command is not a single-line scalar, so it cannot be compared across templates"
+        printf '%s\n' "$unreadable"
+        ERRORS=$((ERRORS + 1))
+    fi
+
+    local gate variants
+    while IFS= read -r gate; do
+        [[ -z "$gate" ]] && continue
+
+        variants=$(printf '%s' "$rows" \
+            | awk -F'\t' -v g="$gate" '$2 == "COMMAND" && $3 == g { print $4 }' | sort -u)
+
+        if [[ $(printf '%s\n' "$variants" | wc -l) -gt 1 ]]; then
+            echo "ERROR: gate '$gate' has drifted between templates"
+            local owner
+            while IFS= read -r owner; do
+                echo "  $owner"
+            done < <(printf '%s' "$rows" \
+                | awk -F'\t' -v g="$gate" '$2 == "COMMAND" && $3 == g { print $1 ": " $4 }' | sort -u)
+            ERRORS=$((ERRORS + 1))
+        fi
+    done < <(printf '%s' "$rows" | awk -F'\t' '$2 == "COMMAND" { print $3 }' | sort | uniq -d)
+}
+
+# ---------------------------------------------------------------------------
 # Main: determine files to validate
 # ---------------------------------------------------------------------------
 
@@ -172,15 +266,22 @@ check_template() {
     check_hardcoded_names "$template"
 }
 
+TEMPLATE_SET=()
+
 if [[ $# -gt 0 ]]; then
-    for f in "$@"; do
-        check_template "$f"
-    done
+    TEMPLATE_SET=("$@")
 else
     while IFS= read -r f; do
-        check_template "$f"
+        TEMPLATE_SET+=("$f")
     done < <(find . -path "*/koto-templates/*.md" ! -name "*.mermaid.md" -type f 2>/dev/null | sort)
 fi
+
+for f in "${TEMPLATE_SET[@]+"${TEMPLATE_SET[@]}"}"; do
+    check_template "$f"
+done
+
+# Check 4 compares templates against each other, so it runs once over the set.
+check_shared_gate_commands "${TEMPLATE_SET[@]+"${TEMPLATE_SET[@]}"}"
 
 if [[ $ERRORS -gt 0 ]]; then
     echo ""

--- a/scripts/validate-template-mermaid.sh
+++ b/scripts/validate-template-mermaid.sh
@@ -158,72 +158,61 @@ check_hardcoded_names() {
 # silently disagree about what a gate means -- that is how issue #244 got two
 # templates gating CI on the same wrong expression. This check makes the
 # duplication mechanical rather than a matter of remembering.
+#
+# The reader lives in scripts/lib/koto-gates.sh so that this script and
+# scripts/ci-gate-expression_test.sh share one description of koto's layout.
 # ---------------------------------------------------------------------------
 
-# Emits one "<gate-name>\t<command>" line per gate that defines a command.
-#
-# Only the single-line `command: "..."` form is understood, which is the form
-# every gate in this repo uses. A YAML block scalar (`command: >` or `command: |`)
-# would put the body on following lines where this cannot see it, and comparing
-# the empty remainders would make two different commands look identical. So a
-# block scalar is reported as its own error rather than quietly compared: the
-# whole point of this check is that it must not pass on something it did not read.
-extract_gate_commands() {
-    local template="$1"
-    awk '
-        /^    gates:[[:space:]]*$/ { in_gates = 1; gate = ""; next }
-        in_gates && /^      [a-z_][a-z_0-9]*:[[:space:]]*$/ {
-            gate = $0
-            sub(/:.*/, "", gate)
-            sub(/^[[:space:]]+/, "", gate)
-            next
-        }
-        in_gates && gate != "" && /^        command:/ {
-            cmd = $0
-            sub(/^        command:[[:space:]]*/, "", cmd)
-            if (cmd ~ /^[|>][0-9+-]*[[:space:]]*$/ || cmd == "") {
-                print "UNREADABLE\t" gate "\t"
-            } else {
-                print "COMMAND\t" gate "\t" cmd
-            }
-            next
-        }
-        /^  [a-z_]/ { in_gates = 0 }
-    ' "$template"
-}
+# shellcheck source=lib/koto-gates.sh
+. "$(dirname "$0")/lib/koto-gates.sh"
 
 check_shared_gate_commands() {
     local templates=("$@")
 
-    # Fewer than two templates means there is nothing to compare against.
-    if [[ ${#templates[@]} -lt 2 ]]; then
-        return 0
-    fi
+    [[ ${#templates[@]} -eq 0 ]] && return 0
 
-    # Each row is "<template>\t<kind>\t<gate>\t<command>", where kind is COMMAND
-    # for a gate this can read and UNREADABLE for one it cannot.
+    # Each row is "<template>\t<kind>\t<gate>\t<command>", where kind is
+    # COMMAND for a gate the reader could read and UNREADABLE for one it
+    # could not.
     local rows=""
     local t line
     for t in "${templates[@]}"; do
         while IFS= read -r line; do
             [[ -z "$line" ]] && continue
             rows+="${t}"$'\t'"${line}"$'\n'
-        done < <(extract_gate_commands "$t")
+        done < <(koto_gate_rows "$t")
     done
 
-    [[ -z "$rows" ]] && return 0
+    # No gate anywhere in a non-empty template set means the reader matched
+    # nothing. That is far more likely to be a layout change in koto than a
+    # repo with no gates, and reporting "all valid" would hide it.
+    if [[ -z "$rows" ]]; then
+        local any_gates=0
+        for t in "${templates[@]}"; do
+            if grep -q "^    gates:" "$t" 2>/dev/null; then
+                any_gates=1
+                break
+            fi
+        done
+        if [[ $any_gates -eq 1 ]]; then
+            echo "ERROR: templates declare gates but none could be read"
+            echo "  scripts/lib/koto-gates.sh no longer matches koto's template layout"
+            ERRORS=$((ERRORS + 1))
+        fi
+        return 0
+    fi
 
     # A gate whose command could not be read cannot be compared, so say so
     # rather than treating it as agreeing with everything.
     local unreadable
     unreadable=$(printf '%s' "$rows" | awk -F'\t' '$2 == "UNREADABLE" { print "  " $1 ": " $3 }' | sort -u)
     if [[ -n "$unreadable" ]]; then
-        echo "ERROR: gate command is not a single-line scalar, so it cannot be compared across templates"
+        echo "ERROR: gate command is not a single-line scalar, so it cannot be compared"
         printf '%s\n' "$unreadable"
         ERRORS=$((ERRORS + 1))
     fi
 
-    local gate variants
+    local gate variants owners
     while IFS= read -r gate; do
         [[ -z "$gate" ]] && continue
 
@@ -231,12 +220,12 @@ check_shared_gate_commands() {
             | awk -F'\t' -v g="$gate" '$2 == "COMMAND" && $3 == g { print $4 }' | sort -u)
 
         if [[ $(printf '%s\n' "$variants" | wc -l) -gt 1 ]]; then
-            echo "ERROR: gate '$gate' has drifted between templates"
-            local owner
-            while IFS= read -r owner; do
-                echo "  $owner"
-            done < <(printf '%s' "$rows" \
+            echo "ERROR: gate '$gate' is defined more than once with different commands"
+            owners=$(printf '%s' "$rows" \
                 | awk -F'\t' -v g="$gate" '$2 == "COMMAND" && $3 == g { print $1 ": " $4 }' | sort -u)
+            printf '%s\n' "$owners" | sed 's/^/  /'
+            echo "  A gate name is shared across templates, so the same name must mean"
+            echo "  the same command. If the difference is deliberate, rename one gate."
             ERRORS=$((ERRORS + 1))
         fi
     done < <(printf '%s' "$rows" | awk -F'\t' '$2 == "COMMAND" { print $3 }' | sort | uniq -d)

--- a/scripts/validate-template-mermaid_test.sh
+++ b/scripts/validate-template-mermaid_test.sh
@@ -275,12 +275,13 @@ noop
 EOF
 run_multi_test "check4: unshared gate names are not compared" 0 "$T/a.md" "$T/b.md"
 
-# Passing: a single template has nothing to compare against
+# Passing: a single template with one gate has nothing to disagree with
 T=$(mktemp -d "$TMPDIR_ROOT/check4-single.XXXXXX")
 write_gate_template "$T/a.md" "$GATE_CMD"
-run_multi_test "check4: single template skipped (passes)" 0 "$T/a.md"
+run_multi_test "check4: single template with one gate passes" 0 "$T/a.md"
 
-# Failing: the same gate name drifts within one template
+# A gate name repeated within one template must agree with itself, and the
+# result must not depend on how many files were passed on the command line.
 T=$(mktemp -d "$TMPDIR_ROOT/check4-intrafile.XXXXXX")
 cat > "$T/a.md" <<'EOF'
 ---
@@ -304,6 +305,25 @@ noop
 EOF
 write_gate_template "$T/b.md" "$GATE_CMD"
 run_multi_test "check4: gate drifting within one template fails" 1 "$T/a.md" "$T/b.md"
+run_multi_test "check4: intra-file drift is caught with one file too" 1 "$T/a.md"
+
+# Failing: the template declares gates but the reader matched none of them,
+# which means koto's layout moved and the check is no longer reading anything.
+T=$(mktemp -d "$TMPDIR_ROOT/check4-parserrot.XXXXXX")
+cat > "$T/a.md" <<'EOF'
+---
+name: gate-wf
+states:
+  ci_monitor:
+    gates:
+        ci_passing:
+            type: command
+            command: "true"
+---
+## ci_monitor
+noop
+EOF
+run_multi_test "check4: declared but unreadable gates are reported, not passed" 1 "$T/a.md"
 
 # Failing: a block scalar puts the command body out of reach, so two different
 # commands would compare as equal. The check must refuse to read it rather than

--- a/scripts/validate-template-mermaid_test.sh
+++ b/scripts/validate-template-mermaid_test.sh
@@ -202,6 +202,150 @@ EOF
 run_test "check3: no name in frontmatter skipped (passes)" 0 "$T" "tpl.md"
 
 # ---------------------------------------------------------------------------
+# Check 4: gate commands shared across templates stay identical
+# ---------------------------------------------------------------------------
+
+# Runs the validator over several templates at once, since check 4 only has
+# something to compare when it sees more than one.
+run_multi_test() {
+    local name="$1"
+    local expected_exit="$2"
+    shift 2
+
+    local actual_exit=0
+    bash "$SCRIPT" "$@" > /dev/null 2>&1 || actual_exit=$?
+
+    if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+        echo "PASS: $name"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $name (expected exit $expected_exit, got $actual_exit)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Writes a template carrying a single `ci_passing` gate with the given command.
+write_gate_template() {
+    local path="$1"
+    local command="$2"
+    cat > "$path" <<EOF
+---
+name: gate-wf
+states:
+  ci_monitor:
+    gates:
+      ci_passing:
+        type: command
+        command: "${command}"
+---
+## ci_monitor
+noop
+EOF
+}
+
+GATE_CMD='gh pr checks --json bucket --jq [.[]|select(.bucket != \"pass\")]|length == 0'
+
+# Passing: both templates carry the same command
+T=$(mktemp -d "$TMPDIR_ROOT/check4-pass.XXXXXX")
+write_gate_template "$T/a.md" "$GATE_CMD"
+write_gate_template "$T/b.md" "$GATE_CMD"
+run_multi_test "check4: identical shared gate passes" 0 "$T/a.md" "$T/b.md"
+
+# Failing: one template's copy has drifted
+T=$(mktemp -d "$TMPDIR_ROOT/check4-drift.XXXXXX")
+write_gate_template "$T/a.md" "$GATE_CMD"
+write_gate_template "$T/b.md" 'gh pr checks --json state --jq [.[]|select(.state != \"SUCCESS\")]|length == 0'
+run_multi_test "check4: drifted shared gate fails" 1 "$T/a.md" "$T/b.md"
+
+# Passing: gate names that appear in only one template are not compared
+T=$(mktemp -d "$TMPDIR_ROOT/check4-unique.XXXXXX")
+write_gate_template "$T/a.md" "$GATE_CMD"
+cat > "$T/b.md" <<'EOF'
+---
+name: gate-wf
+states:
+  ci_monitor:
+    gates:
+      merge_state_clean:
+        type: command
+        command: "test -n \"$BRANCH\""
+---
+## ci_monitor
+noop
+EOF
+run_multi_test "check4: unshared gate names are not compared" 0 "$T/a.md" "$T/b.md"
+
+# Passing: a single template has nothing to compare against
+T=$(mktemp -d "$TMPDIR_ROOT/check4-single.XXXXXX")
+write_gate_template "$T/a.md" "$GATE_CMD"
+run_multi_test "check4: single template skipped (passes)" 0 "$T/a.md"
+
+# Failing: the same gate name drifts within one template
+T=$(mktemp -d "$TMPDIR_ROOT/check4-intrafile.XXXXXX")
+cat > "$T/a.md" <<'EOF'
+---
+name: gate-wf
+states:
+  first:
+    gates:
+      on_branch:
+        type: command
+        command: "test -n \"$A\""
+  second:
+    gates:
+      on_branch:
+        type: command
+        command: "test -n \"$B\""
+---
+## first
+noop
+## second
+noop
+EOF
+write_gate_template "$T/b.md" "$GATE_CMD"
+run_multi_test "check4: gate drifting within one template fails" 1 "$T/a.md" "$T/b.md"
+
+# Failing: a block scalar puts the command body out of reach, so two different
+# commands would compare as equal. The check must refuse to read it rather than
+# pass on it.
+T=$(mktemp -d "$TMPDIR_ROOT/check4-blockscalar.XXXXXX")
+cat > "$T/a.md" <<'EOF'
+---
+name: gate-wf
+states:
+  ci_monitor:
+    gates:
+      ci_passing:
+        type: command
+        command: >
+          gh pr checks --json bucket
+---
+## ci_monitor
+noop
+EOF
+cat > "$T/b.md" <<'EOF'
+---
+name: gate-wf
+states:
+  ci_monitor:
+    gates:
+      ci_passing:
+        type: command
+        command: >
+          gh pr checks --json state
+---
+## ci_monitor
+noop
+EOF
+run_multi_test "check4: block-scalar gate command is refused, not silently compared" 1 "$T/a.md" "$T/b.md"
+
+# The real templates must agree. This pins acceptance criterion 3 of issue #244
+# against the checked-in files rather than against fixtures.
+run_multi_test "check4: repository templates agree on shared gates" 0 \
+    "$(dirname "$0")/../skills/work-on/koto-templates/work-on.md" \
+    "$(dirname "$0")/../skills/execute/koto-templates/execute.md"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/skills/execute/evals/fixtures/bin/gh
+++ b/skills/execute/evals/fixtures/bin/gh
@@ -106,7 +106,7 @@ case "$ARGS" in
       exit 0
     fi
     ;;
-  # gh pr checks <number> --json state --jq '...'
+  # gh pr checks <number> --json bucket --jq '...'
   # Used by the ci_monitor ci_passing gate. A scenario-local empty check-runs
   # array models the DIRTY silent-success surface (GitHub suppresses new
   # check-runs on a conflicted PR, so length == 0 evaluates true).

--- a/skills/execute/koto-templates/execute.md
+++ b/skills/execute/koto-templates/execute.md
@@ -167,9 +167,20 @@ states:
 
   ci_monitor:
     gates:
+      # Gate on `bucket`, not `state`: gh folds the check states into
+      # pass / skipping / fail / cancel / pending and buckets anything it
+      # doesn't recognize as `pending`, so this survives GitHub adding a
+      # state. Green means every check is pass or skipping. Skipping covers
+      # SKIPPED and NEUTRAL -- a repo with conditional jobs skips checks on
+      # every PR, and the old state filter counted each one as a failure
+      # (#244). Pending and cancel deliberately gate: a check that's still
+      # running isn't green, and a cancelled one returned no verdict. Don't
+      # rewrite this as "nothing is in the fail bucket" -- that would let an
+      # all-queued PR report green. Keep byte-identical to the copy in
+      # work-on.md; the validator's shared-gate check enforces it.
       ci_passing:
         type: command
-        command: "gh pr checks $(gh pr list --head $(git rev-parse --abbrev-ref HEAD) --json number --jq '.[0].number // empty') --json state --jq '[.[] | select(.state != \"SUCCESS\")] | length == 0' | grep -q true"
+        command: "gh pr checks $(gh pr list --head $(git rev-parse --abbrev-ref HEAD) --json number --jq '.[0].number // empty') --json bucket --jq '[.[] | select(.bucket != \"pass\" and .bucket != \"skipping\")] | length == 0' | grep -q true"
       merge_state_clean:
         type: command
         command: "[ \"$(gh pr view --json mergeStateStatus --jq .mergeStateStatus)\" != \"DIRTY\" ]"

--- a/skills/execute/koto-templates/execute.md
+++ b/skills/execute/koto-templates/execute.md
@@ -167,17 +167,17 @@ states:
 
   ci_monitor:
     gates:
-      # Gate on `bucket`, not `state`: gh folds the check states into
-      # pass / skipping / fail / cancel / pending and buckets anything it
-      # doesn't recognize as `pending`, so this survives GitHub adding a
-      # state. Green means every check is pass or skipping. Skipping covers
-      # SKIPPED and NEUTRAL -- a repo with conditional jobs skips checks on
-      # every PR, and the old state filter counted each one as a failure
-      # (#244). Pending and cancel deliberately gate: a check that's still
-      # running isn't green, and a cancelled one returned no verdict. Don't
-      # rewrite this as "nothing is in the fail bucket" -- that would let an
-      # all-queued PR report green. Keep byte-identical to the copy in
-      # work-on.md; the validator's shared-gate check enforces it.
+      # Gate on `bucket`, not `state`: gh folds check states into
+      # pass / skipping / fail / cancel / pending, and buckets any state it
+      # doesn't recognize as `pending`, so this survives GitHub adding one.
+      # `skipping` covers SKIPPED and NEUTRAL -- a repo with conditional jobs
+      # skips checks on every PR, and the old state filter counted each one as
+      # a failure (#244). Pending and cancel gate on purpose: a check that's
+      # still running isn't green, and a cancelled one returned no verdict.
+      # Don't rewrite this as "nothing is in the fail bucket" -- that would let
+      # an all-queued PR report green.
+      #   semantics: scripts/ci-gate-expression_test.sh
+      #   kept identical to work-on.md: scripts/validate-template-mermaid.sh check 4
       ci_passing:
         type: command
         command: "gh pr checks $(gh pr list --head $(git rev-parse --abbrev-ref HEAD) --json number --jq '.[0].number // empty') --json bucket --jq '[.[] | select(.bucket != \"pass\" and .bucket != \"skipping\")] | length == 0' | grep -q true"

--- a/skills/work-on/koto-templates/work-on.md
+++ b/skills/work-on/koto-templates/work-on.md
@@ -719,17 +719,17 @@ states:
 
   ci_monitor:
     gates:
-      # Gate on `bucket`, not `state`: gh folds the check states into
-      # pass / skipping / fail / cancel / pending and buckets anything it
-      # doesn't recognize as `pending`, so this survives GitHub adding a
-      # state. Green means every check is pass or skipping. Skipping covers
-      # SKIPPED and NEUTRAL -- a repo with conditional jobs skips checks on
-      # every PR, and the old state filter counted each one as a failure
-      # (#244). Pending and cancel deliberately gate: a check that's still
-      # running isn't green, and a cancelled one returned no verdict. Don't
-      # rewrite this as "nothing is in the fail bucket" -- that would let an
-      # all-queued PR report green. Keep byte-identical to the copy in
-      # execute.md; the validator's shared-gate check enforces it.
+      # Gate on `bucket`, not `state`: gh folds check states into
+      # pass / skipping / fail / cancel / pending, and buckets any state it
+      # doesn't recognize as `pending`, so this survives GitHub adding one.
+      # `skipping` covers SKIPPED and NEUTRAL -- a repo with conditional jobs
+      # skips checks on every PR, and the old state filter counted each one as
+      # a failure (#244). Pending and cancel gate on purpose: a check that's
+      # still running isn't green, and a cancelled one returned no verdict.
+      # Don't rewrite this as "nothing is in the fail bucket" -- that would let
+      # an all-queued PR report green.
+      #   semantics: scripts/ci-gate-expression_test.sh
+      #   kept identical to execute.md: scripts/validate-template-mermaid.sh check 4
       ci_passing:
         type: command
         command: "gh pr checks $(gh pr list --head $(git rev-parse --abbrev-ref HEAD) --json number --jq '.[0].number // empty') --json bucket --jq '[.[] | select(.bucket != \"pass\" and .bucket != \"skipping\")] | length == 0' | grep -q true"

--- a/skills/work-on/koto-templates/work-on.md
+++ b/skills/work-on/koto-templates/work-on.md
@@ -719,9 +719,20 @@ states:
 
   ci_monitor:
     gates:
+      # Gate on `bucket`, not `state`: gh folds the check states into
+      # pass / skipping / fail / cancel / pending and buckets anything it
+      # doesn't recognize as `pending`, so this survives GitHub adding a
+      # state. Green means every check is pass or skipping. Skipping covers
+      # SKIPPED and NEUTRAL -- a repo with conditional jobs skips checks on
+      # every PR, and the old state filter counted each one as a failure
+      # (#244). Pending and cancel deliberately gate: a check that's still
+      # running isn't green, and a cancelled one returned no verdict. Don't
+      # rewrite this as "nothing is in the fail bucket" -- that would let an
+      # all-queued PR report green. Keep byte-identical to the copy in
+      # execute.md; the validator's shared-gate check enforces it.
       ci_passing:
         type: command
-        command: "gh pr checks $(gh pr list --head $(git rev-parse --abbrev-ref HEAD) --json number --jq '.[0].number // empty') --json state --jq '[.[] | select(.state != \"SUCCESS\")] | length == 0' | grep -q true"
+        command: "gh pr checks $(gh pr list --head $(git rev-parse --abbrev-ref HEAD) --json number --jq '.[0].number // empty') --json bucket --jq '[.[] | select(.bucket != \"pass\" and .bucket != \"skipping\")] | length == 0' | grep -q true"
     accepts:
       ci_outcome:
         type: enum


### PR DESCRIPTION
The `ci_monitor` gate in the `work-on` and `execute` koto templates asked gh
for each check's state and rejected anything that wasn't `SUCCESS`. `SKIPPED`
isn't `SUCCESS`, so every check that a path filter or an `if:` condition
skipped counted as a failure. Any repository with conditional jobs had a gate
that could never pass.

Both templates now ask for `bucket` instead. gh folds the check states into
pass, skipping, fail, cancel and pending, and buckets any state it doesn't
recognize as pending, so the filter stays right when GitHub adds a state.
Green means every check is pass or skipping; `SKIPPED` and `NEUTRAL` both land
in skipping.

Pending and cancel still gate, and that's the part worth guarding. Writing the
filter as "nothing is in the fail bucket" reads fine and would let a pull
request whose checks are all still queued report green. A cancelled check
produced no verdict, so it isn't green either. That answers the question the
issue asked to decide explicitly: cancelled gates.

The expression stays duplicated across the two near-copy templates. Sharing it
as a script is possible — koto substitutes template variables into gate
commands, so a `--var PLUGIN_ROOT` would resolve — but deduplicating one line
of jq would mean a new declared variable in both templates, a change at every
`koto init` call site, and a gate depending on a path outside the repository
being worked on. There's already one script-path gate in `work-on.md` and it's
broken today because the script isn't on PATH. Instead the template validator
gained a check that any gate name appearing in more than one template carries
a byte-identical command, which is the mechanical version of what the issue
asked for.

Two test scripts cover this and neither ran anywhere in CI before, so the
template-consistency workflow now runs both. The gate test pulls the live
command out of each template and drives its jq filter against synthetic gh
payloads carrying only the fields the command asked for, which is what catches
a command that requests one field and filters on another.

---

Fixes #244

## Acceptance criteria

| Criterion | Evidence |
|---|---|
| A PR whose checks are all `SUCCESS` or `SKIPPED` passes the gate | Live: `tsukumogami/tsuku#2484` (42 pass, 5 skipping) — gate exits 0; the old expression exits 1 |
| A PR with any genuinely failing check still fails the gate | Live: `tsukumogami/tsuku#2478` (1 fail, 76 pass, 16 skipping) — gate exits 1 |
| Both templates use the same expression | `check 4` in `scripts/validate-template-mermaid.sh`, run in CI, with a case pinning the real checked-in files |
| A stated decision on `CANCELLED` | It gates. gh puts it in its own `cancel` bucket, outside the pass set. Rationale in Part 1 and in the template comment |

`#2478` matters as much as `#2484`: it carries 16 skipped checks alongside one
real failure, so it shows the skip exemption doesn't mask a failure.

## Verifying the issue's claims

The issue's numbers hold. `#2484` returns 42 `SUCCESS` and 5 `SKIPPED`, and
`bucket` is present and populated.

Its account of the consequence is right and slightly understates it. I probed
koto with a throwaway workflow: submitting `ci_outcome: passing` while
`ci_passing` fails does not advance (`advanced: false`), in either template.
The trailing unconditional `- target: done` in `work-on.md` does not rescue it
— koto doesn't even list it among the offered options. So the only exits are
`failing_fixed`, which asks for a rationale describing a repair that never
happened, or `failing_unresolvable`, which is a failure terminal. The agent
isn't merely nudged into fabricating; it has no other way out.

The state-to-bucket mapping is quoted from cli/cli v2.97.0,
`pkg/cmd/pr/checks/aggregate.go:73-87`, and cited in the test header. Worth
recording because a reviewer suspected `STALE` sits in `fail`; it falls to the
`pending` default, which the fetched source confirms.

## Mutation testing

Eight defects injected one at a time, each reverted after. No survivors.

| Defect | Killed by |
|---|---|
| Revert `work-on.md` to the original state-based filter | `pass plus skipping passes`, `every check skipping passes`, `all checks pass`, `templates agree on shared gates` |
| Request `--json state` while filtering on `.bucket` | `the extracted filter does not mention the requested field`, `templates agree on shared gates` |
| Drop the `skipping` exemption | `pass plus skipping passes`, `every check skipping passes`, `templates agree on shared gates` |
| Loosen to `select(.bucket == "fail")` | `pending gates`, `cancel gates`, `an unknown bucket gates`, `templates agree on shared gates` |
| Also exempt the `cancel` bucket | `cancel gates`, `templates agree on shared gates` |
| `length == 0` becomes `length >= 0` | `fail gates`, `cancel gates`, `pending gates`, and three more |
| Drift `execute.md` by one space | `templates agree on shared gates` |
| Also exempt the `pending` bucket | `pending gates`, `templates agree on shared gates` |

The whitespace-only drift is caught by nothing but check 4, which is the case
that justifies it existing.

## Review changed the shape of this

A scrutiny reviewer found my stated reason for keeping the expression
duplicated was wrong. I'd claimed a shared script was unreachable; it isn't.
koto substitutes `{{VAR}}` into gate commands — verified with a probe workflow
— and `work-on.md` already does this with `{{ISSUE_NUMBER}}`. The decision
didn't change but the justification did, and Part 1 states the real one.

An architecture reviewer pointed out the first draft shipped two copies of the
awk that reads a gate command, alongside a check whose whole purpose is
preventing two copies of a string from drifting. They'd already diverged.
Both now come from `scripts/lib/koto-gates.sh`.

A maintainability reviewer found the fixtures paired a check state with a
bucket while the command only ever asks for `bucket`, so the state half was
inert: four failure cases were one assertion repeated, and nothing recorded
where gh's mapping came from. Fixtures now run one case per bucket with the
mapping cited.

## Definition-of-done gate: cannot-verify

`.claude/shirabe-extensions/work-on.md` maps `skills/**` to
`scripts/run-evals.sh <skill>`, so this change's gate runs the `work-on` and
`execute` eval suites. The run hit an API session limit and graded zero of 28
scenarios, so it produced no signal either way. Per the gate's contract that's
cannot-verify, which fails closed — I'm reporting it rather than rounding it up
to a pass. #202 separately records pre-existing failing assertions in this
suite, with #186 and #214, as prerequisites for the gate to enforce on
`work-on` changes.

Everything else ran and passed; the full table is in a comment on this PR.

## Not fixed here

Two things surfaced that belong elsewhere:

- `/work-on`'s `ci_monitor` has no merge-state gate, while `/execute`'s does,
  so a conflicted PR whose checks GitHub suppressed reads as green. Filed as
  #245. Out of scope: this PR is about which check states gate, not about a
  PR reporting no checks at all.
- `work-on.md`'s `staleness_fresh` gate invokes a bare `check-staleness.sh`
  that isn't on PATH, so it can't pass. Already tracked in #80.

`docs/designs/current/DESIGN-shirabe-pattern-v1-workflow-friction.md` shows
the old expression as the design under `designs/current/`, which is a
re-introduction vector, so it gained a note that #244 replaced it. The design's
own record of what it proposed is otherwise untouched.

## Checks armed

`check-template-consistency`, `check-templates` (koto freshness), and
`check-evals`. Both templates still compile under `koto init`.
