### PR TITLE
feat(release): sync callers to new shirabe release tags

### DIFF
--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -3,8 +3,9 @@ name: release
 description: >-
   Release workflow. Analyzes commits to recommend a version, generates
   release notes for review, creates a draft GitHub release, dispatches
-  the reusable workflow, and monitors progress. Falls back to draft +
-  manual tag when no workflow is detected.
+  the reusable workflow, and monitors progress. In shirabe itself, also
+  opens bump PRs for repos pinned to the reusable workflow. Falls back
+  to draft + manual tag when no workflow is detected.
 argument-hint: '[version] [--dry-run]'
 ---
 
@@ -153,12 +154,52 @@ Draft release with notes: <url>
    - **Failure**: Print details. Suggest `gh run view <id> --log-failed`.
    - **Timeout**: Print run URL: "Workflow still running -- monitor at <url>"
 
+### Phase 7: Sync Callers
+
+Only runs in the `shirabe` repo itself, and only after Phase 6 reports
+success. The gate is repo identity alone: if the current repo isn't the
+one that owns and publishes `release.yml`, skip Phase 7 without reading
+`skills/release/callers.json` or otherwise reasoning about its contents
+-- that file is Phase 7's input, not a signal for whether Phase 7 applies.
+Other repos releasing through the reusable workflow don't have callers of
+their own to sync.
+
+Downstream repos pin the reusable workflow to a specific tag rather than
+tracking `@main` (see `docs/prds/PRD-reusable-release-system.md`, US8) so
+that an unreleased or unvetted change to `release.yml` can't break their
+release pipeline out from under them -- nothing in shirabe's own CI
+exercises `release.yml` end-to-end before a merge, so a tagged release is
+the first point a change is known-good. That means every new tag needs its
+own follow-up to move callers forward; left manual, this lags silently.
+
+Run the sync script to open that follow-up automatically:
+
+```bash
+skills/release/scripts/bump-callers.sh v<version>
+```
+
+The script reads the caller registry (`skills/release/callers.json`),
+and for each entry not already pinned to the new tag: shallow-clones the
+repo, updates the `uses:` line in its workflow file, and opens a PR. A
+caller already on the new tag, or whose workflow file no longer
+references the reusable workflow, is skipped and reported rather than
+treated as a failure. A caller with an already-open bump PR for this tag
+is also skipped, so re-running after a partial failure is safe.
+
+Print the script's summary (PR opened, already up to date, or skipped)
+for each caller so the user can see what happened without digging into
+logs.
+
+**New callers**: when another repo starts calling
+`tsukumogami/shirabe/.github/workflows/release.yml`, add it to
+`skills/release/callers.json` so future releases sync it too.
+
 ## Dry-Run Mode
 
 When `--dry-run` is passed:
 
 - Phases 1-3 run normally (version analysis, checks, notes + confirmation)
-- Phase 4-6 are skipped (no draft, no dispatch)
+- Phase 4-7 are skipped (no draft, no dispatch, no caller PRs)
 - Print what would happen: which files change, what tag, what dev version
 
 ## Error Recovery
@@ -174,3 +215,5 @@ When `--dry-run` is passed:
 | 5 | Dispatch fails | Check workflow exists and permissions |
 | 6 | Workflow fails | `gh run view <id> --log-failed` |
 | 6 | Timeout | Check URL printed at timeout |
+| 7 | Clone or push fails for a caller | Re-run `bump-callers.sh v<version>`; other callers already synced are skipped as up to date |
+| 7 | PR create fails after push | Branch is already pushed; open the PR manually or re-run the script |

--- a/skills/release/callers.json
+++ b/skills/release/callers.json
@@ -1,0 +1,16 @@
+{
+  "callers": [
+    {
+      "repo": "tsukumogami/koto",
+      "workflow": ".github/workflows/prepare-release.yml"
+    },
+    {
+      "repo": "tsukumogami/niwa",
+      "workflow": ".github/workflows/prepare-release.yml"
+    },
+    {
+      "repo": "tsukumogami/tsuku",
+      "workflow": ".github/workflows/release-prepare.yml"
+    }
+  ]
+}

