### PR TITLE
fix: pass --repo to gh release list before checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,13 +116,13 @@ jobs:
         run: |
           # gh release view can't find drafts by tag when the git tag doesn't
           # exist yet. Use gh release list with jq filter instead.
-          DRAFT_TAG=$(gh release list --json tagName,isDraft \
+          DRAFT_TAG=$(gh release list --repo "${{ github.repository }}" --json tagName,isDraft \
             --jq '.[] | select(.tagName == "${{ inputs.tag }}" and .isDraft) | .tagName' \
             2>/dev/null || echo "")
 
           if [ -z "$DRAFT_TAG" ]; then
             # Check if a non-draft release exists (already published)
-            PUBLISHED=$(gh release list --json tagName,isDraft \
+            PUBLISHED=$(gh release list --repo "${{ github.repository }}" --json tagName,isDraft \
               --jq '.[] | select(.tagName == "${{ inputs.tag }}" and (.isDraft | not)) | .tagName' \
               2>/dev/null || echo "")
             if [ -n "$PUBLISHED" ]; then


### PR DESCRIPTION
Pass `--repo "${{ github.repository }}"` to both `gh release list` calls in the "Validate draft release exists" step of `.github/workflows/release.yml`. The step runs before the "Checkout" step in the same job, so `gh` has no git remote to infer the target repository from, and both calls previously failed silently.

---

Fixes #247

## Root cause

`steps.draft.outputs.found` was always `false`: with stderr redirected to `/dev/null` and failures swallowed by `|| echo ""`, the missing repo context produced an empty result indistinguishable from "no draft found." This meant the notes-extraction block in the later "Create annotated tag" step never fired, so the annotated tag always got a generic `git tag -a <tag> -m "Release <tag>"` message instead of the draft's curated notes.

That tag annotation is read downstream as a fallback in `release-binaries.yml` (and koto's copy of the same workflow) when no pre-existing draft release is found at that point — in that path the generic message would have leaked into a published release body, not just the tag object.

`GH_TOKEN` is already set at the step level, so auth was never the issue — only repo resolution, which normally comes from the git remote set up by checkout, was missing.