--- a/skills/release/evals/evals.json
+++ b/skills/release/evals/evals.json
@@ -65,6 +65,27 @@
         "Lists the specific blocker issues found",
         "Stops execution and does not proceed to note generation"
       ]
+    },
+    {
+      "id": 7,
+      "name": "sync-callers-on-success",
+      "prompt": "/release 0.6.0 (in the shirabe repo, workflow dispatch succeeds in Phase 6)",
+      "expected_output": "After Phase 6 confirms success, runs skills/release/scripts/bump-callers.sh v0.6.0 and reports which callers got a PR, were already up to date, or were skipped.",
+      "assertions": [
+        "Runs the caller-sync step only after Phase 6 reports success",
+        "Invokes bump-callers.sh with the new tag",
+        "Reports a per-caller result (PR opened, already up to date, or skipped) rather than a single pass/fail"
+      ]
+    },
+    {
+      "id": 8,
+      "name": "sync-callers-skipped-outside-shirabe",
+      "prompt": "/release 1.2.0 (in the tsuku repo, workflow dispatch succeeds in Phase 6)",
+      "expected_output": "Completes Phase 6 and does not attempt Phase 7, since caller-syncing only applies to shirabe's own releases.",
+      "assertions": [
+        "Does not run bump-callers.sh or attempt to open caller PRs",
+        "Does not reference skills/release/callers.json outside the shirabe repo"
+      ]
     }
   ]
 }

--- a/skills/release/scripts/bump-callers.sh
+++ b/skills/release/scripts/bump-callers.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# bump-callers.sh - Open PRs bumping the pinned shirabe release.yml ref in known caller repos
+# Part of the release skill
+#
+# Usage: ./bump-callers.sh <new-tag>
+#
+# Arguments:
+#   new-tag  Required. The shirabe tag callers should pin to, e.g. v0.6.0
+#
+# Reads the caller registry from callers.json (same directory's parent).
+# For each caller already pinned to a different ref, clones the repo,
+# updates the uses: line, and opens a PR. Callers already on the target
+# tag, or whose workflow file doesn't reference the reusable workflow,
+# are skipped and reported, not treated as failures.
+#
+# Exit codes:
+#   0 - Completed (individual callers may have been skipped; see output)
+#   1 - Bad usage or registry unreadable
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REGISTRY="$SCRIPT_DIR/../callers.json"
+REF_PATTERN='shirabe/\.github/workflows/release\.yml@[A-Za-z0-9._/-]+'
+
+NEW_TAG="${1:-}"
+if [[ -z "$NEW_TAG" ]]; then
+    echo "Usage: $0 <new-tag>" >&2
+    exit 1
+fi
+if [[ ! -f "$REGISTRY" ]]; then
+    echo "Registry not found: $REGISTRY" >&2
+    exit 1
+fi
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+RESULTS=()
+
+while IFS=$'\t' read -r REPO WORKFLOW; do
+    NAME="${REPO##*/}"
+    CLONE_DIR="$WORKDIR/$NAME"
+
+    if ! gh repo clone "$REPO" "$CLONE_DIR" -- --depth 1 --quiet 2>/dev/null; then
+        echo "SKIP $REPO: clone failed" >&2
+        RESULTS+=("$REPO: clone failed")
+        continue
+    fi
+
+    WORKFLOW_PATH="$CLONE_DIR/$WORKFLOW"
+    if [[ ! -f "$WORKFLOW_PATH" ]]; then
+        echo "SKIP $REPO: $WORKFLOW not found" >&2
+        RESULTS+=("$REPO: $WORKFLOW not found")
+        continue
+    fi
+
+    CURRENT_REF=$(grep -oE "$REF_PATTERN" "$WORKFLOW_PATH" | head -1 | sed 's#.*@##') || true
+    if [[ -z "$CURRENT_REF" ]]; then
+        echo "SKIP $REPO: $WORKFLOW does not reference the reusable release workflow" >&2
+        RESULTS+=("$REPO: no reference to reusable workflow")
+        continue
+    fi
+    if [[ "$CURRENT_REF" == "$NEW_TAG" ]]; then
+        echo "SKIP $REPO: already pinned to $NEW_TAG" >&2
+        RESULTS+=("$REPO: already up to date")
+        continue
+    fi
+
+    BRANCH="chore/bump-shirabe-release-workflow-$NEW_TAG"
+
+    EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --json url --jq '.[0].url' 2>/dev/null || echo "")
+    if [[ -n "$EXISTING_PR" ]]; then
+        echo "SKIP $REPO: PR already open for $BRANCH: $EXISTING_PR" >&2
+        RESULTS+=("$REPO: already has open PR: $EXISTING_PR")
+        continue
+    fi
+
+    if ! (
+        cd "$CLONE_DIR"
+        git checkout -q -b "$BRANCH"
+        sed -i -E "s#$REF_PATTERN#shirabe/.github/workflows/release.yml@$NEW_TAG#" "$WORKFLOW"
+        git add "$WORKFLOW"
+        git commit -q -m "chore: bump shirabe release workflow to $NEW_TAG"
+        git push -q -u origin "$BRANCH"
+    ); then
+        echo "FAIL $REPO: git commit/push failed" >&2
+        RESULTS+=("$REPO: git commit/push failed")
+        continue
+    fi
+
+    if ! PR_URL=$(gh pr create --repo "$REPO" \
+        --title "chore: bump shirabe release workflow to $NEW_TAG" \
+        --body "Bumps the pinned \`tsukumogami/shirabe/.github/workflows/release.yml\` ref in \`$WORKFLOW\` from \`$CURRENT_REF\` to \`$NEW_TAG\`.
+
+---
+
+Automated follow-up to the shirabe $NEW_TAG release." \
+        --head "$BRANCH" --base main); then
+        echo "FAIL $REPO: pr create failed (branch $BRANCH was pushed)" >&2
+        RESULTS+=("$REPO: pr create failed, branch $BRANCH pushed")
+        continue
+    fi
+
+    echo "PR $REPO: $PR_URL"
+    RESULTS+=("$REPO: $PR_URL")
+done < <(jq -r '.callers[] | [.repo, .workflow] | @tsv' "$REGISTRY")
+
+echo
+echo "Summary:"
+for line in "${RESULTS[@]}"; do
+    echo "  - $line"
+done


### PR DESCRIPTION
Adds a Phase 7 to the `/release` skill that runs only when shirabe releases itself: after Phase 6 confirms the workflow dispatch succeeded, it invokes `skills/release/scripts/bump-callers.sh` to open PRs bumping the pinned `tsukumogami/shirabe/.github/workflows/release.yml` ref in each repo tracked in the new `skills/release/callers.json` registry (currently koto, niwa, tsuku). The script shallow-clones each caller, checks its current pin, and skips (with a reported reason) anything already on the target tag, missing the workflow reference, or with an already-open bump PR from a prior run.

---

Downstream repos pin to a specific tag rather than tracking `@main` so an unreleased change to `release.yml` can't break their release pipeline out from under them -- nothing in shirabe's own CI exercises `release.yml` end-to-end before a merge, so a tagged release is the first point a change is known to work (this is the same reusable workflow fixed in #248). That protection has a cost: every new tag needs a follow-up to move callers forward, and left manual that follow-up lags silently. This automates the follow-up instead of removing the pin.

## Test plan

Ran the skill's evals (`skills/release/evals/evals.json`, 8 scenarios including two new ones for Phase 7) via `/skill-creator`. All 8 pass. The sed-based ref substitution was verified separately against a realistic caller workflow snippet.
